### PR TITLE
chore: ibnode 다운로드 URL을 ohah/suji 릴리즈로 고정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           NODE_DIR="$HOME/.suji/node/${{ env.NODE_VERSION }}"
           mkdir -p "$NODE_DIR"
           ASSET="libnode-${{ env.NODE_VERSION }}-${{ matrix.node_platform }}.tar.gz"
-          URL="https://github.com/${{ github.repository }}/releases/download/libnode-v${{ env.NODE_VERSION }}/$ASSET"
+          URL="https://github.com/ohah/suji/releases/download/libnode-v${{ env.NODE_VERSION }}/$ASSET"
           curl -fSL "$URL" -o /tmp/libnode.tar.gz 2>/dev/null && \
             tar xzf /tmp/libnode.tar.gz -C "$NODE_DIR" && \
             echo "libnode installed: $NODE_DIR" || \
@@ -91,7 +91,7 @@ jobs:
           $nodeDir = "$env:USERPROFILE\.suji\node\${{ env.NODE_VERSION }}"
           New-Item -ItemType Directory -Force -Path $nodeDir
           $asset = "libnode-${{ env.NODE_VERSION }}-${{ matrix.node_platform }}.tar.gz"
-          $url = "https://github.com/${{ github.repository }}/releases/download/libnode-v${{ env.NODE_VERSION }}/$asset"
+          $url = "https://github.com/ohah/suji/releases/download/libnode-v${{ env.NODE_VERSION }}/$asset"
           try {
             Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\libnode.tar.gz"
             tar xzf "$env:TEMP\libnode.tar.gz" -C $nodeDir


### PR DESCRIPTION
## Summary
- CI에서 libnode 다운로드 시 `github.repository` 대신 `ohah/suji`를 직접 사용하도록 변경
- fork 레포에서도 libnode 릴리즈를 정상적으로 다운로드할 수 있도록 수정

## Changes
- `.github/workflows/ci.yml`: Unix/Windows libnode 다운로드 URL 고정 (`ohah/suji`)

## Test plan
- [ ] CI가 libnode를 정상 다운로드하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)