### PR TITLE
http plugin: custom headers with allowlist (Cookie/Authorization opt-in)

### DIFF
--- a/plugins/http/js/src/index.test.ts
+++ b/plugins/http/js/src/index.test.ts
@@ -65,3 +65,32 @@ describe("error propagation", () => {
     await expect(http.fetch("https://blocked/")).rejects.toThrow("http: forbidden");
   });
 });
+
+describe("http headers + allowlist", () => {
+  it("fetch passes headers map", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { status: 200, body: "" } });
+    await http.fetch("https://x/", { headers: { "X-Foo": "bar", Accept: "application/json" } });
+    expect(mockBridge.invoke).toHaveBeenCalledWith("http:fetch", {
+      url: "https://x/",
+      headers: { "X-Foo": "bar", Accept: "application/json" },
+    });
+  });
+
+  it("setAllowedHeaders routes array", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true } });
+    await http.setAllowedHeaders(["X-Custom", "Authorization"]);
+    expect(mockBridge.invoke).toHaveBeenCalledWith("http:set_allowed_headers", {
+      headers: ["X-Custom", "Authorization"],
+    });
+  });
+
+  it("getAllowedHeaders returns array", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { headers: ["X-Custom"] } });
+    expect(await http.getAllowedHeaders()).toEqual(["X-Custom"]);
+  });
+
+  it("getAllowedHeaders returns empty when missing", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: {} });
+    expect(await http.getAllowedHeaders()).toEqual([]);
+  });
+});

--- a/plugins/http/js/src/index.ts
+++ b/plugins/http/js/src/index.ts
@@ -24,6 +24,8 @@ function getBridge(): SujiBridge {
 export interface FetchOpts {
   method?: "GET" | "POST";
   body?: string;
+  /** 헤더 맵. 이름이 setAllowedHeaders 로 등록된 것만 허용. 미허용 시 fetch 거부. */
+  headers?: Record<string, string>;
 }
 
 export interface FetchResponse {
@@ -43,6 +45,7 @@ export const http = {
       url,
       ...(opts.method ? { method: opts.method } : {}),
       ...(opts.body !== undefined ? { body: opts.body } : {}),
+      ...(opts.headers ? { headers: opts.headers } : {}),
     });
     return {
       status: Number(r?.status ?? 0),
@@ -57,5 +60,17 @@ export const http = {
   async getAllowedUrls(): Promise<string[]> {
     const r = await call("http:get_allowed_urls", {});
     return (r?.urls ?? []) as string[];
+  },
+
+  /** 요청 헤더 이름 화이트리스트 (case-insensitive). 정책: deny-by-default —
+   * 등록 안 된 이름은 fetch 거부. Cookie/Authorization 등 누출 위험 헤더는
+   * 명시적 opt-in 만 허용. */
+  async setAllowedHeaders(headers: string[]): Promise<void> {
+    await call("http:set_allowed_headers", { headers });
+  },
+
+  async getAllowedHeaders(): Promise<string[]> {
+    const r = await call("http:get_allowed_headers", {});
+    return (r?.headers ?? []) as string[];
   },
 };

--- a/plugins/http/node/src/index.test.ts
+++ b/plugins/http/node/src/index.test.ts
@@ -58,4 +58,19 @@ describe("http.fetch Node — channel + payload shape", () => {
     expect(r.status).toBe(0);
     expect(r.body).toBe("");
   });
+
+  it("fetch passes headers map", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"status":200,"body":""}}');
+    await http.fetch("https://x/", { headers: { "X-Foo": "bar" } });
+    expect(lastPayload()).toEqual({ cmd: "http:fetch", url: "https://x/", headers: { "X-Foo": "bar" } });
+  });
+
+  it("setAllowedHeaders + getAllowedHeaders", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true}}');
+    await http.setAllowedHeaders(["X-A"]);
+    expect(lastPayload()).toEqual({ cmd: "http:set_allowed_headers", headers: ["X-A"] });
+
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"headers":["X-A"]}}');
+    expect(await http.getAllowedHeaders()).toEqual(["X-A"]);
+  });
 });

--- a/plugins/http/node/src/index.ts
+++ b/plugins/http/node/src/index.ts
@@ -38,6 +38,7 @@ async function call(cmd: string, payload: Record<string, unknown>): Promise<any>
 export interface FetchOpts {
   method?: "GET" | "POST";
   body?: string;
+  headers?: Record<string, string>;
 }
 
 export interface FetchResponse {
@@ -51,6 +52,7 @@ export const http = {
       url,
       ...(opts.method ? { method: opts.method } : {}),
       ...(opts.body !== undefined ? { body: opts.body } : {}),
+      ...(opts.headers ? { headers: opts.headers } : {}),
     });
     return {
       status: Number(r?.status ?? 0),
@@ -65,5 +67,14 @@ export const http = {
   async getAllowedUrls(): Promise<string[]> {
     const r = await call("http:get_allowed_urls", {});
     return (r?.urls ?? []) as string[];
+  },
+
+  async setAllowedHeaders(headers: string[]): Promise<void> {
+    await call("http:set_allowed_headers", { headers });
+  },
+
+  async getAllowedHeaders(): Promise<string[]> {
+    const r = await call("http:get_allowed_headers", {});
+    return (r?.headers ?? []) as string[];
   },
 };

--- a/plugins/http/zig/app.zig
+++ b/plugins/http/zig/app.zig
@@ -23,7 +23,9 @@ pub const app = suji.app()
     .named("http")
     .handle("http:fetch", httpFetch)
     .handle("http:set_allowed_urls", httpSetAllowedUrls)
-    .handle("http:get_allowed_urls", httpGetAllowedUrls);
+    .handle("http:get_allowed_urls", httpGetAllowedUrls)
+    .handle("http:set_allowed_headers", httpSetAllowedHeaders)
+    .handle("http:get_allowed_headers", httpGetAllowedHeaders);
 
 var gpa: std.heap.DebugAllocator(.{}) = .init;
 const alloc = gpa.allocator();
@@ -37,6 +39,10 @@ const MAX_URL_LEN: usize = 4096;
 const MAX_PATTERN_LEN: usize = 1024;
 const MAX_PATTERNS: usize = 256;
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+const MAX_HEADERS_PER_REQUEST: usize = 16;
+const MAX_HEADER_NAME_LEN: usize = 128;
+const MAX_HEADER_VALUE_LEN: usize = 4096;
+const MAX_ALLOWED_HEADERS: usize = 32;
 
 // ============================================
 // Allowlist
@@ -44,6 +50,9 @@ const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 
 var allowed_urls: std.ArrayList([]const u8) = .empty;
 var allowed_mutex: std.Io.Mutex = .init;
+
+var allowed_headers: std.ArrayList([]const u8) = .empty;
+var allowed_headers_mutex: std.Io.Mutex = .init;
 
 fn matchGlob(pattern: []const u8, text: []const u8) bool {
     // src/core/util.zig matchGlob 미러 — 플러그인은 util import 안 함, 동형 구현.
@@ -86,6 +95,44 @@ fn isAllowed(url: []const u8) bool {
 fn clearAllowed() void {
     for (allowed_urls.items) |p| alloc.free(p);
     allowed_urls.clearRetainingCapacity();
+}
+
+fn clearAllowedHeaders() void {
+    for (allowed_headers.items) |h| alloc.free(h);
+    allowed_headers.clearRetainingCapacity();
+}
+
+/// RFC 7230 token char: alpha/digit + !#$%&'*+-.^_`|~
+fn isHeaderTokenChar(c: u8) bool {
+    if (std.ascii.isAlphanumeric(c)) return true;
+    return switch (c) {
+        '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~' => true,
+        else => false,
+    };
+}
+
+fn isValidHeaderName(name: []const u8) bool {
+    if (name.len == 0 or name.len > MAX_HEADER_NAME_LEN) return false;
+    for (name) |c| if (!isHeaderTokenChar(c)) return false;
+    return true;
+}
+
+/// CRLF/NUL 차단 — std.http.Client 도 assert 하지만 정직 경계로 사전 차단.
+fn isValidHeaderValue(value: []const u8) bool {
+    if (value.len > MAX_HEADER_VALUE_LEN) return false;
+    for (value) |c| {
+        if (c == '\r' or c == '\n' or c == 0) return false;
+    }
+    return true;
+}
+
+fn isHeaderAllowed(name: []const u8) bool {
+    allowed_headers_mutex.lockUncancelable(pluginIo());
+    defer allowed_headers_mutex.unlock(pluginIo());
+    for (allowed_headers.items) |allowed| {
+        if (std.ascii.eqlIgnoreCase(allowed, name)) return true;
+    }
+    return false;
 }
 
 // ============================================
@@ -150,6 +197,30 @@ fn httpFetch(req: suji.Request, _: suji.InvokeEvent) suji.Response {
         is_post = body != null;
     }
 
+    // headers 처리 — set_allowed_headers 로 등록한 이름만 허용. 응답에 잘못된
+    // 이름/값이 있으면 fetch 안 시도 하고 즉시 error 반환.
+    var extra_headers: std.ArrayList(std.http.Header) = .empty;
+    defer extra_headers.deinit(req.arena);
+    if (suji.extractJsonValue(req.raw, "headers")) |headers_raw| {
+        const parsed = std.json.parseFromSlice(std.json.Value, alloc, headers_raw, .{}) catch return req.err("invalid headers");
+        defer parsed.deinit();
+        if (parsed.value != .object) return req.err("headers must be object");
+        if (parsed.value.object.count() > MAX_HEADERS_PER_REQUEST) return req.err("too many headers");
+        var iter = parsed.value.object.iterator();
+        while (iter.next()) |entry| {
+            const name = entry.key_ptr.*;
+            if (entry.value_ptr.* != .string) return req.err("header value not string");
+            const value = entry.value_ptr.*.string;
+            if (!isValidHeaderName(name)) return req.err("invalid header name");
+            if (!isValidHeaderValue(value)) return req.err("invalid header value");
+            if (!isHeaderAllowed(name)) return req.err("header not allowed");
+            // arena 에 복제 — parsed 의 lifetime 은 이 블록만, fetch 호출시까지 살아야 함.
+            const name_dup = req.arena.dupe(u8, name) catch return req.err("alloc");
+            const value_dup = req.arena.dupe(u8, value) catch return req.err("alloc");
+            extra_headers.append(req.arena, .{ .name = name_dup, .value = value_dup }) catch return req.err("alloc");
+        }
+    }
+
     var client: std.http.Client = .{ .allocator = alloc, .io = pluginIo() };
     defer client.deinit();
 
@@ -169,6 +240,7 @@ fn httpFetch(req: suji.Request, _: suji.InvokeEvent) suji.Response {
     const r = client.fetch(.{
         .location = .{ .url = url },
         .payload = fetch_payload,
+        .extra_headers = extra_headers.items,
         .response_writer = &resp_writer,
         .redirect_behavior = .not_allowed,
     }) catch |e| {
@@ -220,6 +292,55 @@ fn httpSetAllowedUrls(req: suji.Request, _: suji.InvokeEvent) suji.Response {
     allowed_urls.deinit(alloc);
     allowed_urls = new_list;
     return req.okRaw("{\"ok\":true}");
+}
+
+fn httpSetAllowedHeaders(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    const raw_array = suji.extractJsonValue(req.raw, "headers") orelse return req.err("missing headers");
+
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, raw_array, .{}) catch return req.err("invalid headers");
+    defer parsed.deinit();
+    if (parsed.value != .array) return req.err("headers must be array");
+    if (parsed.value.array.items.len > MAX_ALLOWED_HEADERS) return req.err("too many headers");
+
+    var new_list: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (new_list.items) |h| alloc.free(h);
+        new_list.deinit(alloc);
+    }
+    for (parsed.value.array.items) |val| {
+        if (val != .string) return req.err("header name not string");
+        if (!isValidHeaderName(val.string)) return req.err("invalid header name");
+        const owned = alloc.dupe(u8, val.string) catch return req.err("alloc");
+        new_list.append(alloc, owned) catch {
+            alloc.free(owned);
+            return req.err("alloc");
+        };
+    }
+
+    allowed_headers_mutex.lockUncancelable(pluginIo());
+    defer allowed_headers_mutex.unlock(pluginIo());
+    clearAllowedHeaders();
+    allowed_headers.deinit(alloc);
+    allowed_headers = new_list;
+    return req.okRaw("{\"ok\":true}");
+}
+
+fn httpGetAllowedHeaders(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    allowed_headers_mutex.lockUncancelable(pluginIo());
+    defer allowed_headers_mutex.unlock(pluginIo());
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(req.arena);
+    out.appendSlice(req.arena, "{\"headers\":[") catch return req.err("alloc");
+    for (allowed_headers.items, 0..) |name, i| {
+        if (i > 0) out.append(req.arena, ',') catch return req.err("alloc");
+        out.append(req.arena, '"') catch return req.err("alloc");
+        appendJsonEscaped(&out, req.arena, name) catch return req.err("alloc");
+        out.append(req.arena, '"') catch return req.err("alloc");
+    }
+    out.appendSlice(req.arena, "]}") catch return req.err("alloc");
+    const final = out.toOwnedSlice(req.arena) catch return req.err("alloc");
+    return req.okRaw(final);
 }
 
 fn httpGetAllowedUrls(req: suji.Request, _: suji.InvokeEvent) suji.Response {

--- a/tests/http_plugin_test.zig
+++ b/tests/http_plugin_test.zig
@@ -244,6 +244,94 @@ test "http plugin: oversized pattern rejected" {
     try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\":\"invalid pattern\"") != null);
 }
 
+test "http plugin: allowed_headers round-trip + replace" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const s = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_headers\",\"headers\":[\"X-Test\",\"Authorization\"]}");
+    defer freeResp(&reg, s);
+    try std.testing.expect(std.mem.indexOf(u8, s.?, "\"ok\":true") != null);
+
+    const g = invokePlugin(&reg, "{\"cmd\":\"http:get_allowed_headers\"}");
+    defer freeResp(&reg, g);
+    try std.testing.expect(std.mem.indexOf(u8, g.?, "\"X-Test\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, g.?, "\"Authorization\"") != null);
+
+    // 두 번째 set 은 replace
+    const s2 = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_headers\",\"headers\":[\"Accept\"]}");
+    defer freeResp(&reg, s2);
+    const g2 = invokePlugin(&reg, "{\"cmd\":\"http:get_allowed_headers\"}");
+    defer freeResp(&reg, g2);
+    try std.testing.expect(std.mem.indexOf(u8, g2.?, "\"X-Test\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, g2.?, "\"Accept\"") != null);
+}
+
+test "http plugin: header name validation rejects bad tokens" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const cases = [_][]const u8{
+        "{\"cmd\":\"http:set_allowed_headers\",\"headers\":[\"X:bad\"]}", // colon
+        "{\"cmd\":\"http:set_allowed_headers\",\"headers\":[\"With Space\"]}", // space
+        "{\"cmd\":\"http:set_allowed_headers\",\"headers\":[\"X\\r\\n\"]}", // CRLF
+        "{\"cmd\":\"http:set_allowed_headers\",\"headers\":[\"\"]}", // empty
+        "{\"cmd\":\"http:set_allowed_headers\",\"headers\":[42]}", // non-string
+        "{\"cmd\":\"http:set_allowed_headers\",\"headers\":\"not-array\"}", // wrong type
+    };
+    for (cases) |c| {
+        const r = invokePlugin(&reg, c);
+        defer freeResp(&reg, r);
+        try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\"") != null);
+    }
+}
+
+test "http plugin: fetch headers gated by allowlist" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const s_url = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"https://api.allowed/*\"]}");
+    defer freeResp(&reg, s_url);
+    const s_clear = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_headers\",\"headers\":[]}");
+    defer freeResp(&reg, s_clear);
+
+    // empty allowlist → 미허용 header 거부
+    const r1 = invokePlugin(&reg, "{\"cmd\":\"http:fetch\",\"url\":\"https://api.allowed/v1\",\"headers\":{\"X-Custom\":\"v\"}}");
+    defer freeResp(&reg, r1);
+    try std.testing.expect(std.mem.indexOf(u8, r1.?, "\"error\":\"header not allowed\"") != null);
+
+    // 허용 후 동일 호출 → 다른 에러(네트워크 등)는 가능하지만 header 자체는 통과해야 함
+    const s_set = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_headers\",\"headers\":[\"X-Custom\"]}");
+    defer freeResp(&reg, s_set);
+    const r2 = invokePlugin(&reg, "{\"cmd\":\"http:fetch\",\"url\":\"https://api.allowed/v1\",\"headers\":{\"X-Custom\":\"v\"}}");
+    defer freeResp(&reg, r2);
+    try std.testing.expect(std.mem.indexOf(u8, r2.?, "\"error\":\"header not allowed\"") == null);
+}
+
+test "http plugin: header value CRLF injection blocked" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadHttp(&reg);
+
+    const s_url = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_urls\",\"urls\":[\"*\"]}");
+    defer freeResp(&reg, s_url);
+    const s_h = invokePlugin(&reg, "{\"cmd\":\"http:set_allowed_headers\",\"headers\":[\"X\"]}");
+    defer freeResp(&reg, s_h);
+
+    // JSON 이스케이프 시퀀스 \r\n → 디코드 후 실제 CR/LF 바이트가 헤더 값에 들어감.
+    // 우리 isValidHeaderValue 가 byte-level 로 거부.
+    const req_bytes = "{\"cmd\":\"http:fetch\",\"url\":\"https://x.com/\",\"headers\":{\"X\":\"a\\r\\nHost: evil\"}}";
+    const r = invokePlugin(&reg, req_bytes);
+    defer freeResp(&reg, r);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\":\"invalid header value\"") != null);
+}
+
 test "http plugin: oversized URL rejected" {
     var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
     defer reg.deinit();


### PR DESCRIPTION
## Summary
PR #47 의 v1 미지원이었던 **커스텀 헤더** 활성. 보안: 헤더 이름 **화이트리스트 (deny-by-default)** — 호출자가 명시적으로 등록한 이름만 fetch 요청에 포함 가능. Cookie/Authorization 같은 누출 위험 헤더는 명시적 opt-in.

## 새 채널
- `http:set_allowed_headers` `{headers: string[]}` → `{ok:true}`
- `http:get_allowed_headers` `{}` → `{headers: string[]}`

## http:fetch 새 옵션
- `headers?: Record<string, string>` — 미등록 이름이면 fetch 거부 (`header not allowed`)
- case-insensitive 매칭 (RFC 7230 §3.2)

## 보안 가드
- **이름**: RFC 7230 token 문자만 (alpha/digit/!#$%&'*+-.^_\`|~), 1~128 chars
- **값**: CR/LF/NUL 차단 (CRLF injection 사전 가드, std.http.Client assert 중복 방어), 0~4096 chars
- 요청당 최대 16 헤더, allowlist 최대 32 이름

## Test plan
- [x] `zig build test-http` — **17/17** (기존 13 + 신규 4: set/get round-trip + replace, 토큰 검증, fetch gate, CRLF injection)
- [x] `run-plugin-wrappers.sh` — **175/175** (12 파일, JS+Node 신규 6 케이스)
- [x] `zig build test` — 862/871 (regression 0)