### PR TITLE
Windows autoUpdater (zip format) — PowerShell helper + Expand-Archive

### DIFF
--- a/src/core/auto_updater.zig
+++ b/src/core/auto_updater.zig
@@ -431,7 +431,6 @@ pub fn defaultPrepareInstallStageDir(artifact_path: []const u8, out: []u8) Prepa
 }
 
 pub fn validatePrepareInstallOptions(io: std.Io, opts: PrepareInstallOptions) PrepareError!void {
-    if (builtin.os.tag == .windows) return error.UnsupportedPlatform;
     if (!isValidInstallPath(opts.artifact_path) or !isValidInstallPath(opts.stage_dir)) {
         return error.InvalidPath;
     }
@@ -441,8 +440,14 @@ pub fn validatePrepareInstallOptions(io: std.Io, opts: PrepareInstallOptions) Pr
     if (!pathExists(io, opts.artifact_path)) return error.ArtifactNotFound;
 
     switch (opts.format) {
-        .app, .zip, .dmg => {
+        .app, .dmg => {
             if (builtin.os.tag != .macos) return error.UnsupportedPlatform;
+            if (opts.target_path.len == 0) return error.InvalidPath;
+        },
+        .zip => {
+            // .zip 은 macOS(stage 내 .app 추출 → target.app 교체) + Windows
+            // (stage 디렉토리 → install dir 통째 교체) 둘 다 지원.
+            if (builtin.os.tag != .macos and builtin.os.tag != .windows) return error.UnsupportedPlatform;
             if (opts.target_path.len == 0) return error.InvalidPath;
         },
         .appimage => {
@@ -535,11 +540,11 @@ fn findAppBundleInner(
 
 pub fn defaultQuitAndInstallHelperPath(source_path: []const u8, out: []u8) InstallError![]const u8 {
     if (!isValidInstallPath(source_path)) return error.InvalidPath;
-    return std.fmt.bufPrint(out, "{s}.quit-install.sh", .{source_path}) catch error.HelperPathTooLong;
+    const ext: []const u8 = if (builtin.os.tag == .windows) ".quit-install.ps1" else ".quit-install.sh";
+    return std.fmt.bufPrint(out, "{s}{s}", .{ source_path, ext }) catch error.HelperPathTooLong;
 }
 
 pub fn validateQuitAndInstallOptions(io: std.Io, opts: QuitAndInstallOptions) InstallError!void {
-    if (builtin.os.tag == .windows) return error.UnsupportedPlatform;
     if (!isValidInstallPath(opts.source_path) or
         !isValidInstallPath(opts.target_path) or
         !isValidInstallPath(opts.helper_path))
@@ -560,7 +565,6 @@ pub fn renderQuitAndInstallScript(
     allocator: std.mem.Allocator,
     opts: QuitAndInstallOptions,
 ) InstallError![]u8 {
-    if (builtin.os.tag == .windows) return error.UnsupportedPlatform;
     if (!isValidInstallPath(opts.source_path) or
         !isValidInstallPath(opts.target_path) or
         !isValidInstallPath(opts.helper_path))
@@ -568,6 +572,8 @@ pub fn renderQuitAndInstallScript(
         return error.InvalidPath;
     }
     if (opts.wait_pid <= 0) return error.InvalidPid;
+
+    if (builtin.os.tag == .windows) return renderQuitAndInstallScriptWindows(allocator, opts);
 
     var out = std.ArrayList(u8).empty;
     errdefer out.deinit(allocator);
@@ -616,6 +622,93 @@ pub fn renderQuitAndInstallScript(
     );
 
     return out.toOwnedSlice(allocator);
+}
+
+/// Windows PowerShell `.ps1` helper. caller 가
+/// `powershell -NoProfile -ExecutionPolicy Bypass -File <helper>` 으로 실행.
+/// `.zip` 포맷 — source 는 압축 해제된 stage 디렉토리, target 은 install dir.
+/// Move-Item 으로 디렉토리 통째 교체, 실패 시 backup 복구.
+fn renderQuitAndInstallScriptWindows(
+    allocator: std.mem.Allocator,
+    opts: QuitAndInstallOptions,
+) InstallError![]u8 {
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(allocator);
+
+    // PowerShell single-quoted string: backtick-escape backtick + double single-quote.
+    try out.appendSlice(allocator, "$ErrorActionPreference = 'Stop'\n$src = '");
+    try appendPwshSingleQuoted(allocator, &out, opts.source_path);
+    try out.appendSlice(allocator, "'\n$dst = '");
+    try appendPwshSingleQuoted(allocator, &out, opts.target_path);
+    try out.appendSlice(allocator, "'\n$waitPid = ");
+    try out.print(allocator, "{d}", .{opts.wait_pid});
+    try out.appendSlice(allocator, "\n$relaunch = ");
+    try out.appendSlice(allocator, if (opts.relaunch) "1" else "0");
+    try out.appendSlice(allocator,
+        \\
+        \\try {
+        \\  # WaitForExit 는 process handle 기준 — `Get-Process` 만 쓰면 PID 재사용
+        \\  # race 가능 (Suji 종료 직후 OS 가 같은 PID 를 svchost 등에 재할당 →
+        \\  # 무한 대기 또는 잘못된 process 대기). handle 잡고 즉시 WaitForExit.
+        \\  $waitProc = Get-Process -Id $waitPid -ErrorAction SilentlyContinue
+        \\  if ($waitProc) {
+        \\    try { $waitProc.WaitForExit() } catch { }
+        \\  }
+        \\  if (-not (Test-Path -LiteralPath $src)) { exit 2 }
+        \\  $bk = "$dst.suji-update-backup-$([guid]::NewGuid().ToString('N'))"
+        \\  if (Test-Path -LiteralPath $dst) {
+        \\    try { Move-Item -LiteralPath $dst -Destination $bk -Force } catch { exit 4 }
+        \\  }
+        \\  try {
+        \\    Move-Item -LiteralPath $src -Destination $dst -Force
+        \\  } catch {
+        \\    if (Test-Path -LiteralPath $bk) {
+        \\      try { Move-Item -LiteralPath $bk -Destination $dst -Force } catch { }
+        \\    }
+        \\    exit 3
+        \\  }
+        \\  if (Test-Path -LiteralPath $bk) {
+        \\    Remove-Item -LiteralPath $bk -Recurse -Force -ErrorAction SilentlyContinue
+        \\  }
+        \\  # Move 후 source parent (extract_dir) 가 빈 디렉토리로 남아 누적 → 정리.
+        \\  $srcParent = Split-Path -Parent $src
+        \\  if ($srcParent -and (Test-Path -LiteralPath $srcParent)) {
+        \\    $remaining = @(Get-ChildItem -LiteralPath $srcParent -Force -ErrorAction SilentlyContinue)
+        \\    if ($remaining.Count -eq 0) {
+        \\      Remove-Item -LiteralPath $srcParent -Recurse -Force -ErrorAction SilentlyContinue
+        \\    }
+        \\  }
+        \\  if ($relaunch -eq 1) {
+        \\    # target 이 디렉토리(.zip 포맷) — `.exe` 단일 후보 선택. unins*는 Inno
+        \\    # Setup 의 uninstaller 라 제외. target 이 파일이면 직접 실행.
+        \\    if (Test-Path -LiteralPath $dst -PathType Container) {
+        \\      $exe = Get-ChildItem -LiteralPath $dst -Filter '*.exe' -File -ErrorAction SilentlyContinue |
+        \\        Where-Object { $_.Name -notlike 'unins*' } |
+        \\        Select-Object -First 1
+        \\      if ($exe) { Start-Process -FilePath $exe.FullName | Out-Null }
+        \\    } else {
+        \\      Start-Process -FilePath $dst | Out-Null
+        \\    }
+        \\  }
+        \\} finally {
+        \\  Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue
+        \\}
+        \\
+    );
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// PowerShell single-quoted literal escape — backtick 와 single quote 만 처리
+/// (PowerShell 의 single-quoted 는 backslash interpolation 없음).
+fn appendPwshSingleQuoted(allocator: std.mem.Allocator, out: *std.ArrayList(u8), s: []const u8) !void {
+    for (s) |c| {
+        if (c == '\'') {
+            try out.appendSlice(allocator, "''");
+        } else {
+            try out.append(allocator, c);
+        }
+    }
 }
 
 pub fn writeQuitAndInstallScript(
@@ -998,6 +1091,51 @@ test "quitAndInstall helper script quotes paths and encodes relaunch policy" {
     try std.testing.expect(std.mem.indexOf(u8, script, "while kill -0 \"$WAIT_PID\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "mv \"$SOURCE\" \"$TARGET\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "open -n \"$TARGET\"") != null);
+}
+
+test "Windows: quitAndInstall renders PowerShell helper with .ps1 path" {
+    if (@import("builtin").os.tag != .windows) return error.SkipZigTest;
+
+    var helper_buf: [std.Io.Dir.max_path_bytes + 32]u8 = undefined;
+    const helper = try defaultQuitAndInstallHelperPath("C:\\Apps\\Suji.exe", &helper_buf);
+    try std.testing.expect(std.mem.endsWith(u8, helper, ".quit-install.ps1"));
+
+    const script = try renderQuitAndInstallScript(std.testing.allocator, .{
+        .source_path = "C:\\Apps\\stage\\extract\\Suji-1.0.0-windows-x64",
+        .target_path = "C:\\Apps\\Suji",
+        .helper_path = helper,
+        .wait_pid = 4321,
+        .relaunch = true,
+    });
+    defer std.testing.allocator.free(script);
+
+    try std.testing.expect(std.mem.indexOf(u8, script, "$ErrorActionPreference") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "$waitProc.WaitForExit()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "$waitPid = 4321") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "$relaunch = 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "Move-Item -LiteralPath $src") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "Start-Process -FilePath") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "Remove-Item -LiteralPath $PSCommandPath") != null);
+    // source parent cleanup (extract_dir 누적 방지).
+    try std.testing.expect(std.mem.indexOf(u8, script, "Split-Path -Parent $src") != null);
+}
+
+test "Windows: quitAndInstall escapes single quotes in paths" {
+    if (@import("builtin").os.tag != .windows) return error.SkipZigTest;
+
+    const script = try renderQuitAndInstallScript(std.testing.allocator, .{
+        .source_path = "C:\\Apps\\Joe's\\stage",
+        .target_path = "C:\\Apps\\Joe's\\install",
+        .helper_path = "C:\\Apps\\helper.ps1",
+        .wait_pid = 1,
+        .relaunch = false,
+    });
+    defer std.testing.allocator.free(script);
+
+    // PowerShell single-quoted single quote escape = doubled.
+    try std.testing.expect(std.mem.indexOf(u8, script, "$src = 'C:\\Apps\\Joe''s\\stage'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "$dst = 'C:\\Apps\\Joe''s\\install'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "$relaunch = 0") != null);
 }
 
 test "quitAndInstall validates source and writes helper script" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3981,6 +3981,11 @@ fn prepareAutoUpdaterInstallArtifact(
         },
         .deb => return auto_updater.preparedSystemPackage(artifact, stage_dir),
         .zip => {
+            if (builtin.os.tag == .windows) {
+                const source = prepareWindowsZip(artifact, stage_dir) catch |err| return err;
+                owned_source.* = source;
+                return auto_updater.preparedQuitAndInstall(source, target, stage_dir, .zip);
+            }
             const source = prepareMacZipApp(artifact, stage_dir) catch |err| return err;
             owned_source.* = source;
             return auto_updater.preparedQuitAndInstall(source, target, stage_dir, .zip);
@@ -3991,6 +3996,57 @@ fn prepareAutoUpdaterInstallArtifact(
             return auto_updater.preparedQuitAndInstall(source, target, stage_dir, .dmg);
         },
     }
+}
+
+/// Windows `.zip` extraction → 압축 풀린 stage 디렉토리의 single child dir
+/// (Suji packaging 이 `<name>-<ver>-windows-x64/` 하나만 만듦) 반환.
+/// quitAndInstall 이 이 source dir 를 target install dir 로 통째 교체.
+fn prepareWindowsZip(artifact: []const u8, stage_dir: []const u8) auto_updater.PrepareError![]u8 {
+    if (builtin.os.tag != .windows) return error.UnsupportedPlatform;
+    std.Io.Dir.cwd().createDirPath(runtime.io, stage_dir) catch return error.CommandFailed;
+
+    const extract_dir = std.fmt.allocPrint(runtime.gpa, "{s}/extract", .{stage_dir}) catch
+        return error.OutOfMemory;
+    defer runtime.gpa.free(extract_dir);
+
+    std.Io.Dir.cwd().deleteTree(runtime.io, extract_dir) catch {};
+    std.Io.Dir.cwd().createDirPath(runtime.io, extract_dir) catch return error.CommandFailed;
+
+    // PowerShell Expand-Archive — .zip → extract_dir.
+    const ps_cmd = std.fmt.allocPrint(
+        runtime.gpa,
+        "Expand-Archive -LiteralPath '{s}' -DestinationPath '{s}' -Force",
+        .{ artifact, extract_dir },
+    ) catch return error.OutOfMemory;
+    defer runtime.gpa.free(ps_cmd);
+    runCmd(runtime.gpa, &.{ "powershell", "-NoProfile", "-Command", ps_cmd }) catch
+        return error.CommandFailed;
+
+    // 압축 풀린 디렉토리 안의 single child 디렉토리를 찾는다 (suji packaging
+    // 이 `<name>-<ver>-windows-x64/` 디렉토리 하나만 생성). 여러 entry 면
+    // extract_dir 자체를 source 로 사용 (사용자가 직접 만든 zip 호환).
+    var d = std.Io.Dir.cwd().openDir(runtime.io, extract_dir, .{ .iterate = true }) catch
+        return error.CommandFailed;
+    defer d.close(runtime.io);
+    var it = d.iterate();
+    var single: ?[]u8 = null;
+    var multiple = false;
+    while (it.next(runtime.io) catch return error.CommandFailed) |entry| {
+        if (entry.kind != .directory) continue;
+        if (single != null) {
+            multiple = true;
+            if (single) |p| runtime.gpa.free(p);
+            single = null;
+            break;
+        }
+        single = std.fmt.allocPrint(runtime.gpa, "{s}/{s}", .{ extract_dir, entry.name }) catch
+            return error.OutOfMemory;
+    }
+    if (multiple or single == null) {
+        if (single) |p| runtime.gpa.free(p);
+        return runtime.gpa.dupe(u8, extract_dir) catch error.OutOfMemory;
+    }
+    return single.?;
 }
 
 fn prepareMacZipApp(artifact: []const u8, stage_dir: []const u8) auto_updater.PrepareError![]u8 {
@@ -4060,6 +4116,19 @@ fn defaultAutoUpdaterInstallTarget(buf: []u8) ?[]const u8 {
 }
 
 fn launchQuitAndInstallHelper(helper_path: []const u8) !void {
+    if (builtin.os.tag == .windows) {
+        // PowerShell `.ps1` helper. `-ExecutionPolicy Bypass` 로 사용자 정책
+        // (RestrictedScript 등) 우회 — script 는 우리가 직접 쓴 파일이고
+        // 즉시 종료 후 self-delete 하므로 영구 정책 변경 아님.
+        const child = try std.process.spawn(runtime.io, .{
+            .argv = &.{ "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", helper_path },
+            .stdin = .ignore,
+            .stdout = .ignore,
+            .stderr = .ignore,
+        });
+        _ = child;
+        return;
+    }
     const child = try std.process.spawn(runtime.io, .{
         .argv = &.{ "/bin/sh", helper_path },
         .stdin = .ignore,


### PR DESCRIPTION
## Summary

2순위 우선순위 fix. 이전엔 macOS `.zip`/`.dmg` + Linux `.AppImage` 만 지원, Windows 사용자는 매번 zip 수동 다운로드해야 했음. 이번 PR 로 Windows 자동 업데이트 (`.zip` portable) 동작.

## 변경

### `src/core/auto_updater.zig`
- `validatePrepareInstallOptions` Windows 전체 거부 가드 제거 + `.zip` 에 Windows 허용
- `validateQuitAndInstallOptions` Windows 거부 가드 제거
- `renderQuitAndInstallScript` Windows 분기: 새 helper `renderQuitAndInstallScriptWindows` (PowerShell `.ps1`)
- `defaultQuitAndInstallHelperPath`: Windows 면 `.ps1` 확장자
- Windows-only 신규 unit test 2개

### `src/main.zig`
- `prepareAutoUpdaterInstallArtifact .zip` arm: Windows 면 `prepareWindowsZip` 호출
- `prepareWindowsZip`: PowerShell `Expand-Archive` 로 stage 추출 + single child dir 자동 감지
- `launchQuitAndInstallHelper`: Windows 면 PowerShell 로 helper 실행

## 코드 리뷰 (5-angle) 적용 fix
- **PID 재사용 race**: `Get-Process` polling 만으로는 OS 의 PID 빠른 재할당 race 봉쇄 불가 → process handle `WaitForExit` (.NET API)
- **`extract_dir` 누적**: Move-Item 후 source 의 parent (빈 dir) 정리

## ⚠️ 알려진 한계 (정직)
- AD GPO ExecutionPolicy=`AllSigned`/`Restricted` 강제 시 `-Bypass` 무시 → 기업 환경에서 fail. 후속: signed helper 또는 native CreateProcess.
- `.exe installer` (Inno Setup) / `.msi` (WiX) 포맷은 별도 PR — 현재는 `.zip` (portable) 만 지원
- Expand-Archive 실패 시 partial extraction 잔존 — 다음 prepareInstall 의 deleteTree 가 정리하지만 단일 호출 retry 시 잔존

## Test plan
- [x] zig build / zig build test: 862/871 pass (9 skip = Linux/macOS-only)
- [x] 신규 Windows-only test 2개 통과
- [ ] 사용자 수동: 패키지 .zip 받아서 `prepareInstall` + `quitAndInstall` 호출 → 재시작 후 새 버전 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)