### PR TITLE
Windows packaging: self-contained CEF/Node runtime + packaged exe bootstrap

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -76,16 +76,42 @@ pub fn main(init: std.process.Init) !void {
 
     log.info("suji starting pid={d} log_level={s}", .{ getCurrentPid(), @tagName(log_level) });
 
-    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    const raw_args = try init.minimal.args.toSlice(init.arena.allocator());
 
-    // 번들에서 실행 시 자동으로 run (macOS .app / Linux AppImage)
+    // `--do-not-de-elevate` 는 maybeRelaunchWithNoDeElevate 가 자기 자신 spawn
+    // 시 child cmdline 에 추가하는 internal flag — 사용자 명령으로 해석되면 안 됨.
+    // 사전 필터링 후 나머지를 command-line args 로 사용.
+    var filtered_buf: [64][:0]const u8 = undefined;
+    var filtered_len: usize = 0;
+    for (raw_args) |a| {
+        if (std.mem.eql(u8, a, "--do-not-de-elevate")) continue;
+        if (filtered_len >= filtered_buf.len) break;
+        filtered_buf[filtered_len] = a;
+        filtered_len += 1;
+    }
+    const args = filtered_buf[0..filtered_len];
+
+    // 번들에서 실행 시 자동으로 run (macOS .app / Linux AppImage / Windows packaged exe).
+    // Windows packaging 은 `<name>.exe` 옆에 `resources/frontend/index.html` 을 둔다 —
+    // 그게 있으면 packaged app 으로 판단해 runProd.
     if (args.len < 2) {
         var exe_buf: [1024]u8 = undefined;
         if (std.process.executablePath(init.io, &exe_buf)) |n| {
             const ep = exe_buf[0..n];
             const is_bundle = switch (comptime @import("builtin").os.tag) {
                 .macos => std.mem.indexOf(u8, ep, ".app/Contents/MacOS/") != null,
-                else => false, // Linux/Windows: 향후 AppImage 등 감지 추가
+                .windows => blk: {
+                    // 같은 디렉토리에 resources/frontend/index.html 존재 = packaged.
+                    const exe_dir = std.fs.path.dirname(ep) orelse break :blk false;
+                    const probe = std.fmt.allocPrint(
+                        init.arena.allocator(),
+                        "{s}/resources/frontend/index.html",
+                        .{exe_dir},
+                    ) catch break :blk false;
+                    std.Io.Dir.cwd().access(runtime.io, probe, .{}) catch break :blk false;
+                    break :blk true;
+                },
+                else => false, // Linux: 향후 AppImage 등 감지 추가
             };
             if (is_bundle) {
                 try runProd(allocator);
@@ -4709,8 +4735,17 @@ fn cefEmitHandler(target: ?u32, event: []const u8, data: []const u8) void {
 
 /// dist 디렉토리 절대 경로 탐색 (로컬 → .app/AppImage 번들)
 fn findDistPath(allocator: std.mem.Allocator, dist_dir: []const u8) ?[]const u8 {
+    // realPathFileAlloc 가 sentinel 포함 [:0]u8 (alloc N+1) 을 반환 — caller 가
+    // []const u8 로 받아 free 하면 size mismatch panic. dupe 로 length-exact 재할당.
+    const dupe = struct {
+        fn run(a: std.mem.Allocator, sentinel: [:0]u8) ?[]const u8 {
+            defer a.free(sentinel);
+            return a.dupe(u8, sentinel) catch null;
+        }
+    }.run;
+
     // 1. CWD 기준 (로컬 개발)
-    if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, dist_dir, allocator)) |p| return p else |_| {}
+    if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, dist_dir, allocator)) |p| return dupe(allocator, p) else |_| {}
 
     // 2. .app 번들: exe/../Resources/frontend/dist
     var exe_buf: [1024]u8 = undefined;
@@ -4721,12 +4756,24 @@ fn findDistPath(allocator: std.mem.Allocator, dist_dir: []const u8) ?[]const u8 
 
     const bundle_dist = std.fmt.allocPrint(allocator, "{s}/Resources/frontend/dist", .{contents_dir}) catch return null;
     defer allocator.free(bundle_dist);
-    if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, bundle_dist, allocator)) |p| return p else |_| {}
+    if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, bundle_dist, allocator)) |p| return dupe(allocator, p) else |_| {}
 
     // 3. .app 번들: Resources/frontend (dist 없이)
     const bundle_frontend = std.fmt.allocPrint(allocator, "{s}/Resources/frontend", .{contents_dir}) catch return null;
     defer allocator.free(bundle_frontend);
-    if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, bundle_frontend, allocator)) |p| return p else |_| {}
+    if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, bundle_frontend, allocator)) |p| return dupe(allocator, p) else |_| {}
+
+    // 3.5. Windows packaged: <exe_dir>/resources/frontend (소문자 r). packageWindows
+    // 가 만드는 layout — macOS 의 macos_dir/contents_dir 계층 대신 단순 flat.
+    if (builtin.os.tag == .windows) {
+        const exe_dir_win = std.fs.path.dirname(exe_path) orelse return null;
+        const win_pkg_dist = std.fmt.allocPrint(allocator, "{s}/resources/frontend/dist", .{exe_dir_win}) catch return null;
+        defer allocator.free(win_pkg_dist);
+        if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, win_pkg_dist, allocator)) |p| return dupe(allocator, p) else |_| {}
+        const win_pkg_frontend = std.fmt.allocPrint(allocator, "{s}/resources/frontend", .{exe_dir_win}) catch return null;
+        defer allocator.free(win_pkg_frontend);
+        if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, win_pkg_frontend, allocator)) |p| return dupe(allocator, p) else |_| {}
+    }
 
     // 4. Linux AppImage/AppDir: AppDir/usr/bin/<exe> + AppDir/usr/resources/frontend.
     if (builtin.os.tag == .linux) {
@@ -4734,11 +4781,11 @@ fn findDistPath(allocator: std.mem.Allocator, dist_dir: []const u8) ?[]const u8 
         const usr_dir = std.fs.path.dirname(bin_dir) orelse return null;
         const appdir_resources_dist = std.fmt.allocPrint(allocator, "{s}/resources/frontend/dist", .{usr_dir}) catch return null;
         defer allocator.free(appdir_resources_dist);
-        if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, appdir_resources_dist, allocator)) |p| return p else |_| {}
+        if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, appdir_resources_dist, allocator)) |p| return dupe(allocator, p) else |_| {}
 
         const appdir_resources_frontend = std.fmt.allocPrint(allocator, "{s}/resources/frontend", .{usr_dir}) catch return null;
         defer allocator.free(appdir_resources_frontend);
-        if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, appdir_resources_frontend, allocator)) |p| return p else |_| {}
+        if (std.Io.Dir.cwd().realPathFileAlloc(runtime.io, appdir_resources_frontend, allocator)) |p| return dupe(allocator, p) else |_| {}
     }
 
     return null;

--- a/src/package_desktop.zig
+++ b/src/package_desktop.zig
@@ -448,6 +448,20 @@ pub fn packageLinuxDebAt(
 /// Windows: stage(bin/<name>.exe) + 선택적 signtool 서명 + zip.
 /// sign_tool_args 비어있으면 서명 생략(zero-native 와 동일 — 호스트 위임).
 /// 반환 아카이브 경로(caller free).
+/// Windows 패키지 — flat layout (모든 DLL + .pak/.dat 이 .exe 옆에 있어야 CEF
+/// 로더가 찾는다. macOS .app 같이 nested 구조 못 씀). exe_path 의 부모 디렉토리
+/// (보통 zig-out/bin) 가 이미 build.zig 의 copy step 으로 CEF/Node runtime
+/// 전부 stage 돼 있어서, 그 디렉토리를 통째로 복사.
+///
+/// 산출: <name>-<ver>-windows-<arch>/
+///   ├── <name>.exe (renamed from suji.exe)
+///   ├── libcef.dll, libnode.dll, etc. (~30 DLL)
+///   ├── locales/ (CEF i18n)
+///   ├── resources/frontend/ (dist 빌드)
+///   └── *.pak, *.dat, *.bin (CEF data)
+///
+/// Linux 와 달리 Windows 는 bash/cp/zip 의존 제거 — PowerShell Compress-Archive
+/// 가 OS native. signtool 도 정식 Windows 도구로 PATH 에 있어야.
 pub fn packageWindows(
     allocator: std.mem.Allocator,
     name: []const u8,
@@ -461,11 +475,42 @@ pub fn packageWindows(
     defer allocator.free(stage);
     const exe_name = try std.fmt.allocPrint(allocator, "{s}.exe", .{name});
     defer allocator.free(exe_name);
-    try stageCommon(allocator, stage, exe_name, exe_path, frontend_dist);
 
-    // 선택적 Authenticode 서명 (signtool, PFX cert + password). CI secret 주입.
+    // 1) 기존 stage 정리.
+    Dir.cwd().deleteTree(runtime.io, stage) catch {};
+    try Dir.cwd().createDirPath(runtime.io, stage);
+
+    // 2) exe_path 의 부모 디렉토리 = build artifacts dir (zig-out/bin). 그 안의
+    // 모든 파일을 stage 로 복사 — CEF DLL/Resources, Node DLL 전부 포함.
+    const exe_dir = std.fs.path.dirname(exe_path) orelse {
+        std.debug.print("[suji] cannot resolve exe directory\n", .{});
+        return error.InvalidExePath;
+    };
+    try copyDirContents(allocator, exe_dir, stage);
+
+    // 3) suji.exe → <name>.exe rename (config.app.name 사용).
+    if (!std.mem.eql(u8, exe_name, "suji.exe")) {
+        const suji_in_stage = try std.fmt.allocPrint(allocator, "{s}/suji.exe", .{stage});
+        defer allocator.free(suji_in_stage);
+        const renamed = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ stage, exe_name });
+        defer allocator.free(renamed);
+        Dir.cwd().rename(suji_in_stage, Dir.cwd(), renamed, runtime.io) catch |err| {
+            std.debug.print("[suji] rename suji.exe → {s} failed: {s}\n", .{ exe_name, @errorName(err) });
+        };
+    }
+
+    // 4) frontend dist → resources/frontend/.
+    const res_dir = try std.fmt.allocPrint(allocator, "{s}/resources/frontend", .{stage});
+    defer allocator.free(res_dir);
+    try Dir.cwd().createDirPath(runtime.io, res_dir);
+    copyDirContents(allocator, frontend_dist, res_dir) catch |err| {
+        // best-effort — frontend build 실패해도 진행 (사용자가 별도 fix).
+        std.debug.print("[suji] frontend dist copy failed: {s}\n", .{@errorName(err)});
+    };
+
+    // 5) 선택적 Authenticode 서명 (signtool.exe — Windows SDK).
     if (sign_cert) |cert| {
-        const exe_in_stage = try std.fmt.allocPrint(allocator, "{s}/bin/{s}", .{ stage, exe_name });
+        const exe_in_stage = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ stage, exe_name });
         defer allocator.free(exe_in_stage);
         std.debug.print("[suji] signing windows exe (signtool)...\n", .{});
         try runCmd(&.{
@@ -479,10 +524,56 @@ pub fn packageWindows(
         });
     }
 
+    // 6) PowerShell Compress-Archive 로 .zip 생성. zip(.exe) 의존 제거.
     const archive = try std.fmt.allocPrint(allocator, "{s}.zip", .{stage});
     errdefer allocator.free(archive);
     std.debug.print("[suji] packaging windows: {s}\n", .{archive});
-    try runCmd(&.{ "zip", "-r", archive, stage });
+    Dir.cwd().deleteFile(runtime.io, archive) catch {};
+    if (builtin.os.tag == .windows) {
+        const ps_cmd = try std.fmt.allocPrint(
+            allocator,
+            "Compress-Archive -Path '{s}' -DestinationPath '{s}' -Force",
+            .{ stage, archive },
+        );
+        defer allocator.free(ps_cmd);
+        try runCmd(&.{ "powershell", "-NoProfile", "-Command", ps_cmd });
+    } else {
+        // 비-Windows host 에서 cross-package (예: WSL/Linux CI 가 Windows 산출물 만듦).
+        runCmd(&.{ "zip", "-r", archive, stage }) catch {
+            std.debug.print("[suji] zip command not found; install zip or run on Windows host\n", .{});
+            return error.ZipFailed;
+        };
+    }
     std.debug.print("[suji] packaged: {s}\n", .{archive});
     return archive;
+}
+
+/// 디렉토리 contents 를 다른 디렉토리로 재귀 복사 (cross-platform, no shell).
+/// dst 는 호출 전 생성돼 있어야.
+fn copyDirContents(allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {
+    const io = runtime.io;
+    var src_dir = Dir.cwd().openDir(io, src, .{ .iterate = true }) catch |err| {
+        std.debug.print("[suji] open dir '{s}' failed: {s}\n", .{ src, @errorName(err) });
+        return err;
+    };
+    defer src_dir.close(io);
+    var it = src_dir.iterate();
+    while (try it.next(io)) |entry| {
+        const src_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ src, entry.name });
+        defer allocator.free(src_path);
+        const dst_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dst, entry.name });
+        defer allocator.free(dst_path);
+        switch (entry.kind) {
+            .directory => {
+                try Dir.cwd().createDirPath(io, dst_path);
+                try copyDirContents(allocator, src_path, dst_path);
+            },
+            .file, .sym_link => {
+                Dir.cwd().copyFile(src_path, Dir.cwd(), dst_path, io, .{}) catch |err| {
+                    std.debug.print("[suji] copy '{s}' → '{s}' failed: {s}\n", .{ src_path, dst_path, @errorName(err) });
+                };
+            },
+            else => {},
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`suji build` 가 Windows 에서 처음으로 완전 동작. macOS `.app` / Linux `.tar.gz` 동등의 self-contained `.zip` 산출.

## Before / After

**Before**: `suji build` Windows 에서:
- `suji.exe` 만 zip 에 포함 → 사용자 머신에서 `libcef.dll` missing
- `cp`/`rm`/`chmod`/`zip` POSIX shell 의존 → Windows 호스트에서 실패
- 더블클릭하면 `printUsage()` → 종료 (bundle 감지 없음)

**After**: 
- 220MB self-contained zip — CEF + Node runtime DLL + frontend/dist 모두 포함
- Zig std.Io.Dir + PowerShell Compress-Archive — shell 의존 0
- bundle 감지(`resources/frontend/index.html`) → 더블클릭 자동 `runProd()`

## Fix 내역

1. **`packageWindows` 가 CEF/Node DLL 누락** → exe_path 부모 디렉토리(zig-out/bin) 전체 재귀 복사
2. **POSIX shell 의존** → Zig native API + PowerShell
3. **packaged exe 더블클릭 동작** → `resources/frontend/index.html` 감지 (macOS `.app/Contents/MacOS/` 동등)
4. **`--do-not-de-elevate` internal flag 가 명령으로 오해석** → args 사전 필터링
5. **`findDistPath` sentinel size mismatch panic** → realPathFileAlloc 반환을 length-exact dupe (모든 OS path 동일 fix)
6. **`findDistPath` Windows 분기** → `<exe_dir>/resources/frontend(/dist)` 추가

## Test plan
- [x] `zig build` clean
- [x] `cd examples/multi-backend && suji build` → `Multi Backend Example-0.1.0-windows-x64.zip` 생성
- [x] zip 압축 해제 후 `Multi Backend Example.exe` 더블클릭 → CEF window opens, production mode 진입 (`suji://app/index.html` 로드)
- [ ] 사용자 수동: 다른 Windows 머신에서 zip 복사 후 동작 (DLL 의존성 self-contained 확인)

## ⚠️ 알려진 한계 (별도 후속 PR)

백엔드 dylib (zig/rust/go) 와 플러그인 dylib 는 아직 stage 에 포함 안 됨 → runtime 에서 `suji build` 가 또 백엔드 빌드 시도 (zig/cargo/go toolchain 필요). 완전한 self-contained 배포를 위해:
- backend dylib stage 평탄 배치 (예: `<pkg>/backends/zig.dll`)
- runtime path resolution 에 packaged 경로 추가

이번 PR 은 framework runtime (CEF + Node) 자체의 self-contained 만 다룸. 백엔드/플러그인 dylib 동봉은 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)