### PR TITLE
macOS/Linux backend dylib bundling (Windows parity)

### DIFF
--- a/src/bundle_macos.zig
+++ b/src/bundle_macos.zig
@@ -71,6 +71,8 @@ pub fn createBundle(
     exe_path: []const u8,
     frontend_dist: []const u8,
     opts: BundleOptions,
+    backends: []const @import("package_desktop.zig").BackendArtifact,
+    plugins: []const @import("package_desktop.zig").BackendArtifact,
 ) !void {
     const app_name = try std.fmt.allocPrint(allocator, "{s}.app", .{name});
     defer allocator.free(app_name);
@@ -111,6 +113,14 @@ pub fn createBundle(
 
     // 6. 프론트엔드 dist 복사
     try copyDir(allocator, frontend_dist, try std.fmt.allocPrint(allocator, "{s}/Contents/Resources/frontend", .{app_name}));
+
+    // 6.5. backend/plugin dylib + sentinel — packagedExeDir 의 macOS 분기가
+    // Contents/Resources/.suji-packaged 를 probe + 같은 디렉토리에 backends/
+    // plugins/ 평탄 배치 기대.
+    const resources_path = try std.fmt.allocPrint(allocator, "{s}/Contents/Resources", .{app_name});
+    defer allocator.free(resources_path);
+    @import("package_desktop.zig").writePackagedSentinel(allocator, resources_path);
+    try @import("package_desktop.zig").stageBackendArtifacts(allocator, resources_path, backends, plugins);
 
     // 7. 메인 바이너리 install_name_tool
     try fixMainBinaryRpath(allocator, app_name, name);
@@ -411,11 +421,42 @@ fn codesignBundle(allocator: std.mem.Allocator, app_name: []const u8, name: []co
         try codesignWithEntitlements(allocator, helper, h.plist, opts, entitlements_dir);
     }
 
+    // 2.5. backend/plugin dylib — Resources/backends/<name>/<basename> 와
+    // Resources/plugins/<name>/<basename> 각각 sign. inherit entitlements
+    // 라(receiver process), 명시적 entitlements 없이.  --deep 대신 명시 sign
+    // (Apple 권장; --deep 은 deprecated). 디렉토리 부재면 skip.
+    try codesignDylibsIn(allocator, app_name, "Contents/Resources/backends", opts);
+    try codesignDylibsIn(allocator, app_name, "Contents/Resources/plugins", opts);
+
     // 3. 메인 바이너리 + 4. 전체 앱 번들 — 둘 다 main.plist.
     const exe = try std.fmt.allocPrint(allocator, "{s}/Contents/MacOS/{s}", .{ app_name, name });
     defer allocator.free(exe);
     try codesignWithEntitlements(allocator, exe, "main.plist", opts, entitlements_dir);
     try codesignWithEntitlements(allocator, app_name, "main.plist", opts, entitlements_dir);
+}
+
+/// Iterate over `<app_name>/<sub_path>/*/*` and sign each regular file as a
+/// dylib (helper sign, no entitlements). 디렉토리 부재면 silent skip.
+fn codesignDylibsIn(allocator: std.mem.Allocator, app_name: []const u8, sub_path: []const u8, opts: BundleOptions) !void {
+    const root = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ app_name, sub_path });
+    defer allocator.free(root);
+    var root_dir = Dir.cwd().openDir(runtime.io, root, .{ .iterate = true }) catch return;
+    defer root_dir.close(runtime.io);
+    var root_it = root_dir.iterate();
+    while (try root_it.next(runtime.io)) |entry| {
+        if (entry.kind != .directory) continue;
+        const child = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, entry.name });
+        defer allocator.free(child);
+        var child_dir = Dir.cwd().openDir(runtime.io, child, .{ .iterate = true }) catch continue;
+        defer child_dir.close(runtime.io);
+        var child_it = child_dir.iterate();
+        while (try child_it.next(runtime.io)) |f| {
+            if (f.kind != .file) continue;
+            const path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ child, f.name });
+            defer allocator.free(path);
+            try codesignNoEntitlements(allocator, path, opts);
+        }
+    }
 }
 
 /// 서명 ID — adhoc="-", identity=opts.identity (none 은 호출 전 차단됨).

--- a/src/main.zig
+++ b/src/main.zig
@@ -368,6 +368,127 @@ fn runBuild(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         std.debug.print("[suji] frontend build failed: {}\n", .{err});
     };
 
+    // Backend / plugin dylib + Node entry path 수집 (OS-agnostic).
+    // 각 OS packaging 함수가 BackendArtifact 슬라이스를 받아 stage 에 평탄 복사.
+    var backends_list = std.ArrayList(package_desktop.BackendArtifact).empty;
+    defer backends_list.deinit(allocator);
+    defer for (backends_list.items) |a| {
+        if (!a.is_node) allocator.free(@constCast(a.source_path));
+    };
+    var plugins_list = std.ArrayList(package_desktop.BackendArtifact).empty;
+    defer plugins_list.deinit(allocator);
+    // is_node filter — 현재 plugins 는 항상 non-Node 라 모두 free 대상이지만,
+    // 미래 Node plugin 지원 추가 시 entry path 가 heap 이 아닐 수 있어 가드.
+    defer for (plugins_list.items) |a| {
+        if (!a.is_node) allocator.free(@constCast(a.source_path));
+    };
+    var missing_count: usize = 0;
+
+    if (config.isMultiBackend()) {
+        if (config.backends) |bes| {
+            for (bes) |be| {
+                if (std.mem.eql(u8, be.lang, "node")) {
+                    try backends_list.append(allocator, .{
+                        .name = be.name,
+                        .lang = be.lang,
+                        .source_path = be.entry,
+                        .is_node = true,
+                    });
+                    continue;
+                }
+                const dylib = getDylibPath(allocator, be.lang, be.entry, true) catch {
+                    std.debug.print("[suji] WARN: backend '{s}' lang={s} unsupported — backend will be absent from package\n", .{ be.name, be.lang });
+                    missing_count += 1;
+                    continue;
+                };
+                std.Io.Dir.cwd().access(runtime.io, dylib, .{}) catch {
+                    std.debug.print("[suji] WARN: backend '{s}' dylib missing at {s} — backend will be absent from package\n", .{ be.name, dylib });
+                    allocator.free(dylib);
+                    missing_count += 1;
+                    continue;
+                };
+                try backends_list.append(allocator, .{
+                    .name = be.name,
+                    .lang = be.lang,
+                    .source_path = dylib,
+                    .is_node = false,
+                });
+            }
+        }
+    } else if (config.backend) |be| {
+        if (std.mem.eql(u8, be.lang, "node")) {
+            try backends_list.append(allocator, .{
+                .name = be.lang,
+                .lang = be.lang,
+                .source_path = be.entry,
+                .is_node = true,
+            });
+        } else if (getDylibPath(allocator, be.lang, be.entry, true)) |dylib| {
+            std.Io.Dir.cwd().access(runtime.io, dylib, .{}) catch {
+                std.debug.print("[suji] WARN: backend '{s}' dylib missing at {s} — backend will be absent from package\n", .{ be.lang, dylib });
+                allocator.free(dylib);
+                missing_count += 1;
+            };
+            try backends_list.append(allocator, .{
+                .name = be.lang,
+                .lang = be.lang,
+                .source_path = dylib,
+                .is_node = false,
+            });
+        } else |_| {
+            std.debug.print("[suji] WARN: backend lang={s} unsupported — backend will be absent from package\n", .{be.lang});
+            missing_count += 1;
+        }
+    }
+
+    if (config.plugins) |plugin_names| {
+        for (plugin_names) |pname| {
+            const pdir = getPluginDir(allocator, pname) orelse {
+                std.debug.print("[suji] WARN: plugin '{s}' not found — plugin will be absent from package\n", .{pname});
+                missing_count += 1;
+                continue;
+            };
+            defer allocator.free(pdir);
+            const plang = readPluginLang(allocator, pdir) orelse {
+                std.debug.print("[suji] WARN: plugin '{s}' suji-plugin.json invalid — plugin will be absent from package\n", .{pname});
+                missing_count += 1;
+                continue;
+            };
+            defer allocator.free(plang);
+            const pentry = std.fmt.allocPrint(allocator, "{s}/{s}", .{ pdir, plang }) catch continue;
+            defer allocator.free(pentry);
+            const dylib = getDylibPath(allocator, plang, pentry, true) catch {
+                std.debug.print("[suji] WARN: plugin '{s}' lang={s} unsupported — plugin will be absent from package\n", .{ pname, plang });
+                missing_count += 1;
+                continue;
+            };
+            std.Io.Dir.cwd().access(runtime.io, dylib, .{}) catch {
+                std.debug.print("[suji] WARN: plugin '{s}' dylib missing at {s} — plugin will be absent from package\n", .{ pname, dylib });
+                allocator.free(dylib);
+                missing_count += 1;
+                continue;
+            };
+            plugins_list.append(allocator, .{
+                .name = pname,
+                .lang = plang,
+                .source_path = dylib,
+                .is_node = false,
+            }) catch {
+                allocator.free(dylib);
+                missing_count += 1;
+                continue;
+            };
+        }
+    }
+
+    if (missing_count > 0) {
+        std.debug.print("[suji] WARN: packaging incomplete — {d} backend(s)/plugin(s) missing from package\n", .{missing_count});
+        if (want_strict) {
+            std.debug.print("[suji] strict mode: aborting (set SUJI_STRICT_PACKAGING=0 or omit --strict to package anyway)\n", .{});
+            return error.PackagingIncomplete;
+        }
+    }
+
     // suji 바이너리 경로
     var exe_buf: [1024]u8 = undefined;
     const exe_len = std.process.executablePath(runtime.io, &exe_buf) catch {
@@ -411,6 +532,8 @@ fn runBuild(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
                     .sandbox = want_sandbox,
                     .deep_link_schemes = deep_link_slice,
                 },
+                backends_list.items,
+                plugins_list.items,
             );
             if (want_notarize) {
                 bundle_macos.notarizeBundle(allocator, config.app.name, .{
@@ -432,142 +555,18 @@ fn runBuild(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
             }
         },
         .linux => {
-            const archive = try package_desktop.packageLinux(allocator, config.app.name, config.app.version, exe_path, config.frontend.dist_dir);
+            const archive = try package_desktop.packageLinux(allocator, config.app.name, config.app.version, exe_path, config.frontend.dist_dir, backends_list.items, plugins_list.items);
             allocator.free(archive);
             if (want_deb) {
-                const deb = try package_desktop.packageLinuxDeb(allocator, config.app.name, config.app.version, exe_path, config.frontend.dist_dir);
+                const deb = try package_desktop.packageLinuxDeb(allocator, config.app.name, config.app.version, exe_path, config.frontend.dist_dir, backends_list.items, plugins_list.items);
                 allocator.free(deb);
             }
             if (want_appimage) {
-                const appimage = try package_desktop.packageLinuxAppImage(allocator, config.app.name, config.app.version, exe_path, config.frontend.dist_dir);
+                const appimage = try package_desktop.packageLinuxAppImage(allocator, config.app.name, config.app.version, exe_path, config.frontend.dist_dir, backends_list.items, plugins_list.items);
                 allocator.free(appimage);
             }
         },
         .windows => {
-            // Backend / plugin dylib + Node entry path 수집.
-            var backends_list = std.ArrayList(package_desktop.BackendArtifact).empty;
-            defer backends_list.deinit(allocator);
-            // Missing dylib 카운터 — strict 모드에서 1+ 면 process 비정상 종료.
-            var missing_count: usize = 0;
-
-            if (config.isMultiBackend()) {
-                if (config.backends) |bes| {
-                    for (bes) |be| {
-                        if (std.mem.eql(u8, be.lang, "node")) {
-                            try backends_list.append(allocator, .{
-                                .name = be.name,
-                                .lang = be.lang,
-                                .source_path = be.entry,
-                                .is_node = true,
-                            });
-                            continue;
-                        }
-                        const dylib = getDylibPath(allocator, be.lang, be.entry, true) catch {
-                            std.debug.print("[suji] WARN: backend '{s}' lang={s} unsupported — backend will be absent from package\n", .{ be.name, be.lang });
-                            missing_count += 1;
-                            continue;
-                        };
-                        // dylib 실존 검증 — 빌드가 사전에 실패했으면 packaging
-                        // 단계에서 silent miss 가 아닌 명시적 경고.
-                        std.Io.Dir.cwd().access(runtime.io, dylib, .{}) catch {
-                            std.debug.print("[suji] WARN: backend '{s}' dylib missing at {s} — backend will be absent from package\n", .{ be.name, dylib });
-                            allocator.free(dylib);
-                            missing_count += 1;
-                            continue;
-                        };
-                        try backends_list.append(allocator, .{
-                            .name = be.name,
-                            .lang = be.lang,
-                            .source_path = dylib,
-                            .is_node = false,
-                        });
-                    }
-                }
-            } else if (config.backend) |be| {
-                if (std.mem.eql(u8, be.lang, "node")) {
-                    try backends_list.append(allocator, .{
-                        .name = be.lang,
-                        .lang = be.lang,
-                        .source_path = be.entry,
-                        .is_node = true,
-                    });
-                } else {
-                    if (getDylibPath(allocator, be.lang, be.entry, true)) |dylib| {
-                        std.Io.Dir.cwd().access(runtime.io, dylib, .{}) catch {
-                            std.debug.print("[suji] WARN: backend '{s}' dylib missing at {s} — backend will be absent from package\n", .{ be.lang, dylib });
-                            allocator.free(dylib);
-                            missing_count += 1;
-                        };
-                        try backends_list.append(allocator, .{
-                            .name = be.lang,
-                            .lang = be.lang,
-                            .source_path = dylib,
-                            .is_node = false,
-                        });
-                    } else |_| {
-                        std.debug.print("[suji] WARN: backend lang={s} unsupported — backend will be absent from package\n", .{be.lang});
-                        missing_count += 1;
-                    }
-                }
-            }
-            defer for (backends_list.items) |a| {
-                if (!a.is_node) allocator.free(@constCast(a.source_path));
-            };
-
-            // Plugin dylib 도 같이 — config.plugins 는 이름 배열, 실 dylib 는
-            // getPluginDir + readPluginLang + getDylibPath 로 해결.
-            var plugins_list = std.ArrayList(package_desktop.BackendArtifact).empty;
-            defer plugins_list.deinit(allocator);
-            defer for (plugins_list.items) |a| allocator.free(@constCast(a.source_path));
-            if (config.plugins) |plugin_names| {
-                for (plugin_names) |pname| {
-                    const pdir = getPluginDir(allocator, pname) orelse {
-                        std.debug.print("[suji] WARN: plugin '{s}' not found — plugin will be absent from package\n", .{pname});
-                        missing_count += 1;
-                        continue;
-                    };
-                    defer allocator.free(pdir);
-                    const plang = readPluginLang(allocator, pdir) orelse {
-                        std.debug.print("[suji] WARN: plugin '{s}' suji-plugin.json invalid — plugin will be absent from package\n", .{pname});
-                        missing_count += 1;
-                        continue;
-                    };
-                    defer allocator.free(plang);
-                    const pentry = std.fmt.allocPrint(allocator, "{s}/{s}", .{ pdir, plang }) catch continue;
-                    defer allocator.free(pentry);
-                    const dylib = getDylibPath(allocator, plang, pentry, true) catch {
-                        std.debug.print("[suji] WARN: plugin '{s}' lang={s} unsupported — plugin will be absent from package\n", .{ pname, plang });
-                        missing_count += 1;
-                        continue;
-                    };
-                    std.Io.Dir.cwd().access(runtime.io, dylib, .{}) catch {
-                        std.debug.print("[suji] WARN: plugin '{s}' dylib missing at {s} — plugin will be absent from package\n", .{ pname, dylib });
-                        allocator.free(dylib);
-                        missing_count += 1;
-                        continue;
-                    };
-                    plugins_list.append(allocator, .{
-                        .name = pname,
-                        .lang = plang,
-                        .source_path = dylib,
-                        .is_node = false,
-                    }) catch {
-                        allocator.free(dylib);
-                        missing_count += 1;
-                        continue;
-                    };
-                }
-            }
-
-            // Summary: 1+ 누락이면 stderr 명시. strict 모드면 비정상 종료.
-            if (missing_count > 0) {
-                std.debug.print("[suji] WARN: packaging incomplete — {d} backend(s)/plugin(s) missing from package\n", .{missing_count});
-                if (want_strict) {
-                    std.debug.print("[suji] strict mode: aborting (set SUJI_STRICT_PACKAGING=0 or omit --strict to package anyway)\n", .{});
-                    return error.PackagingIncomplete;
-                }
-            }
-
             const archive = try package_desktop.packageWindows(
                 allocator,
                 config.app.name,
@@ -590,19 +589,39 @@ fn runBuild(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
 // 플러그인 빌드/로드
 // ============================================
 
-/// packaged binary 의 exe 디렉토리(<exe_dir>) 반환. caller free.
-/// packaging 이 backend/plugin dylib 들을 `<exe_dir>/backends/<name>/`
-/// `<exe_dir>/plugins/<name>/` 에 평탄 배치하므로 그 경로의 base 가 된다.
+/// packaged binary 의 backend/plugin dylib root 반환. caller free.
+/// OS 별 layout:
+/// - Windows/Linux: `<exe_dir>/.suji-packaged` 가 존재 → `<exe_dir>` 반환
+/// - macOS: `<exe_dir>/../Resources/.suji-packaged` 가 존재 →
+///   `<exe_dir>/../Resources` 반환 (.app 번들 구조 — backends/plugins 가
+///   `Contents/Resources/` 아래에 위치)
 ///
-/// 마커: `<exe_dir>/.suji-packaged` 빈 파일. packageWindows 가 stage 에 생성.
-/// 이전엔 `resources/frontend/index.html` 만 probe 했는데, 개발자가 zig-out/bin
-/// 에 stale 파일 남기면 `suji dev` 가 packaged 로 false-positive → 백엔드 로드
-/// 전체 실패. 전용 sentinel 파일은 packaging 만 생성하므로 false-positive 봉쇄.
+/// 마커: `.suji-packaged` 빈 파일. 각 packaging 함수가 stage 에 생성. 이전엔
+/// `resources/frontend/index.html` 만 probe 했는데, 개발자가 zig-out/bin 에
+/// stale 파일 남기면 dev 가 packaged 로 false-positive → 백엔드 로드 실패.
+/// 전용 sentinel 은 packaging 만 생성하므로 false-positive 봉쇄.
 fn packagedExeDir(allocator: std.mem.Allocator) ?[]const u8 {
     var exe_buf: [1024]u8 = undefined;
     const ep_len = std.process.executablePath(runtime.io, &exe_buf) catch return null;
     const ep = exe_buf[0..ep_len];
     const dir = std.fs.path.dirname(ep) orelse return null;
+
+    if (comptime builtin.os.tag == .macos) {
+        // <exe_dir>=<app>.app/Contents/MacOS → Resources 가 sibling.
+        const contents_dir = std.fs.path.dirname(dir) orelse return null;
+        const resources_dir = std.fmt.allocPrint(allocator, "{s}/Resources", .{contents_dir}) catch return null;
+        const probe = std.fmt.allocPrint(allocator, "{s}/.suji-packaged", .{resources_dir}) catch {
+            allocator.free(resources_dir);
+            return null;
+        };
+        defer allocator.free(probe);
+        std.Io.Dir.cwd().access(runtime.io, probe, .{}) catch {
+            allocator.free(resources_dir);
+            return null;
+        };
+        return resources_dir;
+    }
+
     const probe = std.fmt.allocPrint(allocator, "{s}/.suji-packaged", .{dir}) catch return null;
     defer allocator.free(probe);
     std.Io.Dir.cwd().access(runtime.io, probe, .{}) catch return null;

--- a/src/package_desktop.zig
+++ b/src/package_desktop.zig
@@ -246,6 +246,8 @@ pub fn packageLinux(
     version: []const u8,
     exe_path: []const u8,
     frontend_dist: []const u8,
+    backends: []const BackendArtifact,
+    plugins: []const BackendArtifact,
 ) ![]const u8 {
     const stage = try std.fmt.allocPrint(allocator, "{s}-{s}-linux-{s}", .{ name, version, archName() });
     defer allocator.free(stage);
@@ -258,6 +260,12 @@ pub fn packageLinux(
     const desktop_path = try std.fmt.allocPrint(allocator, "{s}/{s}.desktop", .{ stage, name });
     defer allocator.free(desktop_path);
     try writeFile(desktop_path, desktop);
+
+    // packaged sentinel + backend/plugin dylib (Windows 동등 layout) —
+    // runtime 의 packagedExeDir 가 동일 probe 사용. backends/plugins root
+    // 가 stage 자체.
+    writePackagedSentinel(allocator, stage);
+    try stageBackendArtifacts(allocator, stage, backends, plugins);
 
     const archive = try std.fmt.allocPrint(allocator, "{s}.tar.gz", .{stage});
     errdefer allocator.free(archive);
@@ -322,8 +330,10 @@ pub fn packageLinuxAppImage(
     version: []const u8,
     exe_path: []const u8,
     frontend_dist: []const u8,
+    backends: []const BackendArtifact,
+    plugins: []const BackendArtifact,
 ) ![]const u8 {
-    return packageLinuxAppImageAt(allocator, ".", name, version, exe_path, frontend_dist);
+    return packageLinuxAppImageAt(allocator, ".", name, version, exe_path, frontend_dist, backends, plugins);
 }
 
 pub fn packageLinuxAppImageAt(
@@ -333,6 +343,8 @@ pub fn packageLinuxAppImageAt(
     version: []const u8,
     exe_path: []const u8,
     frontend_dist: []const u8,
+    backends: []const BackendArtifact,
+    plugins: []const BackendArtifact,
 ) ![]const u8 {
     const package_name = try sanitizeDebPackageName(allocator, name);
     defer allocator.free(package_name);
@@ -342,6 +354,14 @@ pub fn packageLinuxAppImageAt(
     const app_dir = try std.fmt.allocPrint(allocator, "{s}/{s}-{s}-linux-{s}.AppDir", .{ output_dir, package_name, version, arch });
     defer allocator.free(app_dir);
     try stageLinuxAppDirAt(allocator, app_dir, name, exe_path, frontend_dist);
+    // AppImage runtime: AppRun → usr/bin/<exe>. <exe_dir> = <AppDir>/usr/bin.
+    // sentinel + backends/plugins 도 거기에 둬야 runtime packagedExeDir 가
+    // `<exe_dir>/.suji-packaged` probe → `<exe_dir>/backends/<name>/<basename>`
+    // resolution 모두 일치.
+    const app_bin = try std.fmt.allocPrint(allocator, "{s}/usr/bin", .{app_dir});
+    defer allocator.free(app_bin);
+    writePackagedSentinel(allocator, app_bin);
+    try stageBackendArtifacts(allocator, app_bin, backends, plugins);
 
     const archive = try std.fmt.allocPrint(allocator, "{s}/{s}-{s}-linux-{s}.AppImage", .{ output_dir, package_name, version, arch });
     errdefer allocator.free(archive);
@@ -361,8 +381,10 @@ pub fn packageLinuxDeb(
     version: []const u8,
     exe_path: []const u8,
     frontend_dist: []const u8,
+    backends: []const BackendArtifact,
+    plugins: []const BackendArtifact,
 ) ![]const u8 {
-    return packageLinuxDebAt(allocator, ".", name, version, exe_path, frontend_dist);
+    return packageLinuxDebAt(allocator, ".", name, version, exe_path, frontend_dist, backends, plugins);
 }
 
 /// 테스트/호출자가 output_dir를 고정할 수 있는 .deb 생성 경로.
@@ -373,6 +395,8 @@ pub fn packageLinuxDebAt(
     version: []const u8,
     exe_path: []const u8,
     frontend_dist: []const u8,
+    backends: []const BackendArtifact,
+    plugins: []const BackendArtifact,
 ) ![]const u8 {
     const package_name = try sanitizeDebPackageName(allocator, name);
     defer allocator.free(package_name);
@@ -410,6 +434,12 @@ pub fn packageLinuxDebAt(
     const frontend_dst = try std.fmt.allocPrint(allocator, "{s}/frontend", .{app_resources});
     defer allocator.free(frontend_dst);
     runCmd(&.{ "cp", "-R", frontend_dist, frontend_dst }) catch {};
+
+    // .deb layout: /opt/<pkg>/bin/<exe> + backends/plugins 평탄 배치 — `<exe_dir>/
+    // backends/<name>/<basename>` 패턴(runtime packagedExeDir 가 그대로 동작).
+    // sentinel 도 같은 dir.
+    writePackagedSentinel(allocator, app_bin);
+    try stageBackendArtifacts(allocator, app_bin, backends, plugins);
 
     const control = try renderDebControl(allocator, package_name, version, deb_arch, name);
     defer allocator.free(control);
@@ -462,7 +492,7 @@ pub fn packageLinuxDebAt(
 ///
 /// Linux 와 달리 Windows 는 bash/cp/zip 의존 제거 — PowerShell Compress-Archive
 /// 가 OS native. signtool 도 정식 Windows 도구로 PATH 에 있어야.
-/// 백엔드/플러그인 dylib 아티팩트 — packageWindows 가 stage 로 복사.
+/// 백엔드/플러그인 dylib 아티팩트 — packageWindows/Linux/macOS 가 stage 로 복사.
 /// is_node = true 면 source_path 는 디렉토리(main.js + package.json + node_modules)
 /// 통째 복사. 그렇지 않으면 단일 dylib 파일.
 pub const BackendArtifact = struct {
@@ -471,6 +501,70 @@ pub const BackendArtifact = struct {
     source_path: []const u8,
     is_node: bool,
 };
+
+/// stage 디렉토리에 빈 `.suji-packaged` sentinel 작성 — runtime 의 packagedExeDir
+/// probe 의 짝. OS 공통.
+pub fn writePackagedSentinel(allocator: std.mem.Allocator, root_dir: []const u8) void {
+    const sentinel_path = std.fmt.allocPrint(allocator, "{s}/.suji-packaged", .{root_dir}) catch return;
+    defer allocator.free(sentinel_path);
+    if (Dir.cwd().createFile(runtime.io, sentinel_path, .{})) |sentinel_file_const| {
+        var sentinel_file = sentinel_file_const;
+        sentinel_file.close(runtime.io);
+    } else |err| {
+        std.debug.print("[suji] sentinel write failed: {s}\n", .{@errorName(err)});
+    }
+}
+
+/// backends/plugins dylib 들을 `<root>/backends/<name>/<basename>` 와
+/// `<root>/plugins/<name>/<basename>` 로 평탄 배치. Node entry 면 디렉토리 통째.
+/// runtime path resolution 이 packaged 환경에서 동일 layout 을 기대.
+/// (root = Windows/Linux 의 stage, macOS .app/Contents/Resources)
+pub fn stageBackendArtifacts(
+    allocator: std.mem.Allocator,
+    root_dir: []const u8,
+    backends: []const BackendArtifact,
+    plugins: []const BackendArtifact,
+) !void {
+    if (backends.len > 0) {
+        const be_root = try std.fmt.allocPrint(allocator, "{s}/backends", .{root_dir});
+        defer allocator.free(be_root);
+        try Dir.cwd().createDirPath(runtime.io, be_root);
+        for (backends) |art| {
+            const be_dir = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ be_root, art.name });
+            defer allocator.free(be_dir);
+            try Dir.cwd().createDirPath(runtime.io, be_dir);
+            if (art.is_node) {
+                copyDirContents(allocator, art.source_path, be_dir) catch |err| {
+                    std.debug.print("[suji] node backend '{s}' copy failed: {s}\n", .{ art.name, @errorName(err) });
+                };
+            } else {
+                const basename = std.fs.path.basename(art.source_path);
+                const dst = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ be_dir, basename });
+                defer allocator.free(dst);
+                Dir.cwd().copyFile(art.source_path, Dir.cwd(), dst, runtime.io, .{}) catch |err| {
+                    std.debug.print("[suji] backend '{s}' dylib copy failed: {s}\n", .{ art.name, @errorName(err) });
+                };
+            }
+        }
+    }
+
+    if (plugins.len > 0) {
+        const pl_root = try std.fmt.allocPrint(allocator, "{s}/plugins", .{root_dir});
+        defer allocator.free(pl_root);
+        try Dir.cwd().createDirPath(runtime.io, pl_root);
+        for (plugins) |art| {
+            const pl_dir = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ pl_root, art.name });
+            defer allocator.free(pl_dir);
+            try Dir.cwd().createDirPath(runtime.io, pl_dir);
+            const basename = std.fs.path.basename(art.source_path);
+            const dst = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ pl_dir, basename });
+            defer allocator.free(dst);
+            Dir.cwd().copyFile(art.source_path, Dir.cwd(), dst, runtime.io, .{}) catch |err| {
+                std.debug.print("[suji] plugin '{s}' dylib copy failed: {s}\n", .{ art.name, @errorName(err) });
+            };
+        }
+    }
+}
 
 pub fn packageWindows(
     allocator: std.mem.Allocator,
@@ -520,62 +614,12 @@ pub fn packageWindows(
         std.debug.print("[suji] frontend dist copy failed: {s}\n", .{@errorName(err)});
     };
 
-    // 4b) packaged sentinel — runtime 의 packagedExeDir 가 이걸 probe 해서
-    // packaged 환경 판단. stale resources/frontend 만 가지고 false-positive
-    // 되는 걸 봉쇄. 빈 파일이면 충분.
-    const sentinel_path = try std.fmt.allocPrint(allocator, "{s}/.suji-packaged", .{stage});
-    defer allocator.free(sentinel_path);
-    if (Dir.cwd().createFile(runtime.io, sentinel_path, .{})) |sentinel_file_const| {
-        var sentinel_file = sentinel_file_const;
-        sentinel_file.close(runtime.io);
-    } else |err| {
-        std.debug.print("[suji] sentinel write failed: {s}\n", .{@errorName(err)});
-    }
+    // 4b) packaged sentinel — runtime 의 packagedExeDir 가 이걸 probe.
+    writePackagedSentinel(allocator, stage);
 
-    // 5a) backend dylib / node entry → <stage>/backends/<name>/ 평탄 배치.
-    //     runtime path resolution 이 packaged 환경에서 이 경로를 찾음.
-    if (backends.len > 0) {
-        const be_root = try std.fmt.allocPrint(allocator, "{s}/backends", .{stage});
-        defer allocator.free(be_root);
-        try Dir.cwd().createDirPath(runtime.io, be_root);
-        for (backends) |art| {
-            const be_dir = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ be_root, art.name });
-            defer allocator.free(be_dir);
-            try Dir.cwd().createDirPath(runtime.io, be_dir);
-            if (art.is_node) {
-                // Node 백엔드: main.js + package.json + node_modules 전체.
-                copyDirContents(allocator, art.source_path, be_dir) catch |err| {
-                    std.debug.print("[suji] node backend '{s}' copy failed: {s}\n", .{ art.name, @errorName(err) });
-                };
-            } else {
-                // dylib 파일 — basename 보존해서 copy.
-                const basename = std.fs.path.basename(art.source_path);
-                const dst = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ be_dir, basename });
-                defer allocator.free(dst);
-                Dir.cwd().copyFile(art.source_path, Dir.cwd(), dst, runtime.io, .{}) catch |err| {
-                    std.debug.print("[suji] backend '{s}' dylib copy failed: {s}\n", .{ art.name, @errorName(err) });
-                };
-            }
-        }
-    }
-
-    // 5b) plugin dylib → <stage>/plugins/<name>/ 평탄 배치.
-    if (plugins.len > 0) {
-        const pl_root = try std.fmt.allocPrint(allocator, "{s}/plugins", .{stage});
-        defer allocator.free(pl_root);
-        try Dir.cwd().createDirPath(runtime.io, pl_root);
-        for (plugins) |art| {
-            const pl_dir = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ pl_root, art.name });
-            defer allocator.free(pl_dir);
-            try Dir.cwd().createDirPath(runtime.io, pl_dir);
-            const basename = std.fs.path.basename(art.source_path);
-            const dst = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ pl_dir, basename });
-            defer allocator.free(dst);
-            Dir.cwd().copyFile(art.source_path, Dir.cwd(), dst, runtime.io, .{}) catch |err| {
-                std.debug.print("[suji] plugin '{s}' dylib copy failed: {s}\n", .{ art.name, @errorName(err) });
-            };
-        }
-    }
+    // 5) backend / plugin dylib 들을 <stage>/backends/<name>/<basename> +
+    //    <stage>/plugins/<name>/<basename> 로 평탄 배치 (OS 공통 helper).
+    try stageBackendArtifacts(allocator, stage, backends, plugins);
 
     // 6) 선택적 Authenticode 서명 (signtool.exe — Windows SDK).
     if (sign_cert) |cert| {

--- a/tests/package_desktop_test.zig
+++ b/tests/package_desktop_test.zig
@@ -124,7 +124,7 @@ test "packageLinuxDebAt creates a Debian ar archive with control and data member
     defer a.free(index);
     try writeFile(index, "<!doctype html><title>fake</title>\n");
 
-    const deb = try package_desktop.packageLinuxDebAt(a, root, "Deb E2E App", "1.2.3", exe, frontend);
+    const deb = try package_desktop.packageLinuxDebAt(a, root, "Deb E2E App", "1.2.3", exe, frontend, &.{}, &.{});
     defer a.free(deb);
     try std.testing.expect(std.mem.endsWith(u8, deb, ".deb"));
     try std.testing.expect(std.mem.indexOf(u8, deb, "deb-e2e-app_1.2.3_") != null);


### PR DESCRIPTION
## Summary

PR #40/#41 의 Windows backend bundling 패턴을 **macOS .app** 번들 + **Linux tar.gz/.deb/AppImage** 까지 확장. 모든 OS 의 packaged 사용자가 toolchain 없이 동작.

## 변경 요약

### 코드 공유화
- `main.zig` 의 backend/plugin 수집을 OS 분기 위로 추출 → 모든 OS 가 같은 list 사용
- `package_desktop.zig` 의 새 helper `writePackagedSentinel` + `stageBackendArtifacts` — OS 공통 평탄 배치 로직

### OS 별 layout (모두 runtime `packagedExeDir` probe 와 일치)
| Format | sentinel + backends/plugins root |
|---|---|
| Windows zip | `<stage>/` (= exe 와 같은 dir) |
| Linux tar.gz | `<stage>/` |
| Linux .deb | `/opt/<pkg>/bin/` |
| Linux AppImage | `<AppDir>/usr/bin/` (AppRun 의 runtime exe_dir) |
| macOS .app | `Contents/Resources/` |

### 추가 fix (code-review 3-angle)
1. AppImage stage 위치 mismatch — `<AppDir>` root → `<AppDir>/usr/bin/`
2. macOS codesign 누락 — `codesignDylibsIn` 헬퍼로 Resources/backends/, plugins/ 의 dylib 개별 sign (Apple 권장 명시 sign, `--deep` 회피)
3. `tests/package_desktop_test.zig` 의 `packageLinuxDebAt` 호출 update (2 args 추가)
4. plugins_list defer 에 `is_node` filter 추가 (future Node plugin 대비)
5. packagedExeDir macOS 분기의 redundant `dir` 변수 cleanup

## Test plan
- [x] zig build / zig build test green
- [x] Windows packaging 회귀 없음 (217MB zip, 모든 backend/plugin 로드)
- [ ] macOS host 에서 `.app` 빌드 + Notarization 통과 검증
- [ ] Linux host 에서 `.tar.gz` / `.deb` / AppImage 실 설치 + 백엔드 로드 검증

## ⚠️ 정직 한계
macOS/Linux 실 빌드는 host 환경 필요. Windows 머신에서 cross-build 코드 path 만 검증. 사용자 macOS/Linux 호스트에서 e2e 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)