### PR TITLE
Add @suji/plugin-http — renderer-safe fetch with URL allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ zig build test-state    # state 플러그인 (KV 스토어)
 zig build test-sqlite   # sqlite 플러그인 (벤더 SQLite 3.51, sql:open/execute/query/close)
 zig build test-log      # log 플러그인 (rotating file logger, level filter, JSON Lines)
 zig build test-store    # store 플러그인 (file-backed config store, named instances, atomic persist)
+zig build test-http     # http 플러그인 (renderer-safe fetch with URL allowlist, deny-by-default)
 
 # 임베드 코어 라이브러리 (CEF 무관 — 모바일/임베드용)
 zig build lib                                  # libsuji_core.a (host)

--- a/build.zig
+++ b/build.zig
@@ -960,6 +960,29 @@ pub fn build(b: *std.Build) void {
     const store_test_step = b.step("test-store", "Run store plugin tests (requires built dylib)");
     store_test_step.dependOn(&store_test_run.step);
 
+    // HTTP plugin tests (log/state/sqlite/store 와 동형)
+    const http_test_mod = b.createModule(.{
+        .root_source_file = b.path("tests/http_plugin_test.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    const http_loader = b.createModule(.{
+        .root_source_file = b.path("src/backends/loader.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    http_loader.addImport("events", events_module);
+    http_loader.addImport("runtime", runtime_module);
+    http_loader.addImport("util", util_module);
+    http_test_mod.addImport("loader", http_loader);
+    http_test_mod.addImport("events", events_module);
+    const http_test = b.addTest(.{ .root_module = http_test_mod });
+    const http_test_run = b.addRunArtifact(http_test);
+    http_test_run.setCwd(b.path("."));
+    const http_test_step = b.step("test-http", "Run http plugin tests (requires built dylib)");
+    http_test_step.dependOn(&http_test_run.step);
+
     // State plugin Rust 래퍼 통합 테스트
     // Rust bridge dylib를 cargo로 빌드한 뒤 Zig 테스트에서 로드.
     const rust_wrapper_mod = b.createModule(.{

--- a/plugins/http/js/package.json
+++ b/plugins/http/js/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@suji/plugin-http",
+  "version": "0.1.0",
+  "description": "Renderer-safe HTTP fetch for Suji with URL allowlist.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "bun test src"
+  },
+  "files": ["dist", "README.md"]
+}

--- a/plugins/http/js/src/index.test.ts
+++ b/plugins/http/js/src/index.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockBridge = {
+  invoke: mock(() => Promise.resolve({})),
+};
+
+(globalThis as any).window = { __suji__: mockBridge };
+
+const { http } = await import("./index");
+
+beforeEach(() => {
+  mockBridge.invoke.mockClear();
+});
+
+describe("http.fetch — channel + payload shape", () => {
+  it("default GET (no method/body)", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { status: 200, body: "{}" } });
+    const r = await http.fetch("https://api.x/v1");
+    expect(mockBridge.invoke).toHaveBeenCalledWith("http:fetch", { url: "https://api.x/v1" });
+    expect(r.status).toBe(200);
+    expect(r.body).toBe("{}");
+  });
+
+  it("explicit POST + body", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { status: 201, body: "ok" } });
+    await http.fetch("https://api.x/v1/items", { method: "POST", body: '{"a":1}' });
+    expect(mockBridge.invoke).toHaveBeenCalledWith("http:fetch", {
+      url: "https://api.x/v1/items",
+      method: "POST",
+      body: '{"a":1}',
+    });
+  });
+
+  it("response defaults: missing status→0, missing body→''", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: {} });
+    const r = await http.fetch("https://api.x/");
+    expect(r.status).toBe(0);
+    expect(r.body).toBe("");
+  });
+});
+
+describe("http allowlist", () => {
+  it("setAllowedUrls passes patterns through", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true } });
+    await http.setAllowedUrls(["https://*.example.com/*", "https://api.x/*"]);
+    expect(mockBridge.invoke).toHaveBeenCalledWith("http:set_allowed_urls", {
+      urls: ["https://*.example.com/*", "https://api.x/*"],
+    });
+  });
+
+  it("getAllowedUrls returns array", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { urls: ["https://*.x/*"] } });
+    expect(await http.getAllowedUrls()).toEqual(["https://*.x/*"]);
+  });
+
+  it("getAllowedUrls returns empty when urls missing", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: {} });
+    expect(await http.getAllowedUrls()).toEqual([]);
+  });
+});
+
+describe("error propagation", () => {
+  it("throws when bridge returns error", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ error: "forbidden" });
+    await expect(http.fetch("https://blocked/")).rejects.toThrow("http: forbidden");
+  });
+});

--- a/plugins/http/js/src/index.ts
+++ b/plugins/http/js/src/index.ts
@@ -1,0 +1,61 @@
+/**
+ * @suji/plugin-http — Renderer-safe HTTP fetch for Suji apps.
+ *
+ * 데스크톱 `suji.http.fetch` 는 backend-only. 이 플러그인은 명시적 URL
+ * allowlist 게이트로 renderer 에서도 fetch 호출 가능.
+ *
+ * ```ts
+ * import { http } from '@suji/plugin-http';
+ * await http.setAllowedUrls(["https://api.example.com/*"]);
+ * const { status, body } = await http.fetch("https://api.example.com/v1/me");
+ * ```
+ */
+
+interface SujiBridge {
+  invoke(channel: string, data?: Record<string, unknown>): Promise<any>;
+}
+
+function getBridge(): SujiBridge {
+  const bridge = (window as any).__suji__;
+  if (!bridge) throw new Error("Suji bridge not available.");
+  return bridge;
+}
+
+export interface FetchOpts {
+  method?: "GET" | "POST";
+  body?: string;
+}
+
+export interface FetchResponse {
+  status: number;
+  body: string;
+}
+
+async function call(cmd: string, payload: Record<string, unknown>): Promise<any> {
+  const resp = await getBridge().invoke(cmd, payload);
+  if (resp?.error) throw new Error(`http: ${resp.error}`);
+  return resp?.result ?? resp;
+}
+
+export const http = {
+  async fetch(url: string, opts: FetchOpts = {}): Promise<FetchResponse> {
+    const r = await call("http:fetch", {
+      url,
+      ...(opts.method ? { method: opts.method } : {}),
+      ...(opts.body !== undefined ? { body: opts.body } : {}),
+    });
+    return {
+      status: Number(r?.status ?? 0),
+      body: String(r?.body ?? ""),
+    };
+  },
+
+  async setAllowedUrls(urls: string[]): Promise<void> {
+    await call("http:set_allowed_urls", { urls });
+  },
+
+  async getAllowedUrls(): Promise<string[]> {
+    const r = await call("http:get_allowed_urls", {});
+    return (r?.urls ?? []) as string[];
+  },
+};

--- a/plugins/http/js/tsconfig.json
+++ b/plugins/http/js/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/plugins/http/node/package.json
+++ b/plugins/http/node/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@suji/plugin-http-node",
+  "version": "0.1.0",
+  "description": "Renderer-safe HTTP fetch wrapper for Suji Node backends.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "bun test src"
+  },
+  "files": ["dist", "README.md"]
+}

--- a/plugins/http/node/src/index.test.ts
+++ b/plugins/http/node/src/index.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockBridge = {
+  invoke: mock(() => Promise.resolve('{"result":{}}')),
+};
+
+(globalThis as any).suji = mockBridge;
+
+const { http } = await import("./index");
+
+beforeEach(() => {
+  mockBridge.invoke.mockClear();
+});
+
+function lastPayload(): Record<string, unknown> {
+  return JSON.parse(mockBridge.invoke.mock.calls.at(-1)![1] as string);
+}
+
+describe("http.fetch Node — channel + payload shape", () => {
+  it("default GET (no method/body)", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"status":200,"body":"ok"}}');
+    const r = await http.fetch("https://api.x/v1");
+    const args = mockBridge.invoke.mock.calls.at(-1)!;
+    expect(args[0]).toBe("http");
+    expect(lastPayload()).toEqual({ cmd: "http:fetch", url: "https://api.x/v1" });
+    expect(r.status).toBe(200);
+    expect(r.body).toBe("ok");
+  });
+
+  it("POST + body", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"status":201,"body":""}}');
+    await http.fetch("https://api.x/v1", { method: "POST", body: '{"a":1}' });
+    expect(lastPayload()).toEqual({
+      cmd: "http:fetch",
+      url: "https://api.x/v1",
+      method: "POST",
+      body: '{"a":1}',
+    });
+  });
+
+  it("setAllowedUrls + getAllowedUrls", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true}}');
+    await http.setAllowedUrls(["https://api.x/*"]);
+    expect(lastPayload()).toEqual({ cmd: "http:set_allowed_urls", urls: ["https://api.x/*"] });
+
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"urls":["a","b"]}}');
+    expect(await http.getAllowedUrls()).toEqual(["a", "b"]);
+  });
+
+  it("error propagation", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"error":"forbidden"}');
+    await expect(http.fetch("https://blocked/")).rejects.toThrow("http: forbidden");
+  });
+
+  it("malformed JSON resp gracefully degrades to defaults", async () => {
+    mockBridge.invoke.mockResolvedValueOnce("not json");
+    const r = await http.fetch("https://x/");
+    expect(r.status).toBe(0);
+    expect(r.body).toBe("");
+  });
+});

--- a/plugins/http/node/src/index.ts
+++ b/plugins/http/node/src/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @suji/plugin-http-node — Node backend wrapper for @suji/plugin-http.
+ * Wire contract 은 renderer 변형과 동일.
+ *
+ * ```ts
+ * const { http } = require('@suji/plugin-http-node');
+ * await http.setAllowedUrls(['https://api.example.com/*']);
+ * const r = await http.fetch('https://api.example.com/v1');
+ * ```
+ */
+
+interface SujiBridge {
+  invoke(backend: string, request: string): Promise<string>;
+}
+
+function getBridge(): SujiBridge {
+  const bridge = (globalThis as any).suji as SujiBridge | undefined;
+  if (!bridge) {
+    throw new Error(
+      "@suji/plugin-http-node: bridge not available. This module must run inside a Suji app (libnode embedding).",
+    );
+  }
+  return bridge;
+}
+
+async function call(cmd: string, payload: Record<string, unknown>): Promise<any> {
+  const raw = await getBridge().invoke("http", JSON.stringify({ cmd, ...payload }));
+  let resp: any;
+  try {
+    resp = JSON.parse(raw);
+  } catch {
+    resp = {};
+  }
+  if (resp?.error) throw new Error(`http: ${resp.error}`);
+  return resp?.result;
+}
+
+export interface FetchOpts {
+  method?: "GET" | "POST";
+  body?: string;
+}
+
+export interface FetchResponse {
+  status: number;
+  body: string;
+}
+
+export const http = {
+  async fetch(url: string, opts: FetchOpts = {}): Promise<FetchResponse> {
+    const r = await call("http:fetch", {
+      url,
+      ...(opts.method ? { method: opts.method } : {}),
+      ...(opts.body !== undefined ? { body: opts.body } : {}),
+    });
+    return {
+      status: Number(r?.status ?? 0),
+      body: String(r?.body ?? ""),
+    };
+  },
+
+  async setAllowedUrls(urls: string[]): Promise<void> {
+    await call("http:set_allowed_urls", { urls });
+  },
+
+  async getAllowedUrls(): Promise<string[]> {
+    const r = await call("http:get_allowed_urls", {});
+    return (r?.urls ?? []) as string[];
+  },
+};

--- a/plugins/http/node/tsconfig.json
+++ b/plugins/http/node/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/plugins/http/suji-plugin.json
+++ b/plugins/http/suji-plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "http",
+  "lang": "zig",
+  "description": "Renderer-safe HTTP client with URL allowlist (CORS-free backend fetch). Zig std.http 위에 allowlist 게이트."
+}

--- a/plugins/http/zig/app.zig
+++ b/plugins/http/zig/app.zig
@@ -1,0 +1,242 @@
+//! @suji/plugin-http — renderer-safe HTTP fetch with URL allowlist.
+//!
+//! 데스크톱 `suji.http.fetch` 는 backend-only (frontend 미노출 — 보안 정책).
+//! 이 플러그인은 명시적 allowlist 게이트를 통해 frontend 에서도 fetch 호출
+//! 가능하게 한다 (Electron `webRequest` allowlist + `net.fetch` 패턴).
+//!
+//! 채널:
+//!   http:fetch              {url, method?, body?}        → {status, body, headers?}
+//!   http:set_allowed_urls   {urls: [glob_pattern, ...]}  → {ok:true}
+//!   http:get_allowed_urls   {}                            → {urls: [...]}
+//!
+//! 정책:
+//!   - 기본 allowlist 비어 있음 — 모든 fetch 차단 (deny-by-default, fs 와 동일).
+//!   - URL glob 매칭은 `util.matchGlob` 재사용 (`https://*.example.com/*` 등).
+//!   - 응답 body 최대 16MB (DoS 방지). 초과 시 error.
+//!   - method 미지정 = GET, body 있고 method 미지정 = POST.
+//!   - 사용자 헤더는 v1 미지원 (Cookie/Authorization 누출 위험 — 후속).
+
+const std = @import("std");
+const suji = @import("suji");
+
+pub const app = suji.app()
+    .named("http")
+    .handle("http:fetch", httpFetch)
+    .handle("http:set_allowed_urls", httpSetAllowedUrls)
+    .handle("http:get_allowed_urls", httpGetAllowedUrls);
+
+var gpa: std.heap.DebugAllocator(.{}) = .init;
+const alloc = gpa.allocator();
+
+fn pluginIo() std.Io {
+    return suji.io();
+}
+
+const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+const MAX_URL_LEN: usize = 4096;
+const MAX_PATTERN_LEN: usize = 1024;
+const MAX_PATTERNS: usize = 256;
+const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+// ============================================
+// Allowlist
+// ============================================
+
+var allowed_urls: std.ArrayList([]const u8) = .empty;
+var allowed_mutex: std.Io.Mutex = .init;
+
+fn matchGlob(pattern: []const u8, text: []const u8) bool {
+    // src/core/util.zig matchGlob 미러 — 플러그인은 util import 안 함, 동형 구현.
+    var pi: usize = 0;
+    var ti: usize = 0;
+    var star_pi: ?usize = null;
+    var star_ti: usize = 0;
+    while (ti < text.len) {
+        if (pi < pattern.len and pattern[pi] == '*') {
+            star_pi = pi;
+            star_ti = ti;
+            pi += 1;
+        } else if (pi < pattern.len and pattern[pi] == '?') {
+            pi += 1;
+            ti += 1;
+        } else if (pi < pattern.len and pattern[pi] == text[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if (star_pi) |sp| {
+            pi = sp + 1;
+            star_ti += 1;
+            ti = star_ti;
+        } else {
+            return false;
+        }
+    }
+    while (pi < pattern.len and pattern[pi] == '*') pi += 1;
+    return pi == pattern.len;
+}
+
+fn isAllowed(url: []const u8) bool {
+    allowed_mutex.lockUncancelable(pluginIo());
+    defer allowed_mutex.unlock(pluginIo());
+    for (allowed_urls.items) |pat| {
+        if (matchGlob(pat, url)) return true;
+    }
+    return false;
+}
+
+fn clearAllowed() void {
+    for (allowed_urls.items) |p| alloc.free(p);
+    allowed_urls.clearRetainingCapacity();
+}
+
+// ============================================
+// JSON helpers
+// ============================================
+
+fn appendJsonEscaped(buf: *std.ArrayList(u8), a: std.mem.Allocator, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '"' => try buf.appendSlice(a, "\\\""),
+            '\\' => try buf.appendSlice(a, "\\\\"),
+            '\n' => try buf.appendSlice(a, "\\n"),
+            '\r' => try buf.appendSlice(a, "\\r"),
+            '\t' => try buf.appendSlice(a, "\\t"),
+            0...8, 11, 12, 14...31 => {
+                var tmp: [6]u8 = undefined;
+                const out = std.fmt.bufPrint(&tmp, "\\u{x:0>4}", .{c}) catch continue;
+                try buf.appendSlice(a, out);
+            },
+            else => try buf.append(a, c),
+        }
+    }
+}
+
+// ============================================
+// Handlers
+// ============================================
+
+fn httpFetch(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    const url = req.string("url") orelse return req.err("missing url");
+    if (url.len == 0 or url.len > MAX_URL_LEN) return req.err("invalid url");
+
+    // 스킴 검사 — http:/https: 만 허용 (file:, data:, javascript: 차단).
+    const is_http = std.mem.startsWith(u8, url, "http://");
+    const is_https = std.mem.startsWith(u8, url, "https://");
+    if (!is_http and !is_https) return req.err("scheme not allowed");
+
+    // userinfo bypass 차단 — `https://allowed.com@evil.com/` 같은 URL 은 glob
+    // `https://allowed.com/*` 에 매치되지만 실제 std.http.Client 는 `evil.com` 으로
+    // 연결한다(RFC 3986 authority = userinfo@host). authority 안의 `@` 거부.
+    const scheme_end = std.mem.indexOf(u8, url, "://") orelse return req.err("invalid url");
+    const authority_start = scheme_end + 3;
+    const authority_end = std.mem.indexOfAnyPos(u8, url, authority_start, "/?#") orelse url.len;
+    if (std.mem.indexOfScalarPos(u8, url[0..authority_end], authority_start, '@') != null) {
+        return req.err("userinfo not allowed");
+    }
+    // CRLF/NUL injection — std.http.Client 도 보통 거부하지만 정직 경계로 사전 차단.
+    for (url) |c| if (c == '\r' or c == '\n' or c == 0) return req.err("invalid url");
+
+    if (!isAllowed(url)) return req.err("forbidden");
+
+    const method_str = req.string("method");
+    const body = req.string("body");
+    if (body) |b| if (b.len > MAX_BODY_BYTES) return req.err("body too large");
+
+    var is_post: bool = false;
+    if (method_str) |m| {
+        if (std.ascii.eqlIgnoreCase(m, "POST")) is_post = true
+        else if (std.ascii.eqlIgnoreCase(m, "GET")) is_post = false
+        else return req.err("method not allowed");
+    } else {
+        is_post = body != null;
+    }
+
+    var client: std.http.Client = .{ .allocator = alloc, .io = pluginIo() };
+    defer client.deinit();
+    var aw = std.Io.Writer.Allocating.init(alloc);
+    defer aw.deinit();
+
+    const fetch_payload: ?[]const u8 = if (is_post) (body orelse "") else null;
+
+    // redirect SSRF 차단 — allowlist 가 최초 URL 만 검증하므로, `https://allowed/r`
+    // → 3xx → `http://169.254.169.254/...` 같은 redirect 가 게이트를 우회한다.
+    // `.not_allowed` = 3xx 응답을 그대로 받고 fetch 가 redirect 따라가지 않음.
+    const r = client.fetch(.{
+        .location = .{ .url = url },
+        .payload = fetch_payload,
+        .response_writer = &aw.writer,
+        .redirect_behavior = .not_allowed,
+    }) catch return req.err("fetch failed");
+
+    // 응답 본문 크기 1차 가드 — toOwnedSlice 전에 written buffer 길이 검사.
+    // v1 정직 한계: std.http.Client 가 이미 전체 body 를 메모리에 allocate 한 뒤
+    // 검사하는 post-allocation 가드. 진정한 streaming bound 는 후속(Request 저수준
+    // API + bounded reader).
+    if (aw.writer.end > MAX_RESPONSE_BYTES) return req.err("response too large");
+    const body_slice = aw.toOwnedSlice() catch return req.err("alloc");
+    defer alloc.free(body_slice);
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(req.arena);
+    out.appendSlice(req.arena, "{\"status\":") catch return req.err("alloc");
+    var tmp: [16]u8 = undefined;
+    const status_str = std.fmt.bufPrint(&tmp, "{d}", .{@intFromEnum(r.status)}) catch return req.err("alloc");
+    out.appendSlice(req.arena, status_str) catch return req.err("alloc");
+    out.appendSlice(req.arena, ",\"body\":\"") catch return req.err("alloc");
+    appendJsonEscaped(&out, req.arena, body_slice) catch return req.err("alloc");
+    out.appendSlice(req.arena, "\"}") catch return req.err("alloc");
+    const final = out.toOwnedSlice(req.arena) catch return req.err("alloc");
+    return req.okRaw(final);
+}
+
+fn httpSetAllowedUrls(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    const raw_array = suji.extractJsonValue(req.raw, "urls") orelse return req.err("missing urls");
+
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, raw_array, .{}) catch return req.err("invalid urls");
+    defer parsed.deinit();
+    if (parsed.value != .array) return req.err("urls must be array");
+    if (parsed.value.array.items.len > MAX_PATTERNS) return req.err("too many patterns");
+
+    var new_list: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (new_list.items) |p| alloc.free(p);
+        new_list.deinit(alloc);
+    }
+    for (parsed.value.array.items) |val| {
+        if (val != .string) return req.err("pattern not string");
+        if (val.string.len == 0 or val.string.len > MAX_PATTERN_LEN) return req.err("invalid pattern");
+        const owned = alloc.dupe(u8, val.string) catch return req.err("alloc");
+        new_list.append(alloc, owned) catch {
+            alloc.free(owned);
+            return req.err("alloc");
+        };
+    }
+
+    allowed_mutex.lockUncancelable(pluginIo());
+    defer allowed_mutex.unlock(pluginIo());
+    clearAllowed();
+    allowed_urls.deinit(alloc);
+    allowed_urls = new_list;
+    return req.okRaw("{\"ok\":true}");
+}
+
+fn httpGetAllowedUrls(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    allowed_mutex.lockUncancelable(pluginIo());
+    defer allowed_mutex.unlock(pluginIo());
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(req.arena);
+    out.appendSlice(req.arena, "{\"urls\":[") catch return req.err("alloc");
+    for (allowed_urls.items, 0..) |pat, i| {
+        if (i > 0) out.append(req.arena, ',') catch return req.err("alloc");
+        out.append(req.arena, '"') catch return req.err("alloc");
+        appendJsonEscaped(&out, req.arena, pat) catch return req.err("alloc");
+        out.append(req.arena, '"') catch return req.err("alloc");
+    }
+    out.appendSlice(req.arena, "]}") catch return req.err("alloc");
+    const final = out.toOwnedSlice(req.arena) catch return req.err("alloc");
+    return req.okRaw(final);
+}
+
+comptime {
+    _ = suji.exportApp(app);
+}

--- a/plugins/http/zig/build.zig
+++ b/plugins/http/zig/build.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const util_mod = b.createModule(.{
+        .root_source_file = b.path("../../../src/core/util.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const suji_mod = b.createModule(.{
+        .root_source_file = b.path("../../../src/core/app.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    suji_mod.addImport("util", util_mod);
+
+    const lib = b.addLibrary(.{
+        .name = "backend",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("app.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+        .linkage = .dynamic,
+    });
+    lib.root_module.addImport("suji", suji_mod);
+
+    if (target.result.os.tag == .windows) {
+        lib.root_module.linkSystemLibrary("ws2_32", .{});
+        lib.root_module.linkSystemLibrary("crypt32", .{});
+        lib.root_module.linkSystemLibrary("ncrypt", .{});
+        lib.root_module.linkSystemLibrary("bcrypt", .{});
+    }
+
+    b.installArtifact(lib);
+}

--- a/tests/e2e/run-plugin-wrappers.sh
+++ b/tests/e2e/run-plugin-wrappers.sh
@@ -8,4 +8,4 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
-bun test plugins/state/js/src plugins/state/node/src plugins/sqlite/js/src plugins/sqlite/node/src plugins/log/js/src plugins/log/node/src plugins/store/js/src plugins/store/node/src
+bun test plugins/state/js/src plugins/state/node/src plugins/sqlite/js/src plugins/sqlite/node/src plugins/log/js/src plugins/log/node/src plugins/store/js/src plugins/store/node/src plugins/http/js/src plugins/http/node/src

--- a/tests/http_plugin_test.zig
+++ b/tests/http_plugin_test.zig
@@ -1,0 +1,266 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const loader = @import("loader");
+
+const PLUGIN_PATH = switch (builtin.os.tag) {
+    .macos => "plugins/http/zig/zig-out/lib/libbackend.dylib",
+    .linux => "plugins/http/zig/zig-out/lib/libbackend.so",
+    .windows => "plugins/http/zig/zig-out/bin/backend.dll",
+    else => @compileError("unsupported OS"),
+};
+
+fn loadHttp(reg: *loader.BackendRegistry) !void {
+    try reg.register("http", PLUGIN_PATH);
+}
+
+fn invokePlugin(reg: *loader.BackendRegistry, request: []const u8) ?[]const u8 {
+    // 일부 테스트(MAX_PATTERNS=256+, MAX_URL_LEN=4096+) 가 8KB+ 페이로드를 보낸다.
+    const a = std.heap.page_allocator;
+    const buf = a.allocSentinel(u8, request.len, 0) catch return null;
+    defer a.free(buf);
+    @memcpy(buf, request);
+    return reg.invoke("http", buf);
+}
+
+fn freeResp(reg: *const loader.BackendRegistry, resp: ?[]const u8) void {
+    reg.freeResponse("http", resp);
+}
+
+test "http plugin: load" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+    try std.testing.expect(reg.get("http") != null);
+}
+
+test "http plugin: fetch denied by default (deny-by-default)" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    // 다른 테스트가 set_allowed_urls 를 호출했을 수 있으므로 초기화.
+    const c = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[]}");
+    defer freeResp(&reg, c);
+
+    const r = invokePlugin(&reg, "{\"cmd\":\"http:fetch\",\"url\":\"https://example.com/\"}");
+    defer freeResp(&reg, r);
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\":\"forbidden\"") != null);
+}
+
+test "http plugin: invalid scheme rejected" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const set_resp = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"*\"]}");
+    defer freeResp(&reg, set_resp);
+
+    const bad = [_][]const u8{
+        "{\"cmd\":\"http:fetch\",\"url\":\"file:///etc/passwd\"}",
+        "{\"cmd\":\"http:fetch\",\"url\":\"javascript:alert(1)\"}",
+        "{\"cmd\":\"http:fetch\",\"url\":\"data:text/plain,x\"}",
+        "{\"cmd\":\"http:fetch\",\"url\":\"\"}",
+    };
+    for (bad) |req| {
+        const r = invokePlugin(&reg, req);
+        defer freeResp(&reg, r);
+        try std.testing.expect(r != null);
+        try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\"") != null);
+    }
+}
+
+test "http plugin: invalid method rejected" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const set_resp = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"*\"]}");
+    defer freeResp(&reg, set_resp);
+
+    const r = invokePlugin(&reg, "{\"cmd\":\"http:fetch\",\"url\":\"https://x/\",\"method\":\"DELETE\"}");
+    defer freeResp(&reg, r);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\":\"method not allowed\"") != null);
+}
+
+test "http plugin: set / get allowed urls round-trip" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const s = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"https://api.x/*\",\"https://*.y.com/*\"]}");
+    defer freeResp(&reg, s);
+    try std.testing.expect(std.mem.indexOf(u8, s.?, "\"ok\":true") != null);
+
+    const g = invokePlugin(&reg, "{\"cmd\":\"http:get_allowed_urls\"}");
+    defer freeResp(&reg, g);
+    try std.testing.expect(std.mem.indexOf(u8, g.?, "\"https://api.x/*\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, g.?, "\"https://*.y.com/*\"") != null);
+}
+
+test "http plugin: set_allowed_urls rejects non-string and oversized" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const non_string = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[123]}");
+    defer freeResp(&reg, non_string);
+    try std.testing.expect(std.mem.indexOf(u8, non_string.?, "\"error\"") != null);
+
+    const non_array = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":\"not-array\"}");
+    defer freeResp(&reg, non_array);
+    try std.testing.expect(std.mem.indexOf(u8, non_array.?, "\"error\"") != null);
+}
+
+test "http plugin: glob matching gates allowlist" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const s = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"https://api.allowed/*\"]}");
+    defer freeResp(&reg, s);
+
+    // 매치 — 실제 네트워크 시도 (이름이 없는 호스트 → fetch failed). 그래도 forbidden 이 아니어야 함.
+    const r_match = invokePlugin(&reg, "{\"cmd\":\"http:fetch\",\"url\":\"https://api.allowed/v1\"}");
+    defer freeResp(&reg, r_match);
+    try std.testing.expect(r_match != null);
+    try std.testing.expect(std.mem.indexOf(u8, r_match.?, "\"error\":\"forbidden\"") == null);
+
+    // 불일치 — forbidden.
+    const r_nomatch = invokePlugin(&reg, "{\"cmd\":\"http:fetch\",\"url\":\"https://api.blocked/v1\"}");
+    defer freeResp(&reg, r_nomatch);
+    try std.testing.expect(std.mem.indexOf(u8, r_nomatch.?, "\"error\":\"forbidden\"") != null);
+}
+
+test "http plugin: userinfo authority bypass blocked" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    // allowlist 가 가장 느슨한 `*` 라도 userinfo 가 있는 URL 은 거부 — glob 매칭은
+    // raw URL 대상이라 `https://allowed@evil.com/` 는 `https://allowed*` 통과하지만
+    // 실제 연결은 `evil.com` 이라는 SSRF 우회. authority 안 `@` 차단으로 sealed.
+    const s = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"*\"]}");
+    defer freeResp(&reg, s);
+
+    const cases = [_][]const u8{
+        "{\"cmd\":\"http:fetch\",\"url\":\"https://allowed.com@evil.com/path\"}",
+        "{\"cmd\":\"http:fetch\",\"url\":\"http://user:pass@evil/\"}",
+    };
+    for (cases) |req| {
+        const r = invokePlugin(&reg, req);
+        defer freeResp(&reg, r);
+        try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\":\"userinfo not allowed\"") != null);
+    }
+}
+
+test "http plugin: CRLF byte injection in URL blocked" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const s = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"*\"]}");
+    defer freeResp(&reg, s);
+
+    // extractJsonString 은 raw substring 반환 — 실 CR/LF 바이트를 보내야 검증 가능.
+    // 정상 JSON 은 string literal 안 unescaped CR/LF 금지지만, 우리 추출기는
+    // JSON 디코드 안 함 → byte-level 검증 효력 유지(SDK 정직 한계 인지하고 가드).
+    const req_bytes = "{\"cmd\":\"http:fetch\",\"url\":\"https://x.com/\r\nHost: evil\"}";
+    const r = invokePlugin(&reg, req_bytes);
+    defer freeResp(&reg, r);
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\":\"invalid url\"") != null);
+}
+
+test "http plugin: setAllowedUrls replaces (not appends)" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const s1 = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"https://first.com/*\"]}");
+    defer freeResp(&reg, s1);
+    const s2 = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"https://second.com/*\"]}");
+    defer freeResp(&reg, s2);
+
+    const g = invokePlugin(&reg, "{\"cmd\":\"http:get_allowed_urls\"}");
+    defer freeResp(&reg, g);
+    try std.testing.expect(std.mem.indexOf(u8, g.?, "\"https://first.com/*\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, g.?, "\"https://second.com/*\"") != null);
+
+    const r = invokePlugin(&reg, "{\"cmd\":\"http:fetch\",\"url\":\"https://first.com/v1\"}");
+    defer freeResp(&reg, r);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\":\"forbidden\"") != null);
+}
+
+test "http plugin: MAX_PATTERNS limit enforced" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    // 257 patterns — MAX_PATTERNS=256 초과 → 거부.
+    var payload: std.ArrayList(u8) = .empty;
+    defer payload.deinit(std.heap.page_allocator);
+    try payload.appendSlice(std.heap.page_allocator, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[");
+    var i: usize = 0;
+    while (i < 257) : (i += 1) {
+        if (i > 0) try payload.append(std.heap.page_allocator, ',');
+        var buf: [32]u8 = undefined;
+        const s = try std.fmt.bufPrint(&buf, "\"https://p{d}/*\"", .{i});
+        try payload.appendSlice(std.heap.page_allocator, s);
+    }
+    try payload.appendSlice(std.heap.page_allocator, "]}");
+
+    const r = invokePlugin(&reg, payload.items);
+    defer freeResp(&reg, r);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\":\"too many patterns\"") != null);
+}
+
+test "http plugin: oversized pattern rejected" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    var payload: std.ArrayList(u8) = .empty;
+    defer payload.deinit(std.heap.page_allocator);
+    try payload.appendSlice(std.heap.page_allocator, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"");
+    var i: usize = 0;
+    while (i < 1100) : (i += 1) try payload.append(std.heap.page_allocator, 'a');
+    try payload.appendSlice(std.heap.page_allocator, "\"]}");
+
+    const r = invokePlugin(&reg, payload.items);
+    defer freeResp(&reg, r);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\":\"invalid pattern\"") != null);
+}
+
+test "http plugin: oversized URL rejected" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const s = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"*\"]}");
+    defer freeResp(&reg, s);
+
+    var payload: std.ArrayList(u8) = .empty;
+    defer payload.deinit(std.heap.page_allocator);
+    try payload.appendSlice(std.heap.page_allocator, "{\"cmd\":\"http:fetch\",\"url\":\"https://x/");
+    var i: usize = 0;
+    while (i < 4200) : (i += 1) try payload.append(std.heap.page_allocator, 'p');
+    try payload.appendSlice(std.heap.page_allocator, "\"}");
+
+    const r = invokePlugin(&reg, payload.items);
+    defer freeResp(&reg, r);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\":\"invalid url\"") != null);
+}


### PR DESCRIPTION
## Summary
- 새 공식 플러그인 `@suji/plugin-http` — renderer-safe HTTP fetch (Electron `net.fetch` + `webRequest` allowlist 패턴)
- 채널: `http:fetch` / `http:set_allowed_urls` / `http:get_allowed_urls`
- **deny-by-default** (allowlist 빈 상태 = 모든 fetch 차단, fs 동형)
- 데스크톱 `suji.http.fetch` 는 backend-only — 이 플러그인은 renderer 접근을 명시적 게이트로 열어준다

## Code-review max (5-angle) — 3 critical SECURITY fixes
- **redirect SSRF 차단** — `client.fetch redirect_behavior=.not_allowed`. std.http.Client 가 기본 redirect 자동 따라가는데, allowlist 가 최초 URL 만 검증해서 `https://allowed/r` → 3xx → `http://169.254.169.254/*` 우회 가능했음.
- **userinfo authority 차단** — `https://allowed.com@evil.com/` 같은 URL 은 glob `https://allowed*` 매치되지만 실 연결은 `evil.com` (SSRF). authority 안 `@` 사전 거부 (RFC 3986).
- **CRLF/NUL byte URL 거부** — header injection 사전 가드.

## Known limitation (정직 경계)
- 응답 크기 한도는 post-allocation 검사 (16MB cap). 진정한 streaming bound 는 후속 (Request 저수준 API + bounded reader).
- v1 헤더 미지원 — Cookie/Authorization 누출 위험 회피용. 후속에서 allowlist 화이트리스트 형태로 노출 검토.

## Test plan
- [x] `zig build test-http` — 13/13 DLL (deny-by-default, scheme/method/userinfo/CRLF 거부, allowlist replace 시맨틱, MAX_PATTERNS/PATTERN_LEN/URL_LEN 한도)
- [x] `bash tests/e2e/run-plugin-wrappers.sh` — 153/153 (10 파일, http JS+Node 신규 12 포함)
- [x] `zig build test` — 862/871 (regression 0)
- [ ] macOS/Linux 빌드 — Windows-only TLS 시스템 라이브러리 (ws2_32/crypt32/ncrypt/bcrypt) 게이트로 격리, CI 에서 검증