### PR TITLE
Fix PR #40 findings: sentinel marker + dylib pre-validation

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -92,8 +92,7 @@ pub fn main(init: std.process.Init) !void {
     const args = filtered_buf[0..filtered_len];
 
     // 번들에서 실행 시 자동으로 run (macOS .app / Linux AppImage / Windows packaged exe).
-    // Windows packaging 은 `<name>.exe` 옆에 `resources/frontend/index.html` 을 둔다 —
-    // 그게 있으면 packaged app 으로 판단해 runProd.
+    // Windows packaging 은 `<name>.exe` 옆에 `.suji-packaged` sentinel 을 둔다.
     if (args.len < 2) {
         var exe_buf: [1024]u8 = undefined;
         if (std.process.executablePath(init.io, &exe_buf)) |n| {
@@ -101,11 +100,10 @@ pub fn main(init: std.process.Init) !void {
             const is_bundle = switch (comptime @import("builtin").os.tag) {
                 .macos => std.mem.indexOf(u8, ep, ".app/Contents/MacOS/") != null,
                 .windows => blk: {
-                    // 같은 디렉토리에 resources/frontend/index.html 존재 = packaged.
                     const exe_dir = std.fs.path.dirname(ep) orelse break :blk false;
                     const probe = std.fmt.allocPrint(
                         init.arena.allocator(),
-                        "{s}/resources/frontend/index.html",
+                        "{s}/.suji-packaged",
                         .{exe_dir},
                     ) catch break :blk false;
                     std.Io.Dir.cwd().access(runtime.io, probe, .{}) catch break :blk false;
@@ -458,6 +456,13 @@ fn runBuild(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
                             continue;
                         }
                         const dylib = getDylibPath(allocator, be.lang, be.entry, true) catch continue;
+                        // dylib 실존 검증 — 빌드가 사전에 실패했으면 packaging
+                        // 단계에서 silent miss 가 아닌 명시적 경고.
+                        std.Io.Dir.cwd().access(runtime.io, dylib, .{}) catch {
+                            std.debug.print("[suji] WARN: backend '{s}' dylib missing at {s} — backend will be absent from package\n", .{ be.name, dylib });
+                            allocator.free(dylib);
+                            continue;
+                        };
                         try backends_list.append(allocator, .{
                             .name = be.name,
                             .lang = be.lang,
@@ -503,6 +508,11 @@ fn runBuild(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
                     const pentry = std.fmt.allocPrint(allocator, "{s}/{s}", .{ pdir, plang }) catch continue;
                     defer allocator.free(pentry);
                     const dylib = getDylibPath(allocator, plang, pentry, true) catch continue;
+                    std.Io.Dir.cwd().access(runtime.io, dylib, .{}) catch {
+                        std.debug.print("[suji] WARN: plugin '{s}' dylib missing at {s} — plugin will be absent from package\n", .{ pname, dylib });
+                        allocator.free(dylib);
+                        continue;
+                    };
                     plugins_list.append(allocator, .{
                         .name = pname,
                         .lang = plang,
@@ -540,14 +550,17 @@ fn runBuild(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
 /// packaged binary 의 exe 디렉토리(<exe_dir>) 반환. caller free.
 /// packaging 이 backend/plugin dylib 들을 `<exe_dir>/backends/<name>/`
 /// `<exe_dir>/plugins/<name>/` 에 평탄 배치하므로 그 경로의 base 가 된다.
+///
+/// 마커: `<exe_dir>/.suji-packaged` 빈 파일. packageWindows 가 stage 에 생성.
+/// 이전엔 `resources/frontend/index.html` 만 probe 했는데, 개발자가 zig-out/bin
+/// 에 stale 파일 남기면 `suji dev` 가 packaged 로 false-positive → 백엔드 로드
+/// 전체 실패. 전용 sentinel 파일은 packaging 만 생성하므로 false-positive 봉쇄.
 fn packagedExeDir(allocator: std.mem.Allocator) ?[]const u8 {
     var exe_buf: [1024]u8 = undefined;
     const ep_len = std.process.executablePath(runtime.io, &exe_buf) catch return null;
     const ep = exe_buf[0..ep_len];
     const dir = std.fs.path.dirname(ep) orelse return null;
-    // packaged 마커: `<exe_dir>/resources/frontend/index.html` 존재 (macOS .app
-    // 의 ".app/Contents/MacOS/" 패턴과 동일 목적).
-    const probe = std.fmt.allocPrint(allocator, "{s}/resources/frontend/index.html", .{dir}) catch return null;
+    const probe = std.fmt.allocPrint(allocator, "{s}/.suji-packaged", .{dir}) catch return null;
     defer allocator.free(probe);
     std.Io.Dir.cwd().access(runtime.io, probe, .{}) catch return null;
     return allocator.dupe(u8, dir) catch null;

--- a/src/package_desktop.zig
+++ b/src/package_desktop.zig
@@ -520,6 +520,18 @@ pub fn packageWindows(
         std.debug.print("[suji] frontend dist copy failed: {s}\n", .{@errorName(err)});
     };
 
+    // 4b) packaged sentinel — runtime 의 packagedExeDir 가 이걸 probe 해서
+    // packaged 환경 판단. stale resources/frontend 만 가지고 false-positive
+    // 되는 걸 봉쇄. 빈 파일이면 충분.
+    const sentinel_path = try std.fmt.allocPrint(allocator, "{s}/.suji-packaged", .{stage});
+    defer allocator.free(sentinel_path);
+    if (Dir.cwd().createFile(runtime.io, sentinel_path, .{})) |sentinel_file_const| {
+        var sentinel_file = sentinel_file_const;
+        sentinel_file.close(runtime.io);
+    } else |err| {
+        std.debug.print("[suji] sentinel write failed: {s}\n", .{@errorName(err)});
+    }
+
     // 5a) backend dylib / node entry → <stage>/backends/<name>/ 평탄 배치.
     //     runtime path resolution 이 packaged 환경에서 이 경로를 찾음.
     if (backends.len > 0) {


### PR DESCRIPTION
## Summary
`/code-review max HEAD~1..HEAD` 결과 verified 3 critical findings 픽스.

### Fix
1. **packaged false-positive 봉쇄** — 이전 sentinel(`resources/frontend/index.html`) 이 개발자 zig-out/bin 에 stale 로 남으면 `suji dev` 가 packaged 로 오인. 전용 `<exe_dir>/.suji-packaged` 빈 파일 sentinel 로 변경 (packaging 만 생성).
2. **dylib silent miss** — `runBuild` 가 `getDylibPath` 반환 path 의 실존 검증 없이 backends_list/plugins_list 에 append. 사전 빌드 실패 시 path valid 하지만 file 부재 → silent skip. 이제 `access` 검증 + `WARN: dylib missing` 명시.
3. **packageWindows sentinel 생성** — `.suji-packaged` 빈 파일 stage root 에 작성.

### Refuted candidates
- 단일 백엔드 Node 디렉토리명 mismatch: packaging/runtime 모두 `be.lang` 사용 일관적
- `@constCast` + `allocator.free` 잠재 risk: Zig 0.16 metadata-based, OK
- copyDirContents symlink 외부 따라감: file: deps 해소 의도된 동작, 별도 PR 에서 문서화 (warn)

## Test plan
- [x] zig build clean
- [x] `cd examples/multi-backend && suji build` → `.suji-packaged` 파일 stage 에 생성됨
- [x] Packaged `.exe` 더블클릭 → state/Zig/Rust/Go/Node 백엔드 모두 packaged 경로에서 로드
- [ ] 사용자 수동: stale `resources/frontend/index.html` 만 zig-out/bin 에 남긴 후 `suji dev` → 정상 dev 모드 진입 (이전엔 packaged 오인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)