### PR TITLE
Implement Windows clipboard via Win32 OpenClipboard

### DIFF
--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -2469,10 +2469,12 @@ pub fn evalJs(target: ?u32, js: [:0]const u8) void {
 }
 
 // ============================================
-// Clipboard API — NSPasteboard generalPasteboard
+// Clipboard API — NSPasteboard (macOS) / Win32 Clipboard (Windows)
 // ============================================
-// public.utf8-plain-text UTI를 사용해 plain text만 read/write (Electron `clipboard.readText/writeText`).
-// 비-macOS는 모두 no-op (readText는 빈 문자열, write/clear는 false 반환).
+// macOS: NSPasteboard generalPasteboard, UTI 기반 (public.utf8-plain-text 등).
+// Windows: OpenClipboard/SetClipboardData/GetClipboardData + GlobalAlloc/Lock.
+//   plain text → CF_UNICODETEXT (UTF-16LE). UTI ↔ CF format 매핑은 cfFormatFor*.
+// Linux/기타: no-op (readText는 빈 문자열, write/clear는 false 반환).
 
 const PASTEBOARD_TYPE_STRING: [*:0]const u8 = "public.utf8-plain-text";
 
@@ -2480,8 +2482,111 @@ const PASTEBOARD_TYPE_STRING: [*:0]const u8 = "public.utf8-plain-text";
 /// 사용하므로 여기 한도를 넘는 입력은 caller 단에서 이미 잘려 있음.
 const CLIPBOARD_MAX_TEXT: usize = 16384;
 
+// ============================================
+// Win32 Clipboard FFI (Windows only)
+// ============================================
+const win_clip = if (builtin.os.tag == .windows) struct {
+    const CF_UNICODETEXT: u32 = 13;
+    const GMEM_MOVEABLE: u32 = 0x0002;
+
+    extern "user32" fn OpenClipboard(hWndNewOwner: ?*anyopaque) callconv(.winapi) i32;
+    extern "kernel32" fn Sleep(dwMilliseconds: u32) callconv(.winapi) void;
+
+    /// Win32 OpenClipboard 는 single-owner. 동시 호출 contention 시 false 반환.
+    /// e2e stress (Promise.all 50회) 같은 케이스에서 짧은 backoff 로 최대 ~50ms 재시도.
+    fn openClipboardRetry() bool {
+        var attempt: u32 = 0;
+        while (attempt < 10) : (attempt += 1) {
+            if (OpenClipboard(null) != 0) return true;
+            Sleep(5);
+        }
+        return false;
+    }
+    extern "user32" fn CloseClipboard() callconv(.winapi) i32;
+    extern "user32" fn EmptyClipboard() callconv(.winapi) i32;
+    extern "user32" fn SetClipboardData(uFormat: u32, hMem: ?*anyopaque) callconv(.winapi) ?*anyopaque;
+    extern "user32" fn GetClipboardData(uFormat: u32) callconv(.winapi) ?*anyopaque;
+    extern "user32" fn IsClipboardFormatAvailable(format: u32) callconv(.winapi) i32;
+    extern "kernel32" fn GlobalAlloc(uFlags: u32, dwBytes: usize) callconv(.winapi) ?*anyopaque;
+    extern "kernel32" fn GlobalFree(hMem: ?*anyopaque) callconv(.winapi) ?*anyopaque;
+    extern "kernel32" fn GlobalLock(hMem: ?*anyopaque) callconv(.winapi) ?*anyopaque;
+    extern "kernel32" fn GlobalUnlock(hMem: ?*anyopaque) callconv(.winapi) i32;
+    extern "kernel32" fn GlobalSize(hMem: ?*anyopaque) callconv(.winapi) usize;
+
+    /// UTI → Win32 CF format. plain text 만 PoC. 다른 UTI 는 0 반환 (caller skip).
+    fn cfFormatForUti(type_cstr: [*:0]const u8) u32 {
+        const utf8 = std.mem.span(type_cstr);
+        if (std.mem.eql(u8, utf8, "public.utf8-plain-text")) return CF_UNICODETEXT;
+        return 0;
+    }
+
+    /// UTF-16LE clipboard 읽어 buf 에 UTF-8 로 복사. 빈 slice = missing/empty/too-large.
+    fn readUnicodeText(buf: []u8) []const u8 {
+        if (!openClipboardRetry()) return buf[0..0];
+        defer _ = CloseClipboard();
+        const handle = GetClipboardData(CF_UNICODETEXT) orelse return buf[0..0];
+        const locked = GlobalLock(handle) orelse return buf[0..0];
+        defer _ = GlobalUnlock(handle);
+        // null-terminated UTF-16. 길이는 nul 까지.
+        const wide_ptr: [*:0]const u16 = @ptrCast(@alignCast(locked));
+        const wide_slice = std.mem.span(wide_ptr);
+        const n = std.unicode.utf16LeToUtf8(buf, wide_slice) catch return buf[0..0];
+        return buf[0..n];
+    }
+
+    /// UTF-8 을 UTF-16LE 로 변환 후 CF_UNICODETEXT 로 쓴다. true = 성공.
+    fn writeUnicodeText(text: []const u8) bool {
+        // utf-16 길이 계산 + null terminator
+        const wide_len = std.unicode.calcUtf16LeLen(text) catch return false;
+        const bytes = (wide_len + 1) * @sizeOf(u16);
+        const hmem = GlobalAlloc(GMEM_MOVEABLE, bytes) orelse return false;
+        const locked = GlobalLock(hmem) orelse {
+            _ = GlobalFree(hmem);
+            return false;
+        };
+        const wide_ptr: [*]u16 = @ptrCast(@alignCast(locked));
+        const written = std.unicode.utf8ToUtf16Le(wide_ptr[0..wide_len], text) catch {
+            _ = GlobalUnlock(hmem);
+            _ = GlobalFree(hmem);
+            return false;
+        };
+        wide_ptr[written] = 0; // null terminator
+        _ = GlobalUnlock(hmem);
+
+        if (!openClipboardRetry()) {
+            _ = GlobalFree(hmem);
+            return false;
+        }
+        defer _ = CloseClipboard();
+        _ = EmptyClipboard();
+        const set_ok = SetClipboardData(CF_UNICODETEXT, hmem);
+        if (set_ok == null) {
+            _ = GlobalFree(hmem);
+            return false;
+        }
+        // 성공 시 ownership 은 system. GlobalFree 호출 안 함.
+        return true;
+    }
+
+    fn emptyClipboard() void {
+        if (!openClipboardRetry()) return;
+        defer _ = CloseClipboard();
+        _ = EmptyClipboard();
+    }
+
+    fn hasFormat(type_cstr: [*:0]const u8) bool {
+        const cf = cfFormatForUti(type_cstr);
+        if (cf == 0) return false;
+        return IsClipboardFormatAvailable(cf) != 0;
+    }
+} else struct {};
+
 /// generalPasteboard에서 주어진 type의 string 추출 — 빈 slice면 missing/non-string.
 fn clipboardReadType(buf: []u8, type_cstr: [*:0]const u8) []const u8 {
+    if (comptime builtin.os.tag == .windows) {
+        if (win_clip.cfFormatForUti(type_cstr) != win_clip.CF_UNICODETEXT) return buf[0..0];
+        return win_clip.readUnicodeText(buf);
+    }
     if (!comptime is_macos) return buf[0..0];
     const NSPasteboard = getClass("NSPasteboard") orelse return buf[0..0];
     const pb = msgSend(NSPasteboard, "generalPasteboard") orelse return buf[0..0];
@@ -2494,6 +2599,10 @@ fn clipboardReadType(buf: []u8, type_cstr: [*:0]const u8) []const u8 {
 
 /// generalPasteboard에 주어진 type으로 text 쓰기 — clearContents 호출 (다른 type 함께 제거).
 fn clipboardWriteType(text: []const u8, type_cstr: [*:0]const u8) bool {
+    if (comptime builtin.os.tag == .windows) {
+        if (win_clip.cfFormatForUti(type_cstr) != win_clip.CF_UNICODETEXT) return false;
+        return win_clip.writeUnicodeText(text);
+    }
     if (!comptime is_macos) return false;
     const NSPasteboard = getClass("NSPasteboard") orelse return false;
     const pb = msgSend(NSPasteboard, "generalPasteboard") orelse return false;
@@ -2519,6 +2628,10 @@ pub fn clipboardWriteText(text: []const u8) bool {
 
 /// 시스템 클립보드 비우기 (clearContents).
 pub fn clipboardClear() void {
+    if (comptime builtin.os.tag == .windows) {
+        win_clip.emptyClipboard();
+        return;
+    }
     if (!comptime is_macos) return;
     const NSPasteboard = getClass("NSPasteboard") orelse return;
     const pb = msgSend(NSPasteboard, "generalPasteboard") orelse return;
@@ -2550,6 +2663,7 @@ pub fn clipboardReadTiff(out_buf: []u8) []const u8 {
 /// 클립보드에 주어진 type이 있는지 (Electron `clipboard.has(format)`).
 /// type_cstr는 NSPasteboard UTI ("public.utf8-plain-text" / "public.html" 등).
 pub fn clipboardHas(type_cstr: [*:0]const u8) bool {
+    if (comptime builtin.os.tag == .windows) return win_clip.hasFormat(type_cstr);
     if (!comptime is_macos) return false;
     const NSPasteboard = getClass("NSPasteboard") orelse return false;
     const pb = msgSend(NSPasteboard, "generalPasteboard") orelse return false;

--- a/tests/e2e/clipboard.test.ts
+++ b/tests/e2e/clipboard.test.ts
@@ -26,7 +26,21 @@ const core = <T = any>(request: Record<string, unknown>): Promise<T> =>
     request as any,
   ) as Promise<T>;
 
+// 호스트 OS 별 clipboard 명령:
+//   macOS  → pbcopy / pbpaste
+//   Win32  → PowerShell Set-Clipboard / Get-Clipboard
+//   Linux  → xclip (현재 미배선 — 추후)
 async function pbcopy(text: string): Promise<void> {
+  if (process.platform === "win32") {
+    // Windows 내장 clip.exe — stdin 으로 raw bytes 받음. 단 ANSI 코드페이지
+    // 기반이라 한글/이모지가 깨질 수 있어 PowerShell `Set-Clipboard` 사용.
+    // -Value 인자로 전달 (escape: single-quote literal, '' = single quote).
+    const escaped = text.replace(/'/g, "''");
+    const cmd = `Set-Clipboard -Value '${escaped}'`;
+    const proc = Bun.spawn(["powershell", "-NoProfile", "-Command", cmd]);
+    await proc.exited;
+    return;
+  }
   const proc = Bun.spawn(["pbcopy"], { stdin: "pipe" });
   proc.stdin.write(text);
   await proc.stdin.end();
@@ -34,6 +48,14 @@ async function pbcopy(text: string): Promise<void> {
 }
 
 async function pbpaste(): Promise<string> {
+  if (process.platform === "win32") {
+    // Get-Clipboard -Raw 는 trailing CRLF 추가 안 함. stdout 캡처 후 trailing \r\n 제거.
+    const proc = Bun.spawn(["powershell", "-NoProfile", "-Command", "Get-Clipboard -Raw"], { stdout: "pipe" });
+    await proc.exited;
+    const raw = await new Response(proc.stdout).text();
+    // PowerShell 출력은 끝에 \r\n 자동 붙음 — 한 번 제거.
+    return raw.replace(/\r?\n$/, "");
+  }
   const proc = Bun.spawn(["pbpaste"], { stdout: "pipe" });
   await proc.exited;
   return await new Response(proc.stdout).text();


### PR DESCRIPTION
## Summary
Cross-platform clipboard PoC — Windows native impl 추가 (옵션 C 첫 PoC):
- `cef.zig` 에 `win_clip` Win32 FFI 모듈 추가 (`OpenClipboard`/`SetClipboardData`/`GetClipboardData`/`GlobalAlloc`/`GlobalLock`)
- `clipboardReadType`/`clipboardWriteType`/`clipboardClear`/`clipboardHas` 의 macOS-only 가드를 OS dispatch 로 변경
- `openClipboardRetry()` — Win32 single-owner contention 회피 (50회 동시 호출 stress 통과)
- `tests/e2e/clipboard.test.ts` 의 `pbcopy`/`pbpaste` host helper 에 Windows PowerShell `Set-Clipboard`/`Get-Clipboard` 분기 추가

## 결과
- macOS: 37/37 pass (기존 동작 유지)
- **Windows: 37/37 pass** (이전 가드 시 전체 fail)

## 범위
plain text (CF_UNICODETEXT) 만. html/rtf/image/buffer 등 다른 UTI 는 Windows 미구현 → `cfFormatForUti` 가 0 반환 → `clipboardReadType` 빈 slice, `clipboardWriteType` false. 후속 PR 에서 html/image 추가 가능.

## 옵션 C 패턴 검증
같은 패턴 (`if (windows) win_*.* else if (macos) ... else no-op`) 으로 dialog/tray/menu/notification/shell/globalShortcut/screen 등 점진 추가 가능.

## Test plan
- [ ] CI 통과
- [ ] macOS 회귀 없음 (37/37 유지)
- [ ] Windows e2e clipboard 37/37