### PR TITLE
Add Node.js backend (libnode embedding + IPC)

### DIFF
--- a/.github/workflows/build-libnode.yml
+++ b/.github/workflows/build-libnode.yml
@@ -18,26 +18,27 @@ jobs:
             platform: macos-arm64
           - os: ubuntu-24.04
             platform: linux-x86_64
+          - os: windows-latest
+            platform: windows-x86_64
 
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Download Node.js source
+      # ---- Unix (macOS + Linux) ----
+      - name: Build libnode (Unix)
+        if: runner.os != 'Windows'
         run: |
           curl -fSL "https://nodejs.org/dist/v${{ inputs.node_version }}/node-v${{ inputs.node_version }}.tar.gz" -o /tmp/node.tar.gz
           tar xzf /tmp/node.tar.gz -C /tmp
-
-      - name: Build libnode (--shared)
-        run: |
           cd /tmp/node-v${{ inputs.node_version }}
           ./configure --shared --prefix=/tmp/node-install
           make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
 
-      - name: Package
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
         run: |
           NODE_SRC="/tmp/node-v${{ inputs.node_version }}"
           mkdir -p /tmp/libnode-pkg/include
 
-          # dylib/so 복사
           if [ "${{ matrix.platform }}" = "macos-arm64" ]; then
             cp "$NODE_SRC/out/Release/libnode."*.dylib /tmp/libnode-pkg/libnode.dylib
           else
@@ -45,32 +46,76 @@ jobs:
             cp "$NODE_SRC/out/Release/libnode.so."* /tmp/libnode-pkg/libnode.so || true
           fi
 
-          # 헤더 복사
           cp -R "$NODE_SRC/deps/v8/include/"* /tmp/libnode-pkg/include/
           cp -R "$NODE_SRC/deps/uv/include/"* /tmp/libnode-pkg/include/
-          cp "$NODE_SRC/src/node.h" /tmp/libnode-pkg/include/
-          cp "$NODE_SRC/src/node_version.h" /tmp/libnode-pkg/include/
-          cp "$NODE_SRC/src/node_api.h" /tmp/libnode-pkg/include/
-          cp "$NODE_SRC/src/node_api_types.h" /tmp/libnode-pkg/include/
-          cp "$NODE_SRC/src/js_native_api.h" /tmp/libnode-pkg/include/
-          cp "$NODE_SRC/src/js_native_api_types.h" /tmp/libnode-pkg/include/
+          for h in node.h node_version.h node_api.h node_api_types.h js_native_api.h js_native_api_types.h; do
+            cp "$NODE_SRC/src/$h" /tmp/libnode-pkg/include/ 2>/dev/null || true
+          done
 
           cd /tmp/libnode-pkg
           tar czf /tmp/libnode-${{ inputs.node_version }}-${{ matrix.platform }}.tar.gz .
-          ls -lh /tmp/libnode-${{ inputs.node_version }}-${{ matrix.platform }}.tar.gz
 
-      - name: Upload to Release
+      - name: Upload (Unix)
+        if: runner.os != 'Windows'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="libnode-v${{ inputs.node_version }}"
           FILE="/tmp/libnode-${{ inputs.node_version }}-${{ matrix.platform }}.tar.gz"
-
-          # Release가 없으면 생성
           gh release view "$TAG" --repo ${{ github.repository }} 2>/dev/null || \
             gh release create "$TAG" --repo ${{ github.repository }} \
               --title "libnode v${{ inputs.node_version }}" \
               --notes "Node.js ${{ inputs.node_version }} shared library for Suji"
-
-          # 에셋 업로드 (기존 에셋 있으면 덮어쓰기)
           gh release upload "$TAG" "$FILE" --repo ${{ github.repository }} --clobber
+
+      # ---- Windows ----
+      - name: Build libnode (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $nodeVer = "${{ inputs.node_version }}"
+          Invoke-WebRequest -Uri "https://nodejs.org/dist/v$nodeVer/node-v$nodeVer.tar.gz" -OutFile "$env:TEMP\node.tar.gz"
+          tar xzf "$env:TEMP\node.tar.gz" -C "$env:TEMP"
+          cd "$env:TEMP\node-v$nodeVer"
+          # Windows: vcbuild.bat으로 빌드
+          .\vcbuild.bat release dll
+        timeout-minutes: 60
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $nodeVer = "${{ inputs.node_version }}"
+          $nodeSrc = "$env:TEMP\node-v$nodeVer"
+          $pkg = "$env:TEMP\libnode-pkg"
+          New-Item -ItemType Directory -Force -Path "$pkg\include"
+
+          # DLL + LIB 복사
+          Copy-Item "$nodeSrc\Release\libnode.dll" "$pkg\" -ErrorAction SilentlyContinue
+          Copy-Item "$nodeSrc\Release\libnode.lib" "$pkg\" -ErrorAction SilentlyContinue
+          Copy-Item "$nodeSrc\Release\node.dll" "$pkg\libnode.dll" -ErrorAction SilentlyContinue
+          Copy-Item "$nodeSrc\Release\node.lib" "$pkg\libnode.lib" -ErrorAction SilentlyContinue
+
+          # 헤더 복사
+          Copy-Item "$nodeSrc\deps\v8\include\*" "$pkg\include\" -Recurse -Force
+          Copy-Item "$nodeSrc\deps\uv\include\*" "$pkg\include\" -Recurse -Force
+          foreach ($h in @("node.h","node_version.h","node_api.h","node_api_types.h","js_native_api.h","js_native_api_types.h")) {
+            Copy-Item "$nodeSrc\src\$h" "$pkg\include\" -ErrorAction SilentlyContinue
+          }
+
+          cd $pkg
+          tar czf "$env:TEMP\libnode-$nodeVer-windows-x86_64.tar.gz" .
+
+      - name: Upload (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tag = "libnode-v${{ inputs.node_version }}"
+          $file = "$env:TEMP\libnode-${{ inputs.node_version }}-windows-x86_64.tar.gz"
+          gh release view $tag --repo ${{ github.repository }} 2>$null
+          if ($LASTEXITCODE -ne 0) {
+            gh release create $tag --repo ${{ github.repository }} --title "libnode v${{ inputs.node_version }}" --notes "Node.js ${{ inputs.node_version }} shared library for Suji"
+          }
+          gh release upload $tag $file --repo ${{ github.repository }} --clobber

--- a/.github/workflows/build-libnode.yml
+++ b/.github/workflows/build-libnode.yml
@@ -1,0 +1,76 @@
+name: build-libnode
+
+on:
+  workflow_dispatch:
+    inputs:
+      node_version:
+        description: 'Node.js version (e.g., 24.14.1)'
+        required: true
+        default: '24.14.1'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            platform: macos-arm64
+          - os: ubuntu-24.04
+            platform: linux-x86_64
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Download Node.js source
+        run: |
+          curl -fSL "https://nodejs.org/dist/v${{ inputs.node_version }}/node-v${{ inputs.node_version }}.tar.gz" -o /tmp/node.tar.gz
+          tar xzf /tmp/node.tar.gz -C /tmp
+
+      - name: Build libnode (--shared)
+        run: |
+          cd /tmp/node-v${{ inputs.node_version }}
+          ./configure --shared --prefix=/tmp/node-install
+          make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+
+      - name: Package
+        run: |
+          NODE_SRC="/tmp/node-v${{ inputs.node_version }}"
+          mkdir -p /tmp/libnode-pkg/include
+
+          # dylib/so 복사
+          if [ "${{ matrix.platform }}" = "macos-arm64" ]; then
+            cp "$NODE_SRC/out/Release/libnode."*.dylib /tmp/libnode-pkg/libnode.dylib
+          else
+            cp "$NODE_SRC/out/Release/lib/libnode.so."* /tmp/libnode-pkg/libnode.so || \
+            cp "$NODE_SRC/out/Release/libnode.so."* /tmp/libnode-pkg/libnode.so || true
+          fi
+
+          # 헤더 복사
+          cp -R "$NODE_SRC/deps/v8/include/"* /tmp/libnode-pkg/include/
+          cp -R "$NODE_SRC/deps/uv/include/"* /tmp/libnode-pkg/include/
+          cp "$NODE_SRC/src/node.h" /tmp/libnode-pkg/include/
+          cp "$NODE_SRC/src/node_version.h" /tmp/libnode-pkg/include/
+          cp "$NODE_SRC/src/node_api.h" /tmp/libnode-pkg/include/
+          cp "$NODE_SRC/src/node_api_types.h" /tmp/libnode-pkg/include/
+          cp "$NODE_SRC/src/js_native_api.h" /tmp/libnode-pkg/include/
+          cp "$NODE_SRC/src/js_native_api_types.h" /tmp/libnode-pkg/include/
+
+          cd /tmp/libnode-pkg
+          tar czf /tmp/libnode-${{ inputs.node_version }}-${{ matrix.platform }}.tar.gz .
+          ls -lh /tmp/libnode-${{ inputs.node_version }}-${{ matrix.platform }}.tar.gz
+
+      - name: Upload to Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="libnode-v${{ inputs.node_version }}"
+          FILE="/tmp/libnode-${{ inputs.node_version }}-${{ matrix.platform }}.tar.gz"
+
+          # Release가 없으면 생성
+          gh release view "$TAG" --repo ${{ github.repository }} 2>/dev/null || \
+            gh release create "$TAG" --repo ${{ github.repository }} \
+              --title "libnode v${{ inputs.node_version }}" \
+              --notes "Node.js ${{ inputs.node_version }} shared library for Suji"
+
+          # 에셋 업로드 (기존 에셋 있으면 덮어쓰기)
+          gh release upload "$TAG" "$FILE" --repo ${{ github.repository }} --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+env:
+  NODE_VERSION: '24.14.1'
+
 jobs:
   ci:
     strategy:
@@ -15,12 +18,15 @@ jobs:
           - os: macos-14
             cef_platform: macos-arm64
             cef_file: "cef_binary_146.0.9%2Bg3ca6a87%2Bchromium-146.0.7680.165_macosarm64_minimal.tar.bz2"
+            node_platform: macos-arm64
           - os: ubuntu-24.04
             cef_platform: linux-x86_64
             cef_file: "cef_binary_146.0.9%2Bg3ca6a87%2Bchromium-146.0.7680.165_linux64_minimal.tar.bz2"
+            node_platform: linux-x86_64
           - os: windows-latest
             cef_platform: windows-x86_64
             cef_file: "cef_binary_146.0.9%2Bg3ca6a87%2Bchromium-146.0.7680.165_windows64_minimal.tar.bz2"
+            node_platform: windows-x86_64
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -65,6 +71,34 @@ jobs:
           Copy-Item -Recurse "$($extracted.FullName)\include" "$cefDir\" -Force
           Copy-Item "$($extracted.FullName)\Release\*" "$cefDir\Release\" -Force -ErrorAction SilentlyContinue
           Copy-Item "$($extracted.FullName)\Resources\*" "$cefDir\Resources\" -Recurse -Force -ErrorAction SilentlyContinue
+
+      - name: Download libnode (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          NODE_DIR="$HOME/.suji/node/${{ env.NODE_VERSION }}"
+          mkdir -p "$NODE_DIR"
+          ASSET="libnode-${{ env.NODE_VERSION }}-${{ matrix.node_platform }}.tar.gz"
+          URL="https://github.com/${{ github.repository }}/releases/download/libnode-v${{ env.NODE_VERSION }}/$ASSET"
+          curl -fSL "$URL" -o /tmp/libnode.tar.gz 2>/dev/null && \
+            tar xzf /tmp/libnode.tar.gz -C "$NODE_DIR" && \
+            echo "libnode installed: $NODE_DIR" || \
+            echo "libnode not available for ${{ matrix.node_platform }}, skipping Node backend"
+
+      - name: Download libnode (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $nodeDir = "$env:USERPROFILE\.suji\node\${{ env.NODE_VERSION }}"
+          New-Item -ItemType Directory -Force -Path $nodeDir
+          $asset = "libnode-${{ env.NODE_VERSION }}-${{ matrix.node_platform }}.tar.gz"
+          $url = "https://github.com/${{ github.repository }}/releases/download/libnode-v${{ env.NODE_VERSION }}/$asset"
+          try {
+            Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\libnode.tar.gz"
+            tar xzf "$env:TEMP\libnode.tar.gz" -C $nodeDir
+            Write-Host "libnode installed: $nodeDir"
+          } catch {
+            Write-Host "libnode not available for ${{ matrix.node_platform }}, skipping"
+          }
 
       - name: Build
         run: zig build

--- a/build.zig
+++ b/build.zig
@@ -91,10 +91,34 @@ pub fn build(b: *std.Build) void {
         root_module.linkSystemLibrary("shell32", .{});
     }
 
+    // libnode (Node.js 임베딩) — 선택적
+    const node_path = std.fmt.allocPrint(b.allocator, "{s}/.suji/node/24.14.1", .{home}) catch @panic("OOM");
+    const node_available = blk: {
+        const dylib = std.fmt.allocPrint(b.allocator, "{s}/libnode.dylib", .{node_path}) catch break :blk false;
+        std.fs.cwd().access(dylib, .{}) catch break :blk false;
+        break :blk true;
+    };
+    if (node_available) {
+        // Node.js C++ 브릿지 + 헤더
+        root_module.addIncludePath(.{ .cwd_relative = "src/platform/node" });
+        const node_include = std.fmt.allocPrint(b.allocator, "{s}/include", .{node_path}) catch @panic("OOM");
+        root_module.addIncludePath(.{ .cwd_relative = node_include });
+    }
+
     const exe = b.addExecutable(.{
         .name = "suji",
         .root_module = root_module,
     });
+
+    if (node_available) {
+        // bridge.cc를 C++ 오브젝트로 컴파일 + 링크
+        exe.addCSourceFile(.{
+            .file = b.path("src/platform/node/bridge.cc"),
+            .flags = &.{"-std=c++20"},
+        });
+        exe.addLibraryPath(.{ .cwd_relative = node_path });
+        exe.linkSystemLibrary("node");
+    }
 
     if (os_tag == .macos) {
         exe.headerpad_max_install_names = true;

--- a/build.zig
+++ b/build.zig
@@ -98,9 +98,12 @@ pub fn build(b: *std.Build) void {
         std.fs.cwd().access(dylib, .{}) catch break :blk false;
         break :blk true;
     };
+    // Node.js 지원 (libnode가 설치된 경우만)
+    root_module.addIncludePath(.{ .cwd_relative = "src/platform/node" });
+    const node_options = b.addOptions();
+    node_options.addOption(bool, "node_enabled", node_available);
+    root_module.addImport("node_config", node_options.createModule());
     if (node_available) {
-        // Node.js C++ 브릿지 + 헤더
-        root_module.addIncludePath(.{ .cwd_relative = "src/platform/node" });
         const node_include = std.fmt.allocPrint(b.allocator, "{s}/include", .{node_path}) catch @panic("OOM");
         root_module.addIncludePath(.{ .cwd_relative = node_include });
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,7 +3,9 @@ const suji = @import("root.zig");
 const util = @import("util");
 const cef = @import("platform/cef.zig");
 const Watcher = @import("platform/watcher.zig").Watcher;
-const NodeRuntime = @import("platform/node.zig").NodeRuntime;
+const node_mod = @import("platform/node.zig");
+const NodeRuntime = node_mod.NodeRuntime;
+const node_enabled = node_mod.node_enabled;
 const bundle_macos = if (@import("builtin").os.tag == .macos) @import("bundle_macos.zig") else struct {
     pub fn createBundle(_: anytype, _: anytype, _: anytype, _: anytype, _: anytype, _: anytype) !void {
         @panic("macOS bundle not supported on this platform");
@@ -302,6 +304,10 @@ fn loadBackendsFromConfig(allocator: std.mem.Allocator, config: *const suji.Conf
 }
 
 fn startNodeBackend(allocator: std.mem.Allocator, entry: [:0]const u8) !void {
+    if (!node_enabled) {
+        std.debug.print("[suji] Node.js backend not available (libnode not installed)\n", .{});
+        return;
+    }
     // entry 경로를 절대 경로로 변환 (createRequire가 절대 경로 필요)
     const abs_entry = try std.fs.cwd().realpathAlloc(allocator, entry);
     defer allocator.free(abs_entry);
@@ -707,8 +713,8 @@ fn cefInvokeHandler(channel: []const u8, data: []const u8, response_buf: []u8) ?
         return response_buf[0..len];
     }
 
-    // Node.js 백엔드 폴백
-    if (g_node_runtime != null) {
+    // Node.js 백엔드 폴백 (libnode 활성화된 경우만)
+    if (node_enabled and g_node_runtime != null) {
         if (NodeRuntime.invoke(channel, data)) |resp| {
             const len = @min(resp.len, response_buf.len);
             @memcpy(response_buf[0..len], resp[0..len]);

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,6 +3,7 @@ const suji = @import("root.zig");
 const util = @import("util");
 const cef = @import("platform/cef.zig");
 const Watcher = @import("platform/watcher.zig").Watcher;
+const NodeRuntime = @import("platform/node.zig").NodeRuntime;
 const bundle_macos = if (@import("builtin").os.tag == .macos) @import("bundle_macos.zig") else struct {
     pub fn createBundle(_: anytype, _: anytype, _: anytype, _: anytype, _: anytype, _: anytype) !void {
         @panic("macOS bundle not supported on this platform");
@@ -246,16 +247,27 @@ fn readPluginLang(allocator: std.mem.Allocator, plugin_dir: []const u8) ?[]const
 // 백엔드 빌드/로드
 // ============================================
 
+/// Node 런타임 글로벌 참조 (dev 모드에서 정리용)
+var g_node_runtime: ?*NodeRuntime = null;
+
 fn loadBackendsFromConfig(allocator: std.mem.Allocator, config: *const suji.Config, registry: *suji.BackendRegistry, release: bool) !void {
     if (config.isMultiBackend()) {
         if (config.backends) |backends| {
             for (backends) |be| {
-                // Zig도 다른 언어와 동일하게 dlopen
                 std.debug.print("[suji] building {s} ({s})...\n", .{ be.name, be.lang });
                 buildBackendByLang(allocator, be.lang, be.entry, release) catch |err| {
                     std.debug.print("[suji] build failed: {}\n", .{err});
                     continue;
                 };
+
+                if (std.mem.eql(u8, be.lang, "node")) {
+                    // Node 백엔드: libnode로 JS 실행
+                    startNodeBackend(allocator, be.entry) catch |err| {
+                        std.debug.print("[suji] node start failed for {s}: {}\n", .{ be.name, err });
+                    };
+                    continue;
+                }
+
                 const path = getDylibPath(allocator, be.lang, be.entry, release) catch continue;
                 defer allocator.free(path);
                 var path_z: [1024]u8 = undefined;
@@ -271,6 +283,14 @@ fn loadBackendsFromConfig(allocator: std.mem.Allocator, config: *const suji.Conf
             std.debug.print("[suji] build failed: {}\n", .{err});
             return;
         };
+
+        if (std.mem.eql(u8, be.lang, "node")) {
+            startNodeBackend(allocator, be.entry) catch |err| {
+                std.debug.print("[suji] node start failed: {}\n", .{err});
+            };
+            return;
+        }
+
         const path = getDylibPath(allocator, be.lang, be.entry, release) catch return;
         defer allocator.free(path);
         var path_z: [1024]u8 = undefined;
@@ -279,6 +299,21 @@ fn loadBackendsFromConfig(allocator: std.mem.Allocator, config: *const suji.Conf
             std.debug.print("[suji] load failed: {}\n", .{err});
         };
     }
+}
+
+fn startNodeBackend(allocator: std.mem.Allocator, entry: [:0]const u8) !void {
+    // entry 경로를 절대 경로로 변환 (createRequire가 절대 경로 필요)
+    const abs_entry = try std.fs.cwd().realpathAlloc(allocator, entry);
+    defer allocator.free(abs_entry);
+    const entry_js_str = try std.fmt.allocPrint(allocator, "{s}/main.js", .{abs_entry});
+    defer allocator.free(entry_js_str);
+    const entry_js = try allocator.dupeZ(u8, entry_js_str);
+    // entry_js는 NodeRuntime이 소유 (해제하지 않음)
+
+    const rt = try allocator.create(NodeRuntime);
+    rt.* = NodeRuntime.init(allocator, entry_js);
+    try rt.start();
+    g_node_runtime = rt;
 }
 
 fn buildBackendsFromConfig(allocator: std.mem.Allocator, config: *const suji.Config, release: bool) !void {
@@ -317,6 +352,14 @@ fn buildBackendByLang(allocator: std.mem.Allocator, lang: []const u8, entry: []c
             .{ "CC", "/usr/bin/clang" },
             .{ "CGO_ENABLED", "1" },
         });
+    } else if (std.mem.eql(u8, lang, "node")) {
+        // Node 백엔드: npm install (빌드 불필요, 런타임에 JS 실행)
+        const pkg_path = try std.fmt.allocPrint(allocator, "{s}/package.json", .{entry});
+        defer allocator.free(pkg_path);
+        std.fs.cwd().access(pkg_path, .{}) catch return; // package.json 없으면 skip
+        std.debug.print("[suji] installing npm packages...\n", .{});
+        const npm_cmd = if (release) &[_][]const u8{ "npm", "install", "--prefix", entry, "--production" } else &[_][]const u8{ "npm", "install", "--prefix", entry };
+        try runCmd(allocator, npm_cmd);
     } else if (std.mem.eql(u8, lang, "zig")) {
         // Zig 백엔드는 자체 build.zig가 있어야 함
         // --prefix로 빌드 결과물을 entry 디렉토리에 설치
@@ -656,11 +699,25 @@ fn cefInvokeHandler(channel: []const u8, data: []const u8, response_buf: []u8) ?
     const name = registry.getBackendForChannel(channel) orelse channel;
     if (name.len == 0) return null; // 중복 채널
 
-    const resp = registry.invoke(name, request) orelse return null;
-    const len = @min(resp.len, response_buf.len);
-    @memcpy(response_buf[0..len], resp[0..len]);
-    registry.freeResponse(name, resp);
-    return response_buf[0..len];
+    // 네이티브 백엔드 (Zig/Rust/Go) 시도
+    if (registry.invoke(name, request)) |resp| {
+        const len = @min(resp.len, response_buf.len);
+        @memcpy(response_buf[0..len], resp[0..len]);
+        registry.freeResponse(name, resp);
+        return response_buf[0..len];
+    }
+
+    // Node.js 백엔드 폴백
+    if (g_node_runtime != null) {
+        if (NodeRuntime.invoke(channel, data)) |resp| {
+            const len = @min(resp.len, response_buf.len);
+            @memcpy(response_buf[0..len], resp[0..len]);
+            NodeRuntime.freeResponse(resp);
+            return response_buf[0..len];
+        }
+    }
+
+    return null;
 }
 
 /// fanout: 여러 백엔드에 동시 요청

--- a/src/platform/node.zig
+++ b/src/platform/node.zig
@@ -1,10 +1,20 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const node_config = @import("node_config");
 
-/// Node.js C 브릿지 (bridge.h)
-pub const bridge = @cImport({
+pub const node_enabled = node_config.node_enabled;
+
+/// Node.js C 브릿지 (bridge.h) — libnode가 있을 때만 사용
+pub const bridge = if (node_enabled) @cImport({
     @cInclude("bridge.h");
-});
+}) else struct {
+    pub fn suji_node_init(_: c_int, _: anytype) callconv(.c) c_int { return -1; }
+    pub fn suji_node_run(_: anytype) callconv(.c) c_int { return -1; }
+    pub fn suji_node_stop() callconv(.c) void {}
+    pub fn suji_node_shutdown() callconv(.c) void {}
+    pub fn suji_node_invoke(_: anytype, _: anytype) callconv(.c) ?[*:0]const u8 { return null; }
+    pub fn suji_node_free(_: anytype) callconv(.c) void {}
+};
 
 /// Node.js 백엔드 런타임
 pub const NodeRuntime = struct {

--- a/src/platform/node.zig
+++ b/src/platform/node.zig
@@ -1,0 +1,78 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Node.js C 브릿지 (bridge.h)
+pub const bridge = @cImport({
+    @cInclude("bridge.h");
+});
+
+/// Node.js 백엔드 런타임
+pub const NodeRuntime = struct {
+    allocator: std.mem.Allocator,
+    entry_path: [:0]const u8,
+    thread: ?std.Thread = null,
+    initialized: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator, entry_path: [:0]const u8) NodeRuntime {
+        return .{
+            .allocator = allocator,
+            .entry_path = entry_path,
+        };
+    }
+
+    /// Node.js 런타임 초기화 + JS 실행 (별도 스레드)
+    pub fn start(self: *NodeRuntime) !void {
+        if (self.initialized) return;
+
+        // Node 초기화 (프로세스당 한 번)
+        const argv = [_][*c]u8{@constCast("suji-node")};
+        if (bridge.suji_node_init(1, @constCast(&argv)) != 0) {
+            return error.NodeInitFailed;
+        }
+        self.initialized = true;
+
+        // 별도 스레드에서 JS 실행
+        self.thread = try std.Thread.spawn(.{}, runThread, .{self});
+
+        // Node 핸들러 등록 대기 (최대 2초)
+        std.Thread.sleep(2 * std.time.ns_per_s);
+        std.debug.print("[suji-node] started: {s}\n", .{self.entry_path});
+    }
+
+    fn runThread(self: *NodeRuntime) void {
+        _ = bridge.suji_node_run(self.entry_path.ptr);
+    }
+
+    /// Node IPC 호출 (Zig → JS)
+    pub fn invoke(channel: []const u8, data: []const u8) ?[]const u8 {
+        var ch_buf: [256]u8 = undefined;
+        const ch_z = std.fmt.bufPrintZ(&ch_buf, "{s}", .{channel}) catch return null;
+        var data_buf: [8192]u8 = undefined;
+        const data_z = std.fmt.bufPrintZ(&data_buf, "{s}", .{data}) catch return null;
+
+        const result = bridge.suji_node_invoke(ch_z.ptr, data_z.ptr);
+        if (result == null) return null;
+        return std.mem.span(result);
+    }
+
+    /// Node IPC 응답 해제
+    pub fn freeResponse(response: ?[]const u8) void {
+        if (response) |r| {
+            bridge.suji_node_free(@ptrCast(r.ptr));
+        }
+    }
+
+    pub fn stop(self: *NodeRuntime) void {
+        bridge.suji_node_stop();
+        if (self.thread) |t| {
+            t.join();
+            self.thread = null;
+        }
+    }
+
+    pub fn shutdown(self: *NodeRuntime) void {
+        self.stop();
+        bridge.suji_node_shutdown();
+        self.initialized = false;
+    }
+};

--- a/src/platform/node/bridge.cc
+++ b/src/platform/node/bridge.cc
@@ -1,0 +1,313 @@
+// Suji Node.js Bridge — C++ implementation
+// Embeds Node.js runtime using official embedding API
+
+#include <node.h>
+#include <uv.h>
+#include "bridge.h"
+
+#include <string>
+#include <memory>
+#include <atomic>
+#include <cstring>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <unordered_map>
+
+using node::CommonEnvironmentSetup;
+using node::Environment;
+using node::MultiIsolatePlatform;
+using v8::Context;
+using v8::Function;
+using v8::Global;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Local;
+using v8::Locker;
+using v8::String;
+using v8::Value;
+
+// ============================================
+// Global state
+// ============================================
+
+static std::unique_ptr<MultiIsolatePlatform> g_platform;
+static std::unique_ptr<CommonEnvironmentSetup> g_setup;
+static std::atomic<bool> g_running{false};
+static std::atomic<bool> g_initialized{false};
+static std::thread g_thread;
+
+// IPC 핸들러 맵 (channel → JS function)
+static std::unordered_map<std::string, Global<Function>> g_handlers;
+static std::mutex g_handler_mutex;
+
+// IPC 요청/응답 큐 (스레드 간 통신)
+struct IpcRequest {
+    std::string channel;
+    std::string data;
+    std::string response;
+    bool done = false;
+    std::mutex mtx;
+    std::condition_variable cv;
+};
+
+static std::mutex g_ipc_mutex;
+static std::vector<IpcRequest*> g_ipc_queue;
+static uv_async_t g_ipc_async;
+
+// ============================================
+// IPC 처리 (메인 Node 스레드에서 실행)
+// ============================================
+
+static void process_ipc_queue(uv_async_t*) {
+    if (!g_setup) return;
+    Isolate* isolate = g_setup->isolate();
+    if (!isolate) return;
+
+    Locker locker(isolate);
+    Isolate::Scope isolate_scope(isolate);
+    HandleScope handle_scope(isolate);
+    Context::Scope context_scope(g_setup->context());
+
+    std::vector<IpcRequest*> pending;
+    {
+        std::lock_guard<std::mutex> lock(g_ipc_mutex);
+        pending.swap(g_ipc_queue);
+    }
+
+    for (auto* req : pending) {
+        std::string result = "{\"error\":\"no handler\"}";
+
+        {
+            std::lock_guard<std::mutex> lock(g_handler_mutex);
+            auto it = g_handlers.find(req->channel);
+            if (it != g_handlers.end()) {
+                Local<Function> fn = it->second.Get(isolate);
+                Local<String> arg = String::NewFromUtf8(isolate, req->data.c_str()).ToLocalChecked();
+                Local<Value> argv[1] = { arg };
+
+                v8::TryCatch try_catch(isolate);
+                auto maybe_result = fn->Call(g_setup->context(), v8::Undefined(isolate), 1, argv);
+
+                if (!maybe_result.IsEmpty()) {
+                    Local<Value> ret = maybe_result.ToLocalChecked();
+                    if (ret->IsString()) {
+                        String::Utf8Value utf8(isolate, ret);
+                        result = std::string(*utf8, utf8.length());
+                    } else {
+                        // JSON.stringify
+                        Local<Value> json_global;
+                        if (g_setup->context()->Global()->Get(g_setup->context(), String::NewFromUtf8(isolate, "JSON").ToLocalChecked()).ToLocal(&json_global) && json_global->IsObject()) {
+                            Local<Value> stringify_fn;
+                            if (json_global.As<v8::Object>()->Get(g_setup->context(), String::NewFromUtf8(isolate, "stringify").ToLocalChecked()).ToLocal(&stringify_fn) && stringify_fn->IsFunction()) {
+                                Local<Value> str_argv[1] = { ret };
+                                auto str_result = stringify_fn.As<Function>()->Call(g_setup->context(), json_global, 1, str_argv);
+                                if (!str_result.IsEmpty()) {
+                                    String::Utf8Value utf8s(isolate, str_result.ToLocalChecked());
+                                    result = std::string(*utf8s, utf8s.length());
+                                }
+                            }
+                        }
+                    }
+                } else if (try_catch.HasCaught()) {
+                    String::Utf8Value err(isolate, try_catch.Exception());
+                    result = std::string("{\"error\":\"") + *err + "\"}";
+                }
+            }
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(req->mtx);
+            req->response = std::move(result);
+            req->done = true;
+        }
+        req->cv.notify_one();
+    }
+}
+
+// ============================================
+// JS에서 호출하는 네이티브 함수: __suji_handle(channel, fn)
+// ============================================
+
+static void js_suji_handle(const v8::FunctionCallbackInfo<Value>& args) {
+    Isolate* isolate = args.GetIsolate();
+    if (args.Length() < 2 || !args[0]->IsString() || !args[1]->IsFunction()) {
+        isolate->ThrowException(String::NewFromUtf8(isolate, "suji.handle(channel, fn) requires string and function").ToLocalChecked());
+        return;
+    }
+
+    String::Utf8Value channel(isolate, args[0]);
+    std::string ch(*channel, channel.length());
+
+    Local<Function> fn = args[1].As<Function>();
+
+    std::lock_guard<std::mutex> lock(g_handler_mutex);
+    g_handlers[ch] = Global<Function>(isolate, fn);
+
+    fprintf(stderr, "[suji-node] handler registered: %s\n", ch.c_str());
+}
+
+// ============================================
+// C API Implementation
+// ============================================
+
+extern "C" {
+
+int suji_node_init(int argc, char** argv) {
+    if (g_initialized.load()) return 0;
+
+    std::vector<std::string> args(argv, argv + argc);
+
+    auto result = node::InitializeOncePerProcess(args, {
+        node::ProcessInitializationFlags::kNoInitializeV8,
+        node::ProcessInitializationFlags::kNoInitializeNodeV8Platform,
+    });
+
+    if (result->early_return() != 0) {
+        return -1;
+    }
+
+    g_platform = MultiIsolatePlatform::Create(4);
+    v8::V8::InitializePlatform(g_platform.get());
+    v8::V8::Initialize();
+
+    g_initialized.store(true);
+    return 0;
+}
+
+static int run_node_internal(const char* entry_path) {
+    std::vector<std::string> args = {"suji-node"};
+    std::vector<std::string> exec_args;
+    std::vector<std::string> errors;
+
+    g_setup = CommonEnvironmentSetup::Create(
+        g_platform.get(), &errors, args, exec_args);
+
+    if (!g_setup) {
+        for (const auto& e : errors) {
+            fprintf(stderr, "[suji-node] setup error: %s\n", e.c_str());
+        }
+        return -1;
+    }
+
+    Isolate* isolate = g_setup->isolate();
+    Environment* env = g_setup->env();
+
+    {
+        Locker locker(isolate);
+        Isolate::Scope isolate_scope(isolate);
+        HandleScope handle_scope(isolate);
+        Context::Scope context_scope(g_setup->context());
+
+        // process.exit() 크래시 방지
+        node::SetProcessExitHandler(env, [](Environment* e, int code) {
+            node::Stop(e);
+        });
+
+        // IPC async 핸들 등록 (Node 이벤트 루프에서 IPC 처리)
+        uv_async_init(g_setup->event_loop(), &g_ipc_async, process_ipc_queue);
+
+        // globalThis.__suji_handle 등록
+        Local<v8::FunctionTemplate> handle_tmpl = v8::FunctionTemplate::New(isolate, js_suji_handle);
+        g_setup->context()->Global()->Set(
+            g_setup->context(),
+            String::NewFromUtf8(isolate, "__suji_handle").ToLocalChecked(),
+            handle_tmpl->GetFunction(g_setup->context()).ToLocalChecked()
+        ).Check();
+
+        // 엔트리 JS 파일 로드 — @suji/node SDK를 주입하고 사용자 코드 실행
+        std::string code = std::string(
+            "globalThis.suji = { handle: __suji_handle };"
+            "const { createRequire } = require('module');"
+            "const r = createRequire('") + entry_path + "');"
+            "r('" + entry_path + "');";
+
+        auto load_result = node::LoadEnvironment(env, code.c_str());
+
+        if (load_result.IsEmpty()) {
+            fprintf(stderr, "[suji-node] failed to load: %s\n", entry_path);
+            return -1;
+        }
+
+        g_running.store(true);
+        node::SpinEventLoop(env).FromMaybe(1);
+        g_running.store(false);
+    }
+
+    node::Stop(env);
+    g_handlers.clear();
+    g_setup.reset();
+    return 0;
+}
+
+int suji_node_run(const char* entry_path) {
+    if (!g_initialized.load()) return -1;
+    return run_node_internal(entry_path);
+}
+
+int suji_node_run_async(const char* entry_path) {
+    if (!g_initialized.load()) return -1;
+    std::string path(entry_path);
+    g_thread = std::thread([path]() {
+        run_node_internal(path.c_str());
+    });
+    return 0;
+}
+
+void suji_node_stop(void) {
+    if (g_setup && g_running.load()) {
+        Environment* env = g_setup->env();
+        if (env) node::Stop(env);
+    }
+    if (g_thread.joinable()) g_thread.join();
+}
+
+void suji_node_shutdown(void) {
+    suji_node_stop();
+    g_handlers.clear();
+    g_setup.reset();
+    if (g_initialized.load()) {
+        v8::V8::Dispose();
+        v8::V8::DisposePlatform();
+        g_platform.reset();
+        node::TearDownOncePerProcess();
+        g_initialized.store(false);
+    }
+}
+
+const char* suji_node_invoke(const char* channel, const char* data) {
+    if (!g_running.load()) return strdup("{\"error\":\"node not running\"}");
+
+    // IPC 요청을 큐에 넣고 Node 스레드에서 처리 대기
+    auto* req = new IpcRequest();
+    req->channel = channel;
+    req->data = data;
+
+    {
+        std::lock_guard<std::mutex> lock(g_ipc_mutex);
+        g_ipc_queue.push_back(req);
+    }
+
+    // Node 이벤트 루프에 알림
+    uv_async_send(&g_ipc_async);
+
+    // 응답 대기 (최대 30초)
+    {
+        std::unique_lock<std::mutex> lock(req->mtx);
+        req->cv.wait_for(lock, std::chrono::seconds(30), [req]() { return req->done; });
+    }
+
+    char* result = strdup(req->response.c_str());
+    delete req;
+    return result;
+}
+
+void suji_node_free(const char* ptr) {
+    if (ptr) free(const_cast<char*>(ptr));
+}
+
+void suji_node_set_handler(suji_node_handler_fn handler) {
+    (void)handler;
+}
+
+} // extern "C"

--- a/src/platform/node/bridge.h
+++ b/src/platform/node/bridge.h
@@ -1,0 +1,38 @@
+// Suji Node.js Bridge — C API for embedding Node.js
+#ifndef SUJI_NODE_BRIDGE_H
+#define SUJI_NODE_BRIDGE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Node 런타임 초기화 (프로세스당 한 번)
+int suji_node_init(int argc, char** argv);
+
+// JS 파일 실행 + 이벤트 루프 (블로킹)
+int suji_node_run(const char* entry_path);
+
+// JS 파일 실행 + 이벤트 루프 (별도 스레드, 비블로킹)
+int suji_node_run_async(const char* entry_path);
+
+// 이벤트 루프 중지
+void suji_node_stop(void);
+
+// 전체 정리 (V8 + 플랫폼 해제)
+void suji_node_shutdown(void);
+
+// IPC: JS 함수 호출 (호출자가 suji_node_free로 해제)
+const char* suji_node_invoke(const char* channel, const char* data);
+
+// 응답 메모리 해제
+void suji_node_free(const char* ptr);
+
+// 콜백: JS에서 suji.handle() 호출 시
+typedef const char* (*suji_node_handler_fn)(const char* channel, const char* data);
+void suji_node_set_handler(suji_node_handler_fn handler);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
## Summary
- libnode 임베딩으로 Node.js 백엔드 지원
- JS에서 suji.handle(channel, fn) 등록 → 프론트엔드 invoke → Node 핸들러 응답
- npm install 자동 실행, package.json/node_modules 완전 호환
- thread-safe IPC (uv_async + condition_variable)
- build.zig: libnode 선택적 링크 (없으면 Node 기능 비활성)

## Usage
suji.json: { "lang": "node", "entry": "backends/node" }
backends/node/main.js: suji.handle("api", (data) => { ... })

## Test plan
- [x] macOS 로컬: libnode 빌드 + 임베딩 + JS 실행 + npm 패키지 + IPC 핸들러
- [ ] CI (libnode 프리빌트 필요 — 추후 GitHub Releases)