### PR TITLE
@suji/node SDK 추가 + 예제 전환

### DIFF
--- a/examples/multi-backend/backends/node/main.js
+++ b/examples/multi-backend/backends/node/main.js
@@ -1,11 +1,10 @@
+const { handle, invokeSync, send } = require('@suji/node');
 const os = require('os');
 const crypto = require('crypto');
 
-// 핸들러 내부에서는 invokeSync 사용 (동기 컨텍스트)
-// 핸들러 밖에서는 suji.invoke() 사용 (Promise 반환, event loop 비블록)
 function safeInvoke(backend, request) {
   try {
-    return JSON.parse(suji.invokeSync(backend, request));
+    return invokeSync(backend, request);
   } catch (e) {
     return { error: `invoke(${backend}) failed: ${e.message}` };
   }
@@ -13,96 +12,83 @@ function safeInvoke(backend, request) {
 
 // 기본 핸들러
 
-suji.handle('node-ping', () => {
-  return JSON.stringify({ msg: 'pong from Node.js!' });
-});
+handle('node-ping', () => ({ msg: 'pong from Node.js!' }));
 
-suji.handle('node-greet', (data) => {
-  const req = JSON.parse(data);
-  const name = req.name || 'world';
-  return JSON.stringify({ greeting: `Hello ${name} from Node.js!` });
-});
+handle('node-greet', (data) => ({
+  greeting: `Hello ${data.name || 'world'} from Node.js!`
+}));
 
 // 런타임/시스템 정보
 
-suji.handle('node-info', () => {
-  return JSON.stringify({
-    runtime: 'Node.js',
-    version: process.version,
-    platform: process.platform,
-    arch: process.arch,
-    pid: process.pid,
-    uptime: `${process.uptime().toFixed(1)}s`,
-    memory: `${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(1)}MB`
-  });
-});
+handle('node-info', () => ({
+  runtime: 'Node.js',
+  version: process.version,
+  platform: process.platform,
+  arch: process.arch,
+  pid: process.pid,
+  uptime: `${process.uptime().toFixed(1)}s`,
+  memory: `${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(1)}MB`
+}));
 
-suji.handle('node-system', () => {
-  return JSON.stringify({
-    hostname: os.hostname(),
-    cpus: os.cpus().length,
-    totalMemory: `${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)}GB`,
-    freeMemory: `${(os.freemem() / 1024 / 1024 / 1024).toFixed(1)}GB`,
-    osType: `${os.type()} ${os.release()}`
-  });
-});
+handle('node-system', () => ({
+  hostname: os.hostname(),
+  cpus: os.cpus().length,
+  totalMemory: `${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)}GB`,
+  freeMemory: `${(os.freemem() / 1024 / 1024 / 1024).toFixed(1)}GB`,
+  osType: `${os.type()} ${os.release()}`
+}));
 
 // 크로스 호출 (Node → 다른 백엔드)
 
 for (const target of ['zig', 'rust', 'go']) {
-  suji.handle(`node-call-${target}`, () => {
-    const result = safeInvoke(target, '{"cmd":"ping"}');
-    return JSON.stringify({ from: 'node', via: target, result });
-  });
+  handle(`node-call-${target}`, () => ({
+    from: 'node', via: target, result: safeInvoke(target, { cmd: 'ping' })
+  }));
 }
 
-suji.handle('node-call-all', () => {
+handle('node-call-all', () => {
   const results = {};
   for (const target of ['zig', 'rust', 'go']) {
-    results[target] = safeInvoke(target, '{"cmd":"ping"}');
+    results[target] = safeInvoke(target, { cmd: 'ping' });
   }
-  return JSON.stringify({ from: 'node', results });
+  return { from: 'node', results };
 });
 
-// 이벤트 발신 (Node → 프론트엔드)
+// 이벤트 발신
 
-suji.handle('node-emit-event', () => {
-  suji.send('node-event', JSON.stringify({ msg: 'hello from Node.js!', time: Date.now() }));
-  return JSON.stringify({ emitted: 'node-event' });
+handle('node-emit-event', () => {
+  send('node-event', { msg: 'hello from Node.js!', time: Date.now() });
+  return { emitted: 'node-event' };
 });
 
-// Collab (Node leads — 다른 백엔드 협업)
+// Collab
 
-suji.handle('node-collab', (data) => {
-  const req = JSON.parse(data);
-  const payload = req.data || 'node leads';
-
+handle('node-collab', (data) => {
+  const payload = data.data || 'node leads';
   const chain = {};
   for (const target of ['zig', 'rust', 'go']) {
-    chain[target] = safeInvoke(target, JSON.stringify({ cmd: 'ping' }));
+    chain[target] = safeInvoke(target, { cmd: 'ping' });
   }
-
-  return JSON.stringify({ leader: 'node', payload, chain, timestamp: Date.now() });
+  return { leader: 'node', payload, chain, timestamp: Date.now() };
 });
 
-suji.handle('node-chain-all', () => {
+handle('node-chain-all', () => {
   const steps = [
-    { backend: 'zig', cmd: 'greet', result: safeInvoke('zig', JSON.stringify({ cmd: 'greet', name: 'from Node' })) },
-    { backend: 'rust', cmd: 'add', result: safeInvoke('rust', JSON.stringify({ cmd: 'add', a: 100, b: 200 })) },
-    { backend: 'go', cmd: 'ping', result: safeInvoke('go', JSON.stringify({ cmd: 'ping' })) },
+    { backend: 'zig', cmd: 'greet', result: safeInvoke('zig', { cmd: 'greet', name: 'from Node' }) },
+    { backend: 'rust', cmd: 'add', result: safeInvoke('rust', { cmd: 'add', a: 100, b: 200 }) },
+    { backend: 'go', cmd: 'ping', result: safeInvoke('go', { cmd: 'ping' }) },
   ];
-  return JSON.stringify({ chain: 'node→zig→rust→go', steps });
+  return { chain: 'node→zig→rust→go', steps };
 });
 
 // 유틸리티
 
-suji.handle('node-hash', (data) => {
-  const req = JSON.parse(data);
-  const text = req.text || 'hello suji';
-  return JSON.stringify({
+handle('node-hash', (data) => {
+  const text = data.text || 'hello suji';
+  return {
     input: text,
     md5: crypto.createHash('md5').update(text).digest('hex'),
     sha256: crypto.createHash('sha256').update(text).digest('hex').slice(0, 16) + '...',
     uuid: crypto.randomUUID()
-  });
+  };
 });

--- a/examples/multi-backend/backends/node/package.json
+++ b/examples/multi-backend/backends/node/package.json
@@ -1,5 +1,8 @@
 {
   "name": "suji-multi-node-backend",
   "version": "0.1.0",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "@suji/node": "../../../../packages/suji-node"
+  }
 }

--- a/examples/node-backend/backends/node/main.js
+++ b/examples/node-backend/backends/node/main.js
@@ -1,52 +1,42 @@
+const { handle, send } = require('@suji/node');
 const os = require('os');
 const crypto = require('crypto');
 
-suji.handle('ping', () => {
-  return JSON.stringify({ msg: 'pong' });
-});
+handle('ping', () => ({ msg: 'pong' }));
 
-suji.handle('greet', (data) => {
-  const req = JSON.parse(data);
-  const name = req.name || 'world';
-  return JSON.stringify({ msg: name, greeting: 'Hello from Node.js!' });
-});
+handle('greet', (data) => ({
+  msg: data.name || 'world',
+  greeting: 'Hello from Node.js!'
+}));
 
-suji.handle('add', (data) => {
-  const req = JSON.parse(data);
-  const a = req.a || 0;
-  const b = req.b || 0;
-  return JSON.stringify({ result: a + b });
-});
+handle('add', (data) => ({
+  result: (data.a || 0) + (data.b || 0)
+}));
 
-suji.handle('info', () => {
-  return JSON.stringify({
-    runtime: 'Node.js',
-    version: process.version,
-    platform: process.platform,
-    arch: process.arch,
-    pid: process.pid,
-    uptime: `${process.uptime().toFixed(1)}s`,
-    memory: `${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(1)}MB`
-  });
-});
+handle('info', () => ({
+  runtime: 'Node.js',
+  version: process.version,
+  platform: process.platform,
+  arch: process.arch,
+  pid: process.pid,
+  uptime: `${process.uptime().toFixed(1)}s`,
+  memory: `${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(1)}MB`
+}));
 
-suji.handle('system', () => {
-  return JSON.stringify({
-    hostname: os.hostname(),
-    cpus: os.cpus().length,
-    totalMemory: `${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)}GB`,
-    freeMemory: `${(os.freemem() / 1024 / 1024 / 1024).toFixed(1)}GB`,
-    osType: `${os.type()} ${os.release()}`
-  });
-});
+handle('system', () => ({
+  hostname: os.hostname(),
+  cpus: os.cpus().length,
+  totalMemory: `${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)}GB`,
+  freeMemory: `${(os.freemem() / 1024 / 1024 / 1024).toFixed(1)}GB`,
+  osType: `${os.type()} ${os.release()}`
+}));
 
-suji.handle('hash', (data) => {
-  const req = JSON.parse(data);
-  const text = req.text || 'hello suji';
-  return JSON.stringify({
+handle('hash', (data) => {
+  const text = data.text || 'hello suji';
+  return {
     input: text,
     md5: crypto.createHash('md5').update(text).digest('hex'),
     sha256: crypto.createHash('sha256').update(text).digest('hex').slice(0, 16) + '...',
     uuid: crypto.randomUUID()
-  });
+  };
 });

--- a/examples/node-backend/backends/node/package.json
+++ b/examples/node-backend/backends/node/package.json
@@ -1,5 +1,8 @@
 {
   "name": "suji-node-backend",
   "version": "0.1.0",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "@suji/node": "../../../../packages/suji-node"
+  }
 }

--- a/packages/suji-node/dist/index.d.ts
+++ b/packages/suji-node/dist/index.d.ts
@@ -63,6 +63,29 @@ export declare function invokeSync<T = unknown>(backend: string, request?: Recor
  */
 export declare function send(channel: string, data?: unknown): void;
 /**
+ * 이벤트 수신 — 프론트엔드/다른 백엔드에서 발신한 이벤트를 수신
+ *
+ * @returns 구독 해제 함수
+ *
+ * @example
+ * const cancel = on('data-updated', (data) => {
+ *   console.log('received:', data);
+ * });
+ * // 나중에 해제
+ * cancel();
+ */
+export declare function on<T = unknown>(channel: string, callback: (data: T) => void): () => void;
+/**
+ * 이벤트 구독 해제
+ */
+export declare function off(subId: number): void;
+/**
+ * 이벤트 한 번만 수신
+ *
+ * @returns 구독 해제 함수
+ */
+export declare function once<T = unknown>(channel: string, callback: (data: T) => void): () => void;
+/**
  * 채널을 수동으로 등록 (자동 라우팅 테이블에 추가)
  *
  * handle()은 자동으로 register하지 않음 (bridge.cc에서 별도 관리).

--- a/packages/suji-node/dist/index.d.ts
+++ b/packages/suji-node/dist/index.d.ts
@@ -1,0 +1,71 @@
+/**
+ * @suji/node — Suji Desktop Framework Node.js Backend SDK
+ *
+ * libnode 임베딩 환경에서 사용. globalThis.suji를 타입 안전하게 래핑.
+ *
+ * ```ts
+ * import { handle, invoke, invokeSync, send } from '@suji/node';
+ *
+ * handle('ping', () => ({ msg: 'pong' }));
+ *
+ * handle('greet', (data) => ({
+ *   greeting: `Hello ${data.name}!`
+ * }));
+ *
+ * // 크로스 호출 (핸들러 내부 — 동기)
+ * handle('call-zig', () => {
+ *   const result = invokeSync('zig', { cmd: 'ping' });
+ *   return { from: 'node', result };
+ * });
+ *
+ * // 이벤트 발신
+ * send('my-event', { msg: 'hello from Node.js' });
+ * ```
+ */
+export type HandlerFn<TReq = unknown, TRes = unknown> = (data: TReq) => TRes;
+/**
+ * 핸들러 등록 — 프론트엔드/다른 백엔드에서 이 채널로 호출 가능
+ *
+ * 콜백은 파싱된 객체를 받고, 반환값은 자동으로 JSON.stringify됨.
+ * 문자열을 반환하면 그대로 전달.
+ *
+ * @example
+ * handle('ping', () => ({ msg: 'pong' }));
+ * handle('greet', (data) => ({ hello: data.name }));
+ */
+export declare function handle<TReq = unknown, TRes = unknown>(channel: string, handler: HandlerFn<TReq, TRes>): void;
+/**
+ * 다른 백엔드 비동기 호출 (Promise 반환, event loop 비블록)
+ *
+ * 핸들러 밖에서 사용. 핸들러 안에서는 invokeSync 사용.
+ *
+ * @example
+ * const result = await invoke('zig', { cmd: 'ping' });
+ */
+export declare function invoke<T = unknown>(backend: string, request?: Record<string, unknown>): Promise<T>;
+/**
+ * 다른 백엔드 동기 호출 (핸들러 내부용)
+ *
+ * event loop을 블록하므로 핸들러 안에서만 사용할 것.
+ *
+ * @example
+ * handle('call-zig', () => {
+ *   const result = invokeSync('zig', { cmd: 'ping' });
+ *   return { from: 'node', result };
+ * });
+ */
+export declare function invokeSync<T = unknown>(backend: string, request?: Record<string, unknown>): T;
+/**
+ * 이벤트 발신 — 프론트엔드로 전달
+ *
+ * @example
+ * send('data-updated', { items: [1, 2, 3] });
+ */
+export declare function send(channel: string, data?: unknown): void;
+/**
+ * 채널을 수동으로 등록 (자동 라우팅 테이블에 추가)
+ *
+ * handle()은 자동으로 register하지 않음 (bridge.cc에서 별도 관리).
+ * 명시적으로 코어 라우팅 테이블에 등록해야 할 때 사용.
+ */
+export declare function register(channel: string): void;

--- a/packages/suji-node/dist/index.js
+++ b/packages/suji-node/dist/index.js
@@ -1,0 +1,133 @@
+"use strict";
+/**
+ * @suji/node — Suji Desktop Framework Node.js Backend SDK
+ *
+ * libnode 임베딩 환경에서 사용. globalThis.suji를 타입 안전하게 래핑.
+ *
+ * ```ts
+ * import { handle, invoke, invokeSync, send } from '@suji/node';
+ *
+ * handle('ping', () => ({ msg: 'pong' }));
+ *
+ * handle('greet', (data) => ({
+ *   greeting: `Hello ${data.name}!`
+ * }));
+ *
+ * // 크로스 호출 (핸들러 내부 — 동기)
+ * handle('call-zig', () => {
+ *   const result = invokeSync('zig', { cmd: 'ping' });
+ *   return { from: 'node', result };
+ * });
+ *
+ * // 이벤트 발신
+ * send('my-event', { msg: 'hello from Node.js' });
+ * ```
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.handle = handle;
+exports.invoke = invoke;
+exports.invokeSync = invokeSync;
+exports.send = send;
+exports.register = register;
+// ============================================
+// Bridge access
+// ============================================
+function getBridge() {
+    const bridge = globalThis.suji;
+    if (!bridge) {
+        throw new Error('@suji/node: bridge not available. This module must run inside a Suji app (libnode embedding).');
+    }
+    return bridge;
+}
+// ============================================
+// Handler registration
+// ============================================
+/**
+ * 핸들러 등록 — 프론트엔드/다른 백엔드에서 이 채널로 호출 가능
+ *
+ * 콜백은 파싱된 객체를 받고, 반환값은 자동으로 JSON.stringify됨.
+ * 문자열을 반환하면 그대로 전달.
+ *
+ * @example
+ * handle('ping', () => ({ msg: 'pong' }));
+ * handle('greet', (data) => ({ hello: data.name }));
+ */
+function handle(channel, handler) {
+    getBridge().handle(channel, (raw) => {
+        let data;
+        try {
+            data = JSON.parse(raw);
+        }
+        catch {
+            data = raw;
+        }
+        const result = handler(data);
+        if (typeof result === 'string')
+            return result;
+        return JSON.stringify(result);
+    });
+}
+// ============================================
+// Cross-backend invocation
+// ============================================
+/**
+ * 다른 백엔드 비동기 호출 (Promise 반환, event loop 비블록)
+ *
+ * 핸들러 밖에서 사용. 핸들러 안에서는 invokeSync 사용.
+ *
+ * @example
+ * const result = await invoke('zig', { cmd: 'ping' });
+ */
+async function invoke(backend, request = {}) {
+    const raw = await getBridge().invoke(backend, JSON.stringify(request));
+    try {
+        return JSON.parse(raw);
+    }
+    catch {
+        return raw;
+    }
+}
+/**
+ * 다른 백엔드 동기 호출 (핸들러 내부용)
+ *
+ * event loop을 블록하므로 핸들러 안에서만 사용할 것.
+ *
+ * @example
+ * handle('call-zig', () => {
+ *   const result = invokeSync('zig', { cmd: 'ping' });
+ *   return { from: 'node', result };
+ * });
+ */
+function invokeSync(backend, request = {}) {
+    const raw = getBridge().invokeSync(backend, JSON.stringify(request));
+    try {
+        return JSON.parse(raw);
+    }
+    catch {
+        return raw;
+    }
+}
+// ============================================
+// Events
+// ============================================
+/**
+ * 이벤트 발신 — 프론트엔드로 전달
+ *
+ * @example
+ * send('data-updated', { items: [1, 2, 3] });
+ */
+function send(channel, data = {}) {
+    getBridge().send(channel, JSON.stringify(data));
+}
+// ============================================
+// Channel registration
+// ============================================
+/**
+ * 채널을 수동으로 등록 (자동 라우팅 테이블에 추가)
+ *
+ * handle()은 자동으로 register하지 않음 (bridge.cc에서 별도 관리).
+ * 명시적으로 코어 라우팅 테이블에 등록해야 할 때 사용.
+ */
+function register(channel) {
+    getBridge().register(channel);
+}

--- a/packages/suji-node/dist/index.js
+++ b/packages/suji-node/dist/index.js
@@ -28,6 +28,9 @@ exports.handle = handle;
 exports.invoke = invoke;
 exports.invokeSync = invokeSync;
 exports.send = send;
+exports.on = on;
+exports.off = off;
+exports.once = once;
 exports.register = register;
 // ============================================
 // Bridge access
@@ -122,6 +125,57 @@ function send(channel, data = {}) {
 // ============================================
 // Channel registration
 // ============================================
+/**
+ * 이벤트 수신 — 프론트엔드/다른 백엔드에서 발신한 이벤트를 수신
+ *
+ * @returns 구독 해제 함수
+ *
+ * @example
+ * const cancel = on('data-updated', (data) => {
+ *   console.log('received:', data);
+ * });
+ * // 나중에 해제
+ * cancel();
+ */
+function on(channel, callback) {
+    const subId = getBridge().on(channel, (_ch, raw) => {
+        let data;
+        try {
+            data = JSON.parse(raw);
+        }
+        catch {
+            data = raw;
+        }
+        callback(data);
+    });
+    return () => off(subId);
+}
+/**
+ * 이벤트 구독 해제
+ */
+function off(subId) {
+    getBridge().off(subId);
+}
+/**
+ * 이벤트 한 번만 수신
+ *
+ * @returns 구독 해제 함수
+ */
+function once(channel, callback) {
+    let subId;
+    subId = getBridge().on(channel, (_ch, raw) => {
+        getBridge().off(subId);
+        let data;
+        try {
+            data = JSON.parse(raw);
+        }
+        catch {
+            data = raw;
+        }
+        callback(data);
+    });
+    return () => getBridge().off(subId);
+}
 /**
  * 채널을 수동으로 등록 (자동 라우팅 테이블에 추가)
  *

--- a/packages/suji-node/package.json
+++ b/packages/suji-node/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@suji/node",
+  "version": "0.1.0",
+  "description": "Suji desktop framework - Node.js backend SDK",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -1,0 +1,160 @@
+/**
+ * @suji/node — Suji Desktop Framework Node.js Backend SDK
+ *
+ * libnode 임베딩 환경에서 사용. globalThis.suji를 타입 안전하게 래핑.
+ *
+ * ```ts
+ * import { handle, invoke, invokeSync, send } from '@suji/node';
+ *
+ * handle('ping', () => ({ msg: 'pong' }));
+ *
+ * handle('greet', (data) => ({
+ *   greeting: `Hello ${data.name}!`
+ * }));
+ *
+ * // 크로스 호출 (핸들러 내부 — 동기)
+ * handle('call-zig', () => {
+ *   const result = invokeSync('zig', { cmd: 'ping' });
+ *   return { from: 'node', result };
+ * });
+ *
+ * // 이벤트 발신
+ * send('my-event', { msg: 'hello from Node.js' });
+ * ```
+ */
+
+// ============================================
+// Types
+// ============================================
+
+export type HandlerFn<TReq = unknown, TRes = unknown> = (data: TReq) => TRes;
+
+interface SujiBridge {
+  handle(channel: string, fn: (data: string) => string): void;
+  invoke(backend: string, request: string): Promise<string>;
+  invokeSync(backend: string, request: string): string;
+  send(channel: string, data: string): void;
+  register(channel: string): void;
+}
+
+// ============================================
+// Bridge access
+// ============================================
+
+function getBridge(): SujiBridge {
+  const bridge = (globalThis as any).suji as SujiBridge | undefined;
+  if (!bridge) {
+    throw new Error(
+      '@suji/node: bridge not available. This module must run inside a Suji app (libnode embedding).'
+    );
+  }
+  return bridge;
+}
+
+// ============================================
+// Handler registration
+// ============================================
+
+/**
+ * 핸들러 등록 — 프론트엔드/다른 백엔드에서 이 채널로 호출 가능
+ *
+ * 콜백은 파싱된 객체를 받고, 반환값은 자동으로 JSON.stringify됨.
+ * 문자열을 반환하면 그대로 전달.
+ *
+ * @example
+ * handle('ping', () => ({ msg: 'pong' }));
+ * handle('greet', (data) => ({ hello: data.name }));
+ */
+export function handle<TReq = unknown, TRes = unknown>(
+  channel: string,
+  handler: HandlerFn<TReq, TRes>,
+): void {
+  getBridge().handle(channel, (raw: string) => {
+    let data: TReq;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      data = raw as unknown as TReq;
+    }
+
+    const result = handler(data);
+
+    if (typeof result === 'string') return result;
+    return JSON.stringify(result);
+  });
+}
+
+// ============================================
+// Cross-backend invocation
+// ============================================
+
+/**
+ * 다른 백엔드 비동기 호출 (Promise 반환, event loop 비블록)
+ *
+ * 핸들러 밖에서 사용. 핸들러 안에서는 invokeSync 사용.
+ *
+ * @example
+ * const result = await invoke('zig', { cmd: 'ping' });
+ */
+export async function invoke<T = unknown>(
+  backend: string,
+  request: Record<string, unknown> = {},
+): Promise<T> {
+  const raw = await getBridge().invoke(backend, JSON.stringify(request));
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return raw as unknown as T;
+  }
+}
+
+/**
+ * 다른 백엔드 동기 호출 (핸들러 내부용)
+ *
+ * event loop을 블록하므로 핸들러 안에서만 사용할 것.
+ *
+ * @example
+ * handle('call-zig', () => {
+ *   const result = invokeSync('zig', { cmd: 'ping' });
+ *   return { from: 'node', result };
+ * });
+ */
+export function invokeSync<T = unknown>(
+  backend: string,
+  request: Record<string, unknown> = {},
+): T {
+  const raw = getBridge().invokeSync(backend, JSON.stringify(request));
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return raw as unknown as T;
+  }
+}
+
+// ============================================
+// Events
+// ============================================
+
+/**
+ * 이벤트 발신 — 프론트엔드로 전달
+ *
+ * @example
+ * send('data-updated', { items: [1, 2, 3] });
+ */
+export function send(channel: string, data: unknown = {}): void {
+  getBridge().send(channel, JSON.stringify(data));
+}
+
+// ============================================
+// Channel registration
+// ============================================
+
+/**
+ * 채널을 수동으로 등록 (자동 라우팅 테이블에 추가)
+ *
+ * handle()은 자동으로 register하지 않음 (bridge.cc에서 별도 관리).
+ * 명시적으로 코어 라우팅 테이블에 등록해야 할 때 사용.
+ */
+export function register(channel: string): void {
+  getBridge().register(channel);
+}

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -34,6 +34,8 @@ interface SujiBridge {
   invoke(backend: string, request: string): Promise<string>;
   invokeSync(backend: string, request: string): string;
   send(channel: string, data: string): void;
+  on(channel: string, fn: (channel: string, data: string) => void): number;
+  off(subId: number): void;
   register(channel: string): void;
 }
 
@@ -148,6 +150,66 @@ export function send(channel: string, data: unknown = {}): void {
 // ============================================
 // Channel registration
 // ============================================
+
+/**
+ * 이벤트 수신 — 프론트엔드/다른 백엔드에서 발신한 이벤트를 수신
+ *
+ * @returns 구독 해제 함수
+ *
+ * @example
+ * const cancel = on('data-updated', (data) => {
+ *   console.log('received:', data);
+ * });
+ * // 나중에 해제
+ * cancel();
+ */
+export function on<T = unknown>(
+  channel: string,
+  callback: (data: T) => void,
+): () => void {
+  const subId = getBridge().on(channel, (_ch: string, raw: string) => {
+    let data: T;
+    try {
+      data = JSON.parse(raw) as T;
+    } catch {
+      data = raw as unknown as T;
+    }
+    callback(data);
+  });
+
+  return () => off(subId);
+}
+
+/**
+ * 이벤트 구독 해제
+ */
+export function off(subId: number): void {
+  getBridge().off(subId);
+}
+
+/**
+ * 이벤트 한 번만 수신
+ *
+ * @returns 구독 해제 함수
+ */
+export function once<T = unknown>(
+  channel: string,
+  callback: (data: T) => void,
+): () => void {
+  let subId: number;
+  subId = getBridge().on(channel, (_ch: string, raw: string) => {
+    getBridge().off(subId);
+    let data: T;
+    try {
+      data = JSON.parse(raw) as T;
+    } catch {
+      data = raw as unknown as T;
+    }
+    callback(data);
+  });
+
+  return () => getBridge().off(subId);
+}
 
 /**
  * 채널을 수동으로 등록 (자동 라우팅 테이블에 추가)

--- a/packages/suji-node/tsconfig.json
+++ b/packages/suji-node/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/src/platform/node.zig
+++ b/src/platform/node.zig
@@ -16,6 +16,7 @@ pub const bridge = if (node_enabled) @cImport({
     pub fn suji_node_free(_: anytype) callconv(.c) void {}
     pub fn suji_node_set_core(_: anytype) callconv(.c) void {}
     pub fn suji_node_wait_ready(_: c_int) callconv(.c) c_int { return -1; }
+    // on/off는 SujiNodeCore를 통해 전달되므로 stub 불필요
 };
 
 /// Node.js 백엔드 런타임
@@ -104,6 +105,8 @@ pub const NodeRuntime = struct {
             .invoke = core.invoke,
             .free = core.free,
             .emit = core.emit,
+            .on = core.on,
+            .off = core.off,
             .reg = core.register,
         });
     }

--- a/src/platform/node/bridge.cc
+++ b/src/platform/node/bridge.cc
@@ -109,6 +109,23 @@ static std::mutex g_async_invoke_mutex;
 static std::vector<AsyncInvokeRequest*> g_async_invoke_done;
 static uv_async_t g_async_invoke_async;
 
+// Event listener: C 콜백 → Node 스레드 전달
+struct EventNotification {
+    std::string channel;
+    std::string data;
+};
+
+struct JsEventListener {
+    uint64_t sub_id;
+    v8::Global<v8::Function> callback;
+};
+
+static std::mutex g_event_mutex;
+static std::vector<EventNotification*> g_event_queue;
+static uv_async_t g_event_async;
+static std::mutex g_listener_mutex;
+static std::vector<JsEventListener*> g_listeners;
+
 // ============================================
 // Thread Pool (async invoke용, 고정 크기)
 // ============================================
@@ -159,6 +176,63 @@ private:
 };
 
 static std::unique_ptr<ThreadPool> g_invoke_pool;
+
+// ============================================
+// Event 큐 처리 (Node event loop에서 JS 콜백 호출)
+// ============================================
+
+static void process_event_queue(uv_async_t*) {
+    if (!g_setup) return;
+    Isolate* isolate = g_setup->isolate();
+    if (!isolate) return;
+
+    Locker locker(isolate);
+    Isolate::Scope isolate_scope(isolate);
+    HandleScope handle_scope(isolate);
+    Context::Scope context_scope(g_setup->context());
+
+    std::vector<EventNotification*> events;
+    {
+        std::lock_guard<std::mutex> lock(g_event_mutex);
+        events.swap(g_event_queue);
+    }
+
+    std::vector<JsEventListener*> listeners;
+    {
+        std::lock_guard<std::mutex> lock(g_listener_mutex);
+        listeners = g_listeners; // 복사 (콜백 실행 중 수정 방지)
+    }
+
+    for (auto* evt : events) {
+        for (auto* listener : listeners) {
+            // 채널 매칭: 리스너가 특정 채널 또는 전체(*)를 수신
+            Local<Function> fn = listener->callback.Get(isolate);
+            Local<String> ch_arg = String::NewFromUtf8(isolate, evt->channel.c_str()).ToLocalChecked();
+            Local<String> data_arg = String::NewFromUtf8(isolate, evt->data.c_str()).ToLocalChecked();
+            Local<Value> argv[2] = { ch_arg, data_arg };
+
+            v8::TryCatch try_catch(isolate);
+            fn->Call(g_setup->context(), v8::Undefined(isolate), 2, argv).FromMaybe(Local<Value>());
+            if (try_catch.HasCaught()) {
+                String::Utf8Value err(isolate, try_catch.Exception());
+                fprintf(stderr, "[suji-node] event callback error: %s\n", *err);
+            }
+        }
+        delete evt;
+    }
+}
+
+// C 콜백 — EventBus에서 호출됨 (임의 스레드)
+static void on_event_callback(const char* channel, const char* data, void*) {
+    auto* evt = new EventNotification();
+    evt->channel = channel ? channel : "";
+    evt->data = data ? data : "";
+    {
+        std::lock_guard<std::mutex> lock(g_event_mutex);
+        g_event_queue.push_back(evt);
+    }
+    uv_async_send(&g_event_async);
+}
 
 // ============================================
 // 단일 IPC 요청 실행 (V8 isolate lock + context scope 안에서 호출)
@@ -439,6 +513,78 @@ static void js_suji_register(const v8::FunctionCallbackInfo<Value>& args) {
 }
 
 // ============================================
+// JS에서 호출하는 네이티브 함수: __suji_on(channel, callback) → subId
+// ============================================
+
+static void js_suji_on(const v8::FunctionCallbackInfo<Value>& args) {
+    Isolate* isolate = args.GetIsolate();
+    if (!g_core.on) {
+        isolate->ThrowException(String::NewFromUtf8(isolate, "suji.on: core not connected").ToLocalChecked());
+        return;
+    }
+    if (args.Length() < 2 || !args[0]->IsString() || !args[1]->IsFunction()) {
+        isolate->ThrowException(String::NewFromUtf8(isolate, "suji.on(channel, callback) requires string and function").ToLocalChecked());
+        return;
+    }
+
+    String::Utf8Value channel(isolate, args[0]);
+
+    // JS 콜백을 Global로 저장
+    auto* listener = new JsEventListener();
+    listener->callback.Reset(isolate, args[1].As<Function>());
+
+    // C 콜백으로 EventBus에 등록 (임의 스레드에서 호출됨 → on_event_callback이 큐에 전달)
+    uint64_t sub_id = g_core.on(*channel, on_event_callback, nullptr);
+    listener->sub_id = sub_id;
+
+    {
+        std::lock_guard<std::mutex> lock(g_listener_mutex);
+        g_listeners.push_back(listener);
+    }
+
+    // subscription ID 반환 (off에서 사용)
+    args.GetReturnValue().Set(v8::Number::New(isolate, static_cast<double>(sub_id)));
+}
+
+// ============================================
+// JS에서 호출하는 네이티브 함수: __suji_off(subId)
+// ============================================
+
+static void js_suji_off(const v8::FunctionCallbackInfo<Value>& args) {
+    Isolate* isolate = args.GetIsolate();
+    if (!g_core.off) {
+        isolate->ThrowException(String::NewFromUtf8(isolate, "suji.off: core not connected").ToLocalChecked());
+        return;
+    }
+    if (args.Length() < 1 || !args[0]->IsNumber()) {
+        isolate->ThrowException(String::NewFromUtf8(isolate, "suji.off(subId) requires number").ToLocalChecked());
+        return;
+    }
+
+    uint64_t sub_id = static_cast<uint64_t>(args[0]->NumberValue(g_setup->context()).FromJust());
+
+    // EventBus에서 구독 해제
+    g_core.off(sub_id);
+
+    // JS 리스너 정리
+    {
+        std::lock_guard<std::mutex> lock(g_listener_mutex);
+        g_listeners.erase(
+            std::remove_if(g_listeners.begin(), g_listeners.end(),
+                [sub_id](JsEventListener* l) {
+                    if (l->sub_id == sub_id) {
+                        l->callback.Reset();
+                        delete l;
+                        return true;
+                    }
+                    return false;
+                }),
+            g_listeners.end()
+        );
+    }
+}
+
+// ============================================
 // C API Implementation
 // ============================================
 
@@ -498,6 +644,7 @@ static int run_node_internal(const char* entry_path) {
         // IPC async 핸들 등록 (Node 이벤트 루프에서 IPC 처리)
         uv_async_init(g_setup->event_loop(), &g_ipc_async, process_ipc_queue);
         uv_async_init(g_setup->event_loop(), &g_async_invoke_async, process_async_invoke_done);
+        uv_async_init(g_setup->event_loop(), &g_event_async, process_event_queue);
 
         // Async invoke 스레드 풀 (4 workers)
         g_invoke_pool = std::make_unique<ThreadPool>(4);
@@ -515,6 +662,8 @@ static int run_node_internal(const char* entry_path) {
         set_fn("__suji_invoke", js_suji_invoke);
         set_fn("__suji_invoke_sync", js_suji_invoke_sync);
         set_fn("__suji_send", js_suji_send);
+        set_fn("__suji_on", js_suji_on);
+        set_fn("__suji_off", js_suji_off);
         set_fn("__suji_register", js_suji_register);
 
         // 엔트리 JS 파일 로드 — @suji/node SDK를 주입하고 사용자 코드 실행
@@ -525,6 +674,8 @@ static int run_node_internal(const char* entry_path) {
             "  invoke: __suji_invoke,"
             "  invokeSync: __suji_invoke_sync,"
             "  send: __suji_send,"
+            "  on: __suji_on,"
+            "  off: __suji_off,"
             "  register: __suji_register"
             "};"
             "const { createRequire } = require('module');"

--- a/src/platform/node/bridge.h
+++ b/src/platform/node/bridge.h
@@ -40,10 +40,16 @@ typedef void (*suji_core_free_fn)(const char* ptr);
 typedef void (*suji_core_emit_fn)(const char* channel, const char* data);
 typedef void (*suji_core_register_fn)(const char* channel);
 
+typedef void (*suji_core_on_callback_fn)(const char* channel, const char* data, void* arg);
+typedef unsigned long long (*suji_core_on_fn)(const char* channel, suji_core_on_callback_fn cb, void* arg);
+typedef void (*suji_core_off_fn)(unsigned long long id);
+
 struct SujiNodeCore {
     suji_core_invoke_fn invoke;
     suji_core_free_fn free;
     suji_core_emit_fn emit;
+    suji_core_on_fn on;
+    suji_core_off_fn off;
     suji_core_register_fn reg;
 };
 


### PR DESCRIPTION
## Summary
- @suji/node 패키지 추가 (packages/suji-node/)
- handle, invoke, invokeSync, send, register 타입 안전 래핑
- JSON 직렬화/역직렬화 자동 처리
- 예제를 require('@suji/node')로 전환

## Test plan
- [x] zig build test 통과
- [x] node-backend 예제 실행 확인
- [x] multi-backend Node.js 크로스 호출 확인