### PR TITLE
문서 동기화 + suji.json JSON Schema 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,8 @@ suji/
 │   ├── platform/
 │   │   ├── cef.zig           # CEF 통합 (창, IPC, 렌더러, 커스텀 프로토콜)
 │   │   ├── node.zig          # Node.js 런타임 (libnode 임베딩)
-│   │   └── node/bridge.cc    # Node.js C++ 브릿지 (V8 IPC, thread pool)
+│   │   ├── node/bridge.cc    # Node.js C++ 브릿지 (V8 IPC, thread pool)
+│   │   └── watcher.zig       # 파일 감시 (백엔드 핫 리로드)
 │   ├── backends/
 │   │   └── loader.zig        # BackendRegistry + SujiCore
 │   └── templates/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,14 +11,15 @@ Electron 스타일 API (handle/invoke/on/send).
 
 ```bash
 zig build          # 빌드
-zig build test     # 테스트 (164개)
+zig build test     # 테스트 (173개)
 zig build run      # CLI 도움말
 
 # 예제 실행
-cd examples/multi-backend && suji dev   # Zig + Rust + Go
+cd examples/multi-backend && suji dev   # Zig + Rust + Go + Node.js
 cd examples/zig-backend && suji dev     # Zig 단독
 cd examples/rust-backend && suji dev    # Rust 단독
 cd examples/go-backend && suji dev      # Go 단독
+cd examples/node-backend && suji dev    # Node.js 단독
 ```
 
 ## CLI
@@ -105,6 +106,15 @@ suji.handle('hello', (data) => {
   const req = JSON.parse(data);
   return JSON.stringify({ message: 'Hello!', echo: req });
 });
+
+// 크로스 호출 (핸들러 내부 — 동기)
+suji.invokeSync('zig', '{"cmd":"ping"}')
+
+// 크로스 호출 (핸들러 밖 — async, Promise 반환, event loop 비블록)
+const result = await suji.invoke('rust', '{"cmd":"greet"}')
+
+// 이벤트 발신
+suji.send('my-event', JSON.stringify({ msg: 'hello' }))
 ```
 
 libnode 임베딩 방식 (별도 프로세스 없음). `~/.suji/node/24.14.1/libnode.dylib` 필요.
@@ -128,7 +138,9 @@ suji/
 │   │   ├── init.zig          # suji init 스캐폴딩
 │   │   └── util.zig          # nullTerminate, 버퍼 상수
 │   ├── platform/
-│   │   └── cef.zig           # CEF 통합 (창, IPC, 렌더러, 커스텀 프로토콜)
+│   │   ├── cef.zig           # CEF 통합 (창, IPC, 렌더러, 커스텀 프로토콜)
+│   │   ├── node.zig          # Node.js 런타임 (libnode 임베딩)
+│   │   └── node/bridge.cc    # Node.js C++ 브릿지 (V8 IPC, thread pool)
 │   ├── backends/
 │   │   └── loader.zig        # BackendRegistry + SujiCore
 │   └── templates/
@@ -166,13 +178,7 @@ suji/
 - **영향**: WebGL, CSS 애니메이션 60fps, 비디오 가속이 필요하면 GPU 활성화 필요
 - **옵션**: `suji.json`에 `"gpu": true/false` 설정 추가 고려
 
-### Node.js async invoke 스레드 관리
-`suji.invoke()` (async/Promise)가 호출마다 `std::thread`를 생성/detach 중.
-- **해결 방법**: 고정 크기 스레드 풀 (4 workers + task queue)로 교체
-- **영향**: 프론트엔드에서 대량 invoke 시 OS 스레드 폭증 가능
-
-### Node.js 양방향 크로스 호출 제한
-`suji.invokeSync()`는 Node event loop를 블록하므로, 대상 백엔드가 Node로 콜백하면 deadlock.
-- 현재 Node→다른백엔드 단방향만 안전
-- `suji.invoke()` (async)는 별도 스레드에서 실행되어 deadlock 없음
+### Node.js 양방향 크로스 호출
+`suji.invokeSync()` 중 대상 백엔드가 Node로 콜백 시 `drain_ipc_queue_inline()`으로 처리.
+다만 깊은 재귀 체인(A→Node→B→Node→C→...)은 테스트되지 않음.
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,4 +185,30 @@ suji/
 ### Node.js 양방향 크로스 호출
 `suji.invokeSync()` 중 대상 백엔드가 Node로 콜백 시 `drain_ipc_queue_inline()`으로 처리.
 다만 깊은 재귀 체인(A→Node→B→Node→C→...)은 테스트되지 않음.
+
+## 배포 / 설치
+
+### Suji CLI 배포 (예정)
+
+| 채널 | 명령어 | 상태 |
+|------|--------|------|
+| GitHub Releases | 직접 다운로드 | CI 추가 필요 |
+| Homebrew | `brew install ohah/tap/suji` | tap 레포 생성 필요 |
+| npm/npx | `npx @suji/cli init my-app` | npm 패키지 필요 |
+| curl 스크립트 | `curl -fsSL https://get.suji.dev \| sh` | 스크립트 작성 필요 |
+
+### SDK 배포 (예정)
+
+| SDK | 채널 | 패키지명 | 상태 |
+|-----|------|----------|------|
+| 프론트엔드 JS | npm | `@suji/api` | `packages/suji-js` 존재 |
+| Rust SDK | crates.io | `suji` | `crates/suji-rs` 존재 |
+| Go SDK | go module | `github.com/ohah/suji-go` | `sdks/suji-go` 존재 |
+| Node.js SDK | npm | `suji` (require) | 미구현 |
+
+### 배포 우선순위
+1. GitHub Releases — CI에서 플랫폼별 바이너리 빌드 + 자동 릴리즈
+2. Homebrew tap — macOS 사용자 1순위
+3. npx — 크로스 플랫폼, 프론트엔드 개발자 친화적
+4. curl 스크립트 — 범용 설치
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,11 @@ suji.emit("event", { msg: "hello" })
 
 ## suji.json 설정
 
+JSON Schema 제공: [`suji.schema.json`](./suji.schema.json) — IDE 자동완성 + 검증 지원.
+
 ```json
 {
+  "$schema": "./suji.schema.json",
   "app": { "name": "My App", "version": "1.0.0" },
   "window": {
     "title": "My App",

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -596,10 +596,13 @@ func backend_handle_ipc(request *C.char) *C.char {
 - NAPI: Node가 Zig를 로드하는 반대 구조. 구현 쉽지만 `node main.js`로 실행해야 하고 유저 PC에 Node 설치 필요. Zig가 프로세스 주인이 아니게 됨.
 - Unix 소켓: POC에서 검증 완료. 가능하지만 별도 프로세스라 임베드가 아님.
 
-- [ ] libnode 빌드 인프라 (CI에서 빌드, 프리빌트 배포)
-- [ ] Zig에서 libnode 링킹 (`@cImport` + node_api.h)
-- [ ] Node 환경 초기화/해제
-- [ ] Zig에서 Node 환경에 Suji API 주입 (BrowserWindow, app 등)
+- [x] libnode 빌드 인프라 (CI에서 빌드, 프리빌트 배포)
+- [x] Zig에서 libnode 링킹 (`@cImport` + node_api.h)
+- [x] Node 환경 초기화/해제
+- [x] Zig에서 Node 환경에 Suji API 주입 (handle/invoke/invokeSync/send/register)
+- [x] Node.js 크로스 호출 (invoke async + invokeSync + thread pool + deadlock 방지)
+- [x] Node.js 이벤트 발신 (suji.send)
+- [x] Node.js 예제 (node-backend 단독 + multi-backend 포함)
 - [ ] `suji run main.js` CLI
 - [ ] require("suji") 패키지
 - [ ] Node 바이너리 번들링 (배포 시)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -152,37 +152,7 @@ Suji 코어 (Zig) ← 상태 소유자 (단일 진실의 원천)
   - [ ] Go 래퍼 — `plugins/state/go/`
   - [ ] Node 래퍼 (Phase 5 이후)
   - [ ] SQLite 플러그인 (별도, 나중에)
-- [ ] 바이너리 데이터 채널 (로컬 HTTP 서버, 별도 기능으로 분리)
-
-**바이너리 데이터 전송**:
-
-webview IPC는 텍스트 전용이라 바이너리(이미지, 파일 등)를 직접 전송 불가.
-Tauri도 같은 문제로 커스텀 프로토콜(`asset://`)을 사용.
-
-Suji 해결 방식: **Zig 코어에서 로컬 HTTP 서버 실행**
-```
-Zig 코어:
-  ├─ WebView IPC (JSON 텍스트) — 함수 호출, 상태, 이벤트
-  └─ 로컬 HTTP 서버 (바이너리) — 이미지, 파일, 스트림
-      http://localhost:{PORT}/asset/photo.png
-```
-```html
-<!-- WebView에서 바이너리 데이터 접근 -->
-<img src="http://localhost:9876/asset/photo.png">
-```
-```js
-// JS에서 바이너리 fetch
-const response = await fetch("http://localhost:9876/api/file/data.bin");
-const buffer = await response.arrayBuffer();
-```
-
-각 프레임워크 비교:
-| 프레임워크 | 텍스트 IPC | 바이너리 |
-|-----------|-----------|---------|
-| Electron | JSON (구조화 복제) | Buffer/ArrayBuffer 직접 지원 |
-| Tauri | JSON-RPC | 커스텀 프로토콜 (asset://) |
-| Wails | JSON | Base64 / 파일 경로 |
-| **Suji** | JSON (webview_bind) | **로컬 HTTP 서버** |
+- [x] ~~바이너리 데이터 채널~~ — CEF `suji://` 커스텀 프로토콜로 대체 (fetch + 로컬 파일 접근 가능, 별도 HTTP 서버 불필요)
 
 **결과물**:
 ```js
@@ -1047,7 +1017,7 @@ suji build → 결과물:
 
 | 기능 | Electron | Tauri | Suji |
 |------|----------|-------|------|
-| 바이너리 IPC | Buffer 직접 전송 | `asset://` 커스텀 프로토콜 | ❌ (로컬 HTTP 서버 계획) |
+| 바이너리 IPC | Buffer 직접 전송 | `asset://` 커스텀 프로토콜 | ✅ `suji://` 커스텀 프로토콜 |
 | 중앙 상태 스토어 | Redux 등 자유 | Tauri state 관리 | ❌ |
 
 ### 우선순위 제안

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -17,7 +17,7 @@
 
 | | Electron | Tauri | Wails | **Suji** |
 |---|---|---|---|---|
-| 브라우저 | Chromium 번들 | OS WebView | OS WebView | OS WebView |
+| 브라우저 | Chromium 번들 | OS WebView | OS WebView | **CEF (Chromium)** |
 | 백엔드 | Node.js 전용 | Rust 전용 | Go 전용 | **아무 언어** |
 | 번들 크기 | ~150MB | ~3MB | ~8MB | 1~50MB (선택) |
 | 코어 언어 | C++ | Rust | Go | **Zig** |
@@ -391,7 +391,7 @@ watch는 EventBus 연동: `state:set` 시 `state:{key}` 이벤트 발행.
   - [x] `suji dev` — 개발 서버 (프론트엔드 + 백엔드 동시 실행)
   - [x] `suji build` — 프로덕션 빌드
   - [x] `suji run` — 빌드된 앱 실행
-- [ ] 핫 리로드 (백엔드 — dylib 재빌드/재로드, 프론트엔드는 Vite HMR로 동작)
+- [x] 핫 리로드 (백엔드 — dylib 재빌드/재로드, 프론트엔드는 Vite HMR로 동작)
 
 **`suji init` 스펙**:
 

--- a/examples/go-backend/suji.json
+++ b/examples/go-backend/suji.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../suji.schema.json",
   "app": { "name": "Suji Go Example", "version": "0.1.0" },
   "window": { "title": "Suji + Go", "width": 1024, "height": 768, "debug": true },
   "backend": { "lang": "go", "entry": "." },

--- a/examples/multi-backend/suji.json
+++ b/examples/multi-backend/suji.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../suji.schema.json",
   "app": {
     "name": "Multi Backend Example",
     "version": "0.1.0"

--- a/examples/node-backend/suji.json
+++ b/examples/node-backend/suji.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../suji.schema.json",
   "app": { "name": "Suji Node Example", "version": "0.1.0" },
   "window": { "title": "Suji + Node.js", "width": 1024, "height": 768, "debug": true },
   "backend": { "lang": "node", "entry": "backends/node" },

--- a/examples/rust-backend/suji.json
+++ b/examples/rust-backend/suji.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../suji.schema.json",
   "app": { "name": "Suji Rust Example", "version": "0.1.0" },
   "window": { "title": "Suji + Rust", "width": 1024, "height": 768, "debug": true },
   "backend": { "lang": "rust", "entry": "." },

--- a/examples/zig-backend/suji.json
+++ b/examples/zig-backend/suji.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../suji.schema.json",
   "app": { "name": "Suji Zig Example", "version": "0.1.0" },
   "window": { "title": "Suji + Zig", "width": 1024, "height": 768, "debug": true },
   "backend": { "lang": "zig", "entry": "." },

--- a/src/core/init.zig
+++ b/src/core/init.zig
@@ -81,6 +81,7 @@ fn writeConfig(allocator: std.mem.Allocator, dir: std.fs.Dir, name: []const u8, 
     const content = switch (backend) {
         .multi => try std.fmt.bufPrint(&buf,
             \\{{
+            \\  "$schema": "https://raw.githubusercontent.com/ohah/suji/main/suji.schema.json",
             \\  "app": {{ "name": "{s}", "version": "0.1.0" }},
             \\  "window": {{ "title": "{s}", "width": 1024, "height": 768, "debug": true }},
             \\  "backends": [
@@ -93,6 +94,7 @@ fn writeConfig(allocator: std.mem.Allocator, dir: std.fs.Dir, name: []const u8, 
         , .{ name, name }),
         else => try std.fmt.bufPrint(&buf,
             \\{{
+            \\  "$schema": "https://raw.githubusercontent.com/ohah/suji/main/suji.schema.json",
             \\  "app": {{ "name": "{s}", "version": "0.1.0" }},
             \\  "window": {{ "title": "{s}", "width": 1024, "height": 768, "debug": true }},
             \\  "backend": {{ "lang": "{s}", "entry": "." }},

--- a/suji.schema.json
+++ b/suji.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/ohah/suji/blob/main/suji.schema.json",
+  "title": "suji.json",
+  "description": "Suji 데스크톱 앱 프레임워크 프로젝트 설정",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema 경로"
+    },
+    "app": {
+      "type": "object",
+      "description": "앱 메타데이터",
+      "properties": {
+        "name": {
+          "type": "string",
+          "default": "Suji App",
+          "description": "앱 이름"
+        },
+        "version": {
+          "type": "string",
+          "default": "0.1.0",
+          "description": "앱 버전 (semver)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "window": {
+      "type": "object",
+      "description": "CEF 윈도우 설정",
+      "properties": {
+        "title": {
+          "type": "string",
+          "default": "Suji App",
+          "description": "윈도우 타이틀"
+        },
+        "width": {
+          "type": "integer",
+          "default": 1024,
+          "minimum": 100,
+          "description": "윈도우 너비 (px)"
+        },
+        "height": {
+          "type": "integer",
+          "default": 768,
+          "minimum": 100,
+          "description": "윈도우 높이 (px)"
+        },
+        "debug": {
+          "type": "boolean",
+          "default": false,
+          "description": "DevTools 활성화 (Cmd+Shift+I)"
+        },
+        "protocol": {
+          "type": "string",
+          "enum": ["file", "suji"],
+          "default": "file",
+          "description": "프론트엔드 로딩 프로토콜. 'file': file:// (기본), 'suji': suji:// 커스텀 프로토콜 (CORS/fetch/Cookie/SW 정상 동작)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "backend": {
+      "type": "object",
+      "description": "단일 백엔드 설정 (backends와 동시 사용 불가)",
+      "properties": {
+        "lang": {
+          "type": "string",
+          "enum": ["zig", "rust", "go", "node"],
+          "default": "zig",
+          "description": "백엔드 언어"
+        },
+        "entry": {
+          "type": "string",
+          "description": "백엔드 엔트리 디렉토리 경로"
+        }
+      },
+      "required": ["lang", "entry"],
+      "additionalProperties": false
+    },
+    "backends": {
+      "type": "array",
+      "description": "멀티 백엔드 설정 (backend와 동시 사용 불가)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "백엔드 식별자 (target 지정 시 사용)"
+          },
+          "lang": {
+            "type": "string",
+            "enum": ["zig", "rust", "go", "node"],
+            "description": "백엔드 언어"
+          },
+          "entry": {
+            "type": "string",
+            "description": "백엔드 엔트리 디렉토리 경로"
+          }
+        },
+        "required": ["name", "lang", "entry"],
+        "additionalProperties": false
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "description": "활성화할 플러그인 목록",
+      "items": {
+        "type": "string"
+      },
+      "examples": [["state"]]
+    },
+    "asset_dir": {
+      "type": "string",
+      "default": "assets",
+      "description": "정적 에셋 디렉토리"
+    },
+    "frontend": {
+      "type": "object",
+      "description": "프론트엔드 설정",
+      "properties": {
+        "dir": {
+          "type": "string",
+          "default": "frontend",
+          "description": "프론트엔드 소스 디렉토리"
+        },
+        "dev_url": {
+          "type": "string",
+          "default": "http://localhost:5173",
+          "description": "개발 서버 URL (suji dev 시 사용)"
+        },
+        "dist_dir": {
+          "type": "string",
+          "default": "frontend/dist",
+          "description": "프로덕션 빌드 출력 디렉토리"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "oneOf": [
+    {
+      "properties": { "backend": {}, "backends": false },
+      "description": "단일 백엔드 모드"
+    },
+    {
+      "properties": { "backends": {}, "backend": false },
+      "description": "멀티 백엔드 모드"
+    },
+    {
+      "not": {
+        "anyOf": [
+          { "required": ["backend"] },
+          { "required": ["backends"] }
+        ]
+      },
+      "description": "백엔드 없음 (프론트엔드 전용)"
+    }
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- suji.json JSON Schema 추가 (IDE 자동완성/검증)
- 예제 + suji init 템플릿에 $schema 필드 추가
- PLAN.md: CEF 비교표 수정, 핫 리로드/바이너리 채널 체크, Node.js 완료 항목
- CLAUDE.md: 테스트 수 173개, node-backend 예제, watcher.zig, 배포 계획

## Test plan
- [x] zig build test 통과 (173개)