### PR TITLE
Fix Windows Go c-shared DLL load (-ldflags=-s -w)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -885,9 +885,16 @@ pub fn build(b: *std.Build) void {
         .windows => "backend.dll",
         else => "libbackend.dylib",
     };
-    const go_build = b.addSystemCommand(&.{
-        "go", "build", "-buildmode=c-shared", "-o", go_bridge_lib, "main.go",
-    });
+    // Windows 는 -ldflags="-s -w" 로 DWARF strip — Go 1.26+ c-shared DLL 이
+    // PE loader 와 .debug_* 섹션 충돌로 ERROR_BAD_EXE_FORMAT 발생 회피.
+    const go_build = if (target.result.os.tag == .windows)
+        b.addSystemCommand(&.{
+            "go", "build", "-buildmode=c-shared", "-ldflags=-s -w", "-o", go_bridge_lib, "main.go",
+        })
+    else
+        b.addSystemCommand(&.{
+            "go", "build", "-buildmode=c-shared", "-o", go_bridge_lib, "main.go",
+        });
     go_build.setCwd(b.path("tests/fixtures/state_go_bridge"));
     // macOS: Homebrew LLVM과 충돌 회피 (examples/multi-backend/backends/go와 동일)
     if (target.result.os.tag == .macos) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -729,10 +729,14 @@ fn buildBackendByLang(allocator: std.mem.Allocator, lang: []const u8, entry: []c
         defer allocator.free(output);
         const go_entry = try std.fmt.allocPrint(allocator, "{s}/main.go", .{entry});
         defer allocator.free(go_entry);
-        const argv = &.{ "go", "build", "-buildmode=c-shared", "-o", output, go_entry };
         if (builtin.os.tag == .windows) {
+            // Windows: -ldflags="-s -w" 가 없으면 Go c-shared DLL 이 LoadLibrary 에서
+            // ERROR_BAD_EXE_FORMAT(193) 으로 실패하는 케이스가 있다 (Go 1.26+
+            // DWARF/.debug_* 섹션이 PE loader 와 충돌). debug info 제거로 안정 로드.
+            const argv = &.{ "go", "build", "-buildmode=c-shared", "-ldflags=-s -w", "-o", output, go_entry };
             try runCmdEnv(allocator, argv, &.{.{ "CGO_ENABLED", "1" }});
         } else {
+            const argv = &.{ "go", "build", "-buildmode=c-shared", "-o", output, go_entry };
             try runCmdEnv(allocator, argv, &.{
                 .{ "CC", "/usr/bin/clang" },
                 .{ "CGO_ENABLED", "1" },


### PR DESCRIPTION
## Summary
`zig build test-state-go` on Windows: 0/10 → 10/10 pass.

Root cause: Go 1.26's c-shared build emits DWARF/.debug_* sections that the Windows PE loader rejects with `ERROR_BAD_EXE_FORMAT (193)`. Adding `-ldflags=-s -w` strips debug info → DLL loads.

This affected both:
- `suji dev` rebuilds of Go backends (e.g. `examples/multi-backend/backends/go/backend.dll` — previously [suji] load failed for go: error.FileNotFound)
- `test-state-go` Go bridge fixture

Diagnostic (PowerShell `LoadLibraryW` direct probe):
- default build → handle=0, err=193
- with `-ldflags=-s -w` → handle valid

## Plugin status on Windows after this fix

| Plugin | Zig core | Rust wrapper | Go wrapper | Node wrapper | JS wrapper |
|---|---|---|---|---|---|
| state | ✅ | ❌ specta crate unstable feat (cross-platform, not Win-only) | ✅ (this PR) | (untested) | (untested) |
| sqlite | ✅ | (untested) | (untested) | (untested) | (untested) |

Rust wrapper failure is a `specta` dependency `debug_closure_helpers` unstable feature — affects all platforms equally, separate issue.

## Test plan
- [x] `zig build test-state-go` 10/10 pass on Windows
- [x] `zig build test-state` 17/17 (state plugin unchanged)
- [x] `zig build test-sqlite` 14/14 (sqlite plugin unchanged)
- [x] `zig build` clean
- [ ] CI Linux/macOS still pass (paths gated on `target.result.os.tag == .windows`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)