### PR TITLE
notification-rich: re-enable image with plugin-side allowlist

### DIFF
--- a/plugins/notification-rich/js/src/index.test.ts
+++ b/plugins/notification-rich/js/src/index.test.ts
@@ -61,3 +61,33 @@ describe("error propagation", () => {
     );
   });
 });
+
+describe("richNotification image + allowlist", () => {
+  it("show passes image through", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { id: 1 } });
+    await richNotification.show({ title: "T", body: "B", image: "C:/Users/me/icons/x.png" });
+    expect(mockBridge.invoke).toHaveBeenCalledWith("notification:rich_show", {
+      title: "T",
+      body: "B",
+      image: "C:/Users/me/icons/x.png",
+    });
+  });
+
+  it("setImageRoots routes roots array", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true } });
+    await richNotification.setImageRoots(["C:/icons", "D:/img"]);
+    expect(mockBridge.invoke).toHaveBeenCalledWith("notification:set_image_roots", {
+      roots: ["C:/icons", "D:/img"],
+    });
+  });
+
+  it("getImageRoots returns array", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { roots: ["C:/a"] } });
+    expect(await richNotification.getImageRoots()).toEqual(["C:/a"]);
+  });
+
+  it("getImageRoots returns empty when missing", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: {} });
+    expect(await richNotification.getImageRoots()).toEqual([]);
+  });
+});

--- a/plugins/notification-rich/js/src/index.ts
+++ b/plugins/notification-rich/js/src/index.ts
@@ -40,6 +40,9 @@ export interface ShowOpts {
   title: string;
   body: string;
   actions?: ToastAction[];
+  /** 이미지 파일 절대 경로. setImageRoots 로 등록된 root 안에 있어야 표시되고
+   * 아니면 silently 무시(toast 는 image 없이 표시). */
+  image?: string;
   scenario?: "alarm" | "reminder" | "incomingCall" | "urgent";
   silent?: boolean;
 }
@@ -56,6 +59,7 @@ export const richNotification = {
       title: opts.title,
       body: opts.body,
       ...(opts.actions ? { actions: opts.actions } : {}),
+      ...(opts.image ? { image: opts.image } : {}),
       ...(opts.scenario ? { scenario: opts.scenario } : {}),
       ...(opts.silent !== undefined ? { silent: opts.silent } : {}),
     });
@@ -64,5 +68,16 @@ export const richNotification = {
 
   async hide(id: number): Promise<void> {
     await call("notification:rich_hide", { id });
+  },
+
+  /** image 경로 allowlist 설정 — fs sandbox 와 동형(deny-by-default, ".." 차단,
+   * prefix + separator boundary, `["*"]` = escape hatch). */
+  async setImageRoots(roots: string[]): Promise<void> {
+    await call("notification:set_image_roots", { roots });
+  },
+
+  async getImageRoots(): Promise<string[]> {
+    const r = await call("notification:get_image_roots", {});
+    return (r?.roots ?? []) as string[];
   },
 };

--- a/plugins/notification-rich/node/src/index.test.ts
+++ b/plugins/notification-rich/node/src/index.test.ts
@@ -61,4 +61,19 @@ describe("richNotification Node — channel routing", () => {
     const r = await richNotification.show({ title: "T", body: "B" });
     expect(r.id).toBe(0);
   });
+
+  it("show passes image", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"id":1}}');
+    await richNotification.show({ title: "T", body: "B", image: "C:/x.png" });
+    expect(lastPayload()).toEqual({ cmd: "notification:rich_show", title: "T", body: "B", image: "C:/x.png" });
+  });
+
+  it("setImageRoots / getImageRoots round-trip", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true}}');
+    await richNotification.setImageRoots(["C:/icons"]);
+    expect(lastPayload()).toEqual({ cmd: "notification:set_image_roots", roots: ["C:/icons"] });
+
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"roots":["C:/icons"]}}');
+    expect(await richNotification.getImageRoots()).toEqual(["C:/icons"]);
+  });
 });

--- a/plugins/notification-rich/node/src/index.ts
+++ b/plugins/notification-rich/node/src/index.ts
@@ -38,6 +38,9 @@ export interface ShowOpts {
   title: string;
   body: string;
   actions?: ToastAction[];
+  /** 이미지 파일 절대 경로. setImageRoots 로 등록된 root 안에 있어야 표시되고
+   * 아니면 silently 무시. */
+  image?: string;
   scenario?: "alarm" | "reminder" | "incomingCall" | "urgent";
   silent?: boolean;
 }
@@ -48,6 +51,7 @@ export const richNotification = {
       title: opts.title,
       body: opts.body,
       ...(opts.actions ? { actions: opts.actions } : {}),
+      ...(opts.image ? { image: opts.image } : {}),
       ...(opts.scenario ? { scenario: opts.scenario } : {}),
       ...(opts.silent !== undefined ? { silent: opts.silent } : {}),
     });
@@ -56,5 +60,14 @@ export const richNotification = {
 
   async hide(id: number): Promise<void> {
     await call("notification:rich_hide", { id });
+  },
+
+  async setImageRoots(roots: string[]): Promise<void> {
+    await call("notification:set_image_roots", { roots });
+  },
+
+  async getImageRoots(): Promise<string[]> {
+    const r = await call("notification:get_image_roots", {});
+    return (r?.roots ?? []) as string[];
   },
 };

--- a/plugins/notification-rich/zig/app.zig
+++ b/plugins/notification-rich/zig/app.zig
@@ -26,7 +26,9 @@ const suji = @import("suji");
 pub const app = suji.app()
     .named("notification-rich")
     .handle("notification:rich_show", richShow)
-    .handle("notification:rich_hide", richHide);
+    .handle("notification:rich_hide", richHide)
+    .handle("notification:set_image_roots", setImageRoots)
+    .handle("notification:get_image_roots", getImageRoots);
 
 var gpa: std.heap.DebugAllocator(.{}) = .init;
 const alloc = gpa.allocator();
@@ -36,6 +38,9 @@ const MAX_BODY: usize = 1024;
 const MAX_ACTIONS: usize = 5;
 const MAX_LABEL: usize = 64;
 const MAX_ID: usize = 64;
+const MAX_IMAGE_PATH: usize = 4096;
+const MAX_IMAGE_ROOTS: usize = 32;
+const MAX_ROOT_LEN: usize = 4096;
 
 var next_id: u64 = 1;
 var id_mutex: std.Io.Mutex = .init;
@@ -48,9 +53,85 @@ fn nextId() u64 {
 }
 
 // ============================================
+// Image path allowlist — fs sandbox 와 동형:
+//   * "..": 어떤 모드든 차단 (path traversal)
+//   * roots 비어 있음 → 모든 image 차단 (deny-by-default)
+//   * 매칭은 prefix + separator boundary (/foo/bar 허용 시 /foo/barX 통과 X)
+//   * ["*"] = escape hatch (".." 만 차단)
+// ============================================
+
+var image_roots: std.ArrayList([]const u8) = .empty;
+var image_roots_mutex: std.Io.Mutex = .init;
+
+fn clearImageRoots() void {
+    for (image_roots.items) |r| alloc.free(r);
+    image_roots.clearRetainingCapacity();
+}
+
+fn hasParentTraversal(path: []const u8) bool {
+    // ".." path component 검출 — / 와 \ 둘 다 separator 로 취급.
+    var i: usize = 0;
+    while (i < path.len) {
+        // 다음 component 의 시작
+        const start = i;
+        while (i < path.len and path[i] != '/' and path[i] != '\\') : (i += 1) {}
+        if (std.mem.eql(u8, path[start..i], "..")) return true;
+        if (i < path.len) i += 1; // separator 건너뛰기
+    }
+    return false;
+}
+
+fn pathPrefixMatchesRoot(path: []const u8, root: []const u8) bool {
+    if (root.len == 0) return false;
+    if (path.len < root.len) return false;
+    // 대소문자 구분 (Windows 도 OS 호출은 case-insensitive 지만 우리는 strict).
+    if (!std.mem.startsWith(u8, path, root)) return false;
+    if (path.len == root.len) return true;
+    // separator boundary — root 끝이 / 거나 \ 면 OK, 아니면 다음 char 가 separator 여야.
+    const last = root[root.len - 1];
+    if (last == '/' or last == '\\') return true;
+    const next = path[root.len];
+    return next == '/' or next == '\\';
+}
+
+fn isImageAllowed(path: []const u8) bool {
+    if (path.len == 0 or path.len > MAX_IMAGE_PATH) return false;
+    if (hasParentTraversal(path)) return false;
+    image_roots_mutex.lockUncancelable(suji.io());
+    defer image_roots_mutex.unlock(suji.io());
+    if (image_roots.items.len == 0) return false;
+    for (image_roots.items) |root| {
+        if (std.mem.eql(u8, root, "*")) return true; // escape hatch
+        if (pathPrefixMatchesRoot(path, root)) return true;
+    }
+    return false;
+}
+
+// ============================================
 // JSON helpers
 // ============================================
 
+/// JSON output 용 진짜 JSON 이스케이프 — `"\` 와 제어문자 처리.
+fn realJsonEscapeAppend(buf: *std.ArrayList(u8), a: std.mem.Allocator, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '"' => try buf.appendSlice(a, "\\\""),
+            '\\' => try buf.appendSlice(a, "\\\\"),
+            '\n' => try buf.appendSlice(a, "\\n"),
+            '\r' => try buf.appendSlice(a, "\\r"),
+            '\t' => try buf.appendSlice(a, "\\t"),
+            0...8, 11, 12, 14...31 => {
+                var tmp: [6]u8 = undefined;
+                const out = std.fmt.bufPrint(&tmp, "\\u{x:0>4}", .{c}) catch continue;
+                try buf.appendSlice(a, out);
+            },
+            else => try buf.append(a, c),
+        }
+    }
+}
+
+/// XML 콘텐츠/속성 이스케이프 (이름은 jsonEscapeAppend 지만 실제로는 XML/HTML
+/// 엔티티). toast XML body 에서만 사용. ⚠️ JSON output 에는 realJsonEscapeAppend 사용.
 fn jsonEscapeAppend(buf: *std.ArrayList(u8), a: std.mem.Allocator, s: []const u8) !void {
     for (s) |c| {
         switch (c) {
@@ -516,11 +597,14 @@ fn richShow(req: suji.Request, _: suji.InvokeEvent) suji.Response {
     if (body.len > MAX_BODY) return req.err("body too long");
 
     const actions_raw = suji.extractJsonValue(req.raw, "actions");
-    // image: v1 정직 경계 — renderer-supplied 파일 경로를 file:// 로 toast 에
-    // 임베드하면 임의 로컬 파일 접근 가능(allowedRoots fs gate 우회).
-    // 플러그인은 코어의 rendererPathFsGate 에 접근 불가 → v1 image 비활성.
-    // 후속에서 plugin-side allowlist API (`notification:set_image_roots`) 검토.
-    const image_path: ?[]const u8 = null;
+    // image: 플러그인-자체 allowlist (set_image_roots) 통과 시 활성.
+    // deny-by-default — roots 빈 상태 = image 무시(toast 는 표시되지만 image 없음).
+    // 명시적 거부가 아니라 무시 — 호출자 친화(잘못된 image 가 전체 toast 실패시키지 않음).
+    const image_path_raw = req.string("image");
+    const image_path: ?[]const u8 = if (image_path_raw) |p|
+        (if (isImageAllowed(p)) p else null)
+    else
+        null;
     const scenario = req.string("scenario");
     const silent_str = suji.extractJsonValue(req.raw, "silent");
     const silent = if (silent_str) |s| std.mem.eql(u8, std.mem.trim(u8, s, " \t\n\r"), "true") else false;
@@ -565,6 +649,58 @@ fn richHide(req: suji.Request, _: suji.InvokeEvent) suji.Response {
     const ok = if (comptime builtin.os.tag == .windows) winrt.forgetAndHide(@intCast(id_i)) else unreachable;
     if (!ok) return req.err("not_found");
     return req.okRaw("{\"ok\":true}");
+}
+
+fn setImageRoots(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    const raw_array = suji.extractJsonValue(req.raw, "roots") orelse return req.err("missing roots");
+
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, raw_array, .{}) catch return req.err("invalid roots");
+    defer parsed.deinit();
+    if (parsed.value != .array) return req.err("roots must be array");
+    if (parsed.value.array.items.len > MAX_IMAGE_ROOTS) return req.err("too many roots");
+
+    var new_list: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (new_list.items) |p| alloc.free(p);
+        new_list.deinit(alloc);
+    }
+    for (parsed.value.array.items) |val| {
+        if (val != .string) return req.err("root not string");
+        if (val.string.len == 0 or val.string.len > MAX_ROOT_LEN) return req.err("invalid root");
+        // 보안: root 자체에 ".." 가 들어가면 의도된 sandbox 가 아니므로 거부.
+        // ("*" 는 단일 char escape hatch, ".." 검사 통과)
+        if (!std.mem.eql(u8, val.string, "*") and hasParentTraversal(val.string)) return req.err("root has parent traversal");
+        const owned = alloc.dupe(u8, val.string) catch return req.err("alloc");
+        new_list.append(alloc, owned) catch {
+            alloc.free(owned);
+            return req.err("alloc");
+        };
+    }
+
+    image_roots_mutex.lockUncancelable(suji.io());
+    defer image_roots_mutex.unlock(suji.io());
+    clearImageRoots();
+    image_roots.deinit(alloc);
+    image_roots = new_list;
+    return req.okRaw("{\"ok\":true}");
+}
+
+fn getImageRoots(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    image_roots_mutex.lockUncancelable(suji.io());
+    defer image_roots_mutex.unlock(suji.io());
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(req.arena);
+    out.appendSlice(req.arena, "{\"roots\":[") catch return req.err("alloc");
+    for (image_roots.items, 0..) |root, i| {
+        if (i > 0) out.append(req.arena, ',') catch return req.err("alloc");
+        out.append(req.arena, '"') catch return req.err("alloc");
+        realJsonEscapeAppend(&out, req.arena, root) catch return req.err("alloc");
+        out.append(req.arena, '"') catch return req.err("alloc");
+    }
+    out.appendSlice(req.arena, "]}") catch return req.err("alloc");
+    const final = out.toOwnedSlice(req.arena) catch return req.err("alloc");
+    return req.okRaw(final);
 }
 
 comptime {

--- a/tests/notification_rich_plugin_test.zig
+++ b/tests/notification_rich_plugin_test.zig
@@ -146,3 +146,80 @@ test "notification-rich plugin: invalid scenario silently dropped (Windows)" {
     try std.testing.expect(r != null);
     try std.testing.expect(std.mem.indexOf(u8, r.?, "load xml") == null);
 }
+
+test "notification-rich plugin: image roots set/get round-trip" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadPlugin(&reg);
+
+    const s = invokePlugin(&reg, "{\"cmd\":\"notification:set_image_roots\",\"roots\":[\"C:/Users/me/icons\",\"D:/img\"]}");
+    defer freeResp(&reg, s);
+    try std.testing.expect(std.mem.indexOf(u8, s.?, "\"ok\":true") != null);
+
+    const g = invokePlugin(&reg, "{\"cmd\":\"notification:get_image_roots\"}");
+    defer freeResp(&reg, g);
+    try std.testing.expect(std.mem.indexOf(u8, g.?, "\"C:/Users/me/icons\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, g.?, "\"D:/img\"") != null);
+
+    // 두 번째 set 은 replace (append 아님)
+    const s2 = invokePlugin(&reg, "{\"cmd\":\"notification:set_image_roots\",\"roots\":[\"C:/new\"]}");
+    defer freeResp(&reg, s2);
+
+    const g2 = invokePlugin(&reg, "{\"cmd\":\"notification:get_image_roots\"}");
+    defer freeResp(&reg, g2);
+    try std.testing.expect(std.mem.indexOf(u8, g2.?, "\"C:/Users/me/icons\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, g2.?, "\"C:/new\"") != null);
+}
+
+test "notification-rich plugin: image roots reject .. and over-limit" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadPlugin(&reg);
+
+    const cases = [_][]const u8{
+        "{\"cmd\":\"notification:set_image_roots\",\"roots\":[\"C:/../etc\"]}", // traversal
+        "{\"cmd\":\"notification:set_image_roots\",\"roots\":[\"../escape\"]}", // bare ..
+        "{\"cmd\":\"notification:set_image_roots\",\"roots\":[123]}", // non-string
+        "{\"cmd\":\"notification:set_image_roots\",\"roots\":[\"\"]}", // empty
+        "{\"cmd\":\"notification:set_image_roots\",\"roots\":\"not-array\"}", // wrong type
+    };
+    for (cases) |c| {
+        const r = invokePlugin(&reg, c);
+        defer freeResp(&reg, r);
+        try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\"") != null);
+    }
+}
+
+// 이미지 gate 동작: roots 비어 있으면 image 무시 → 정상 show.
+// 화이트리스트 외 경로도 무시. 화이트 안 경로는 XML 에 들어감.
+// 헤드리스에서도 XML build/LoadXml 까지는 검증.
+test "notification-rich plugin: image gated by allowlist (Windows)" {
+    if (comptime builtin.os.tag != .windows) return;
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadPlugin(&reg);
+
+    // roots 비어 → image 무시
+    const s_clear = invokePlugin(&reg, "{\"cmd\":\"notification:set_image_roots\",\"roots\":[]}");
+    defer freeResp(&reg, s_clear);
+
+    const r1 = invokePlugin(&reg, "{\"cmd\":\"notification:rich_show\",\"title\":\"t\",\"body\":\"b\",\"image\":\"C:/blocked/img.png\"}");
+    defer freeResp(&reg, r1);
+    try std.testing.expect(r1 != null);
+    try std.testing.expect(std.mem.indexOf(u8, r1.?, "load xml") == null);
+
+    // 화이트리스트 외 경로 — 무시되어 정상 show
+    const s_set = invokePlugin(&reg, "{\"cmd\":\"notification:set_image_roots\",\"roots\":[\"C:/Users/me/icons\"]}");
+    defer freeResp(&reg, s_set);
+    const r2 = invokePlugin(&reg, "{\"cmd\":\"notification:rich_show\",\"title\":\"t\",\"body\":\"b\",\"image\":\"D:/elsewhere.png\"}");
+    defer freeResp(&reg, r2);
+    try std.testing.expect(std.mem.indexOf(u8, r2.?, "load xml") == null);
+
+    // 화이트리스트 안 경로 — 동일하게 정상 show (XML 안 image 포함)
+    const r3 = invokePlugin(&reg, "{\"cmd\":\"notification:rich_show\",\"title\":\"t\",\"body\":\"b\",\"image\":\"C:/Users/me/icons/app.png\"}");
+    defer freeResp(&reg, r3);
+    try std.testing.expect(std.mem.indexOf(u8, r3.?, "load xml") == null);
+}


### PR DESCRIPTION
## Summary
PR #48 에서 정직 경계로 비활성했던 `image` 필드를 **plugin-side allowlist** 로 보안 격상하여 재활성.

## 새 채널
- `notification:set_image_roots` `{roots: string[]}` → `{ok:true}`
- `notification:get_image_roots` `{}` → `{roots: string[]}`

## allowlist 정책 (`fs.allowedRoots` 동형)
- roots 비어 있음 → image **전부 silently 무시** (deny-by-default)
- `..` path component 차단 (root 자체도 검사)
- prefix + separator boundary (`/foo/bar` 허용 시 `/foo/barX` 통과 X)
- `["*"]` = escape hatch (`..` 만 검사)

## graceful gate
show 의 image 가 gate 통과 못 하면 **silently 무시** — toast 는 image 없이 표시. 호출자 친화 (잘못된 image 가 전체 toast 실패시키지 않음). 명시적 거부가 필요하면 setImageRoots 응답으로 검증.

## 부수 정정
`realJsonEscapeAppend` 추가 — 기존 `jsonEscapeAppend` 는 misnomer (XML 엔티티 이스케이프, XML 콘텐츠 에만 사용). JSON output (`getImageRoots`) 은 진짜 JSON 이스케이프 필요.

## Test plan
- [x] `zig build test-notification-rich` — **10/10** (기존 7 + 3 신규: set/get round-trip, .. + invalid 거부, gate 동작)
- [x] `run-plugin-wrappers.sh` — **169/169** (12 파일, JS+Node 신규 6 케이스)
- [x] `zig build test` — 862/871 (regression 0)