### PR TITLE
feat(ipc): deferred response — printToPDF/capturePage true Promise pattern (closes #16)

### DIFF
--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -686,7 +686,9 @@ pub mod windows {
         )
     }
 
-    /// PDF 인쇄 (콜백 async — 결과는 `window:pdf-print-finished` 이벤트).
+    /// PDF 인쇄. 코어가 CDP 완료까지 응답 보류 → 응답 JSON 에 `success` 직접 포함
+    /// (예: `{"from":"zig-core","cmd":"print_to_pdf","path":"...","success":true}`).
+    /// EventBus emit `window:pdf-print-finished` 도 동시 발화(다른 구독자 호환).
     pub fn print_to_pdf(window_id: u32, path: &str) -> Option<String> {
         invoke(
             "__core__",
@@ -699,8 +701,8 @@ pub mod windows {
     }
 
     /// 페이지 스크린샷 PNG 저장 (Electron `webContents.capturePage`, CDP
-    /// Page.captureScreenshot). 즉시 ack 반환 + 완료는 `window:page-captured`
-    /// 이벤트({path,success}) — caller 가 on 으로 path 매칭(printToPDF 동형).
+    /// Page.captureScreenshot). 코어 deferred response — 응답 JSON 에 `success`
+    /// 직접 포함. EventBus emit `window:page-captured` 도 동시 발화.
     pub fn capture_page(window_id: u32, path: &str) -> Option<String> {
         invoke(
             "__core__",

--- a/packages/suji-js/src/index.test.ts
+++ b/packages/suji-js/src/index.test.ts
@@ -670,26 +670,47 @@ describe("windows.setUserAgent/getUserAgent", () => {
   });
 });
 
-describe("windows.capturePage", () => {
+describe("windows.capturePage (#16 deferred Promise)", () => {
   beforeEach(() => { mockBridge.core.mockClear(); mockBridge.on.mockClear(); });
-  it("capture_page 라우팅 + page-captured 이벤트로 resolve", async () => {
-    mockBridge.core.mockResolvedValueOnce({ ok: true });
-    const p = windows.capturePage(2, "/tmp/s.png");
-    // on('window:page-captured', wrapper) 등록 확인 + coreCall 라우팅
-    expect(mockBridge.on.mock.calls[0][0]).toBe("window:page-captured");
+
+  it("capture_page 라우팅 + coreCall 응답이 곧 결과 (no listener)", async () => {
+    mockBridge.core.mockResolvedValueOnce({ success: true });
+    const r = await windows.capturePage(2, "/tmp/s.png");
     expect(JSON.parse(mockBridge.core.mock.calls[0][0])).toEqual({ cmd: "capture_page", windowId: 2, path: "/tmp/s.png" });
-    // 코어가 완료 이벤트 발화 시뮬
-    const wrapper = mockBridge.on.mock.calls[0][1] as (d: unknown) => void;
-    wrapper({ path: "/tmp/s.png", success: true });
-    expect(await p).toEqual({ success: true });
+    expect(r).toEqual({ success: true });
+    // listener pattern 제거 — on() 호출 없음
+    expect(mockBridge.on).not.toHaveBeenCalled();
   });
-  it("다른 path 이벤트는 무시(매칭 path 만 resolve)", async () => {
-    mockBridge.core.mockResolvedValueOnce({ ok: true });
-    const p = BrowserWindow.fromId(9).capturePage("/a.png");
-    const wrapper = mockBridge.on.mock.calls[0][1] as (d: unknown) => void;
-    wrapper({ path: "/other.png", success: true }); // 무시
-    wrapper({ path: "/a.png", success: false });
-    expect(await p).toEqual({ success: false });
+
+  it("rect 지정 시 clipX/clipY/clipWidth/clipHeight 전송", async () => {
+    mockBridge.core.mockResolvedValueOnce({ success: true });
+    await BrowserWindow.fromId(9).capturePage("/a.png", { x: 10, y: 20, width: 100, height: 50 });
+    expect(JSON.parse(mockBridge.core.mock.calls[0][0])).toEqual({
+      cmd: "capture_page", windowId: 9, path: "/a.png",
+      clipX: 10, clipY: 20, clipWidth: 100, clipHeight: 50,
+    });
+  });
+
+  it("success:false 그대로 반환", async () => {
+    mockBridge.core.mockResolvedValueOnce({ success: false });
+    expect(await windows.capturePage(1, "/x.png")).toEqual({ success: false });
+  });
+});
+
+describe("windows.printToPDF (#16 deferred Promise)", () => {
+  beforeEach(() => { mockBridge.core.mockClear(); mockBridge.on.mockClear(); });
+
+  it("print_to_pdf 라우팅 + 단일 await", async () => {
+    mockBridge.core.mockResolvedValueOnce({ success: true });
+    const r = await windows.printToPDF(1, "/tmp/ok.pdf");
+    expect(JSON.parse(mockBridge.core.mock.calls[0][0])).toEqual({ cmd: "print_to_pdf", windowId: 1, path: "/tmp/ok.pdf" });
+    expect(r).toEqual({ success: true });
+    expect(mockBridge.on).not.toHaveBeenCalled();
+  });
+
+  it("success:false 그대로 반환", async () => {
+    mockBridge.core.mockResolvedValueOnce({ success: false });
+    expect(await windows.printToPDF(1, "/bad.pdf")).toEqual({ success: false });
   });
 });
 

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -464,50 +464,28 @@ export const windows = {
     return coreCall<WindowOpResponse>({ cmd: "stop_find_in_page", windowId, clearSelection });
   },
 
-  /** PDF로 인쇄. CEF는 콜백 기반 async라 두 단계 신호:
-   *  1. 코어 IPC 응답 — 요청 접수만 (CEF에 큐잉됨, 파일 아직 X).
-   *  2. `window:pdf-print-finished` 이벤트({path, success}) — 실 PDF 작성 완료.
-   *  이 SDK는 listener를 path로 매칭해 Promise<{success}>로 단일화 — 사용자는
-   *  await 한 번만. 반환된 success가 false면 PDF 작성 실패 (디스크 권한 등).
-   *
-   *  주의: 같은 path로 동시 인쇄 시 첫 번째 완료 이벤트가 둘 다 resolve. 보통
-   *  사용자 시나리오에서 동시 호출 드물어 OK. */
-  printToPDF(windowId: number, path: string): Promise<{ success: boolean }> {
-    return new Promise((resolve) => {
-      const off = on("window:pdf-print-finished", (data) => {
-        const d = data as { path?: string; success?: boolean };
-        if (d.path === path) {
-          off();
-          resolve({ success: d.success === true });
-        }
-      });
-      coreCall({ cmd: "print_to_pdf", windowId, path });
-    });
+  /** PDF로 인쇄 (Electron `webContents.printToPDF`). 코어가 CDP 완료까지 응답
+   *  보류 → 단일 await 로 결과(`{success}`) 받음. EventBus `window:pdf-print-
+   *  finished` emit 은 다른 구독자(다른 백엔드/창) 호환 유지. */
+  async printToPDF(windowId: number, path: string): Promise<{ success: boolean }> {
+    const r = await coreCall<{ success?: boolean }>({ cmd: "print_to_pdf", windowId, path });
+    return { success: r?.success === true };
   },
 
-  /** 페이지 스크린샷을 PNG 파일로 저장 (Electron `webContents.capturePage`
-   *  대응 — CDP Page.captureScreenshot). printToPDF 와 동일 2단:
-   *  IPC ack 즉시 + `window:page-captured`({path,success}) 이벤트.
+  /** 페이지 스크린샷 PNG 저장 (Electron `webContents.capturePage` — CDP
+   *  Page.captureScreenshot). 코어 deferred response 로 단일 await.
    *  base64 가 IPC 한도(64KB) 초과 가능해 path 파일 방식.
-   *  rect 지정 시 부분 영역만 (Electron `capturePage(rect)`); 미지정=전체. */
-  capturePage(
+   *  rect 지정 시 부분 영역만; 미지정=전체. */
+  async capturePage(
     windowId: number,
     path: string,
     rect?: { x: number; y: number; width: number; height: number },
   ): Promise<{ success: boolean }> {
-    return new Promise((resolve) => {
-      const off = on("window:page-captured", (data) => {
-        const d = data as { path?: string; success?: boolean };
-        if (d.path === path) {
-          off();
-          resolve({ success: d.success === true });
-        }
-      });
-      coreCall({
-        cmd: "capture_page", windowId, path,
-        ...(rect ? { clipX: rect.x, clipY: rect.y, clipWidth: rect.width, clipHeight: rect.height } : {}),
-      });
+    const r = await coreCall<{ success?: boolean }>({
+      cmd: "capture_page", windowId, path,
+      ...(rect ? { clipX: rect.x, clipY: rect.y, clipWidth: rect.width, clipHeight: rect.height } : {}),
     });
+    return { success: r?.success === true };
   },
 
   // ── Phase 17-A: WebContentsView ──

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -679,43 +679,24 @@ export const windows = {
     return invoke<WindowOpResponse>('__core__', { cmd: 'stop_find_in_page', windowId, clearSelection });
   },
 
-  /** PDF 인쇄. CEF는 콜백 async라 두 단계 신호:
-   *  1. 코어 IPC 응답 — 요청 접수만 (CEF에 큐잉, 파일 아직 X).
-   *  2. `window:pdf-print-finished` 이벤트({path, success}) — 실 PDF 작성 완료.
-   *  이 SDK는 listener를 path로 매칭해 Promise<{success}>로 단일화. */
-  printToPDF(windowId: number, path: string): Promise<{ success: boolean }> {
-    return new Promise((resolve) => {
-      const off = on("window:pdf-print-finished", (data) => {
-        const d = data as { path?: string; success?: boolean };
-        if (d.path === path) {
-          off();
-          resolve({ success: d.success === true });
-        }
-      });
-      invoke<WindowOpResponse>('__core__', { cmd: 'print_to_pdf', windowId, path });
-    });
+  /** PDF 인쇄. 코어가 CDP 완료까지 응답 보류 → 단일 await 로 `{success}` 받음.
+   *  EventBus `window:pdf-print-finished` emit 은 다른 구독자 호환 유지. */
+  async printToPDF(windowId: number, path: string): Promise<{ success: boolean }> {
+    const r = await invoke<{ success?: boolean }>('__core__', { cmd: 'print_to_pdf', windowId, path });
+    return { success: r?.success === true };
   },
 
-  /** 페이지 스크린샷 PNG 저장 (Electron `webContents.capturePage`, CDP
-   *  Page.captureScreenshot). printToPDF 동형 2단(ack + window:page-captured). */
-  capturePage(
+  /** 페이지 스크린샷 PNG 저장. 코어 deferred response 로 단일 await. */
+  async capturePage(
     windowId: number,
     path: string,
     rect?: { x: number; y: number; width: number; height: number },
   ): Promise<{ success: boolean }> {
-    return new Promise((resolve) => {
-      const off = on("window:page-captured", (data) => {
-        const d = data as { path?: string; success?: boolean };
-        if (d.path === path) {
-          off();
-          resolve({ success: d.success === true });
-        }
-      });
-      invoke<WindowOpResponse>('__core__', {
-        cmd: 'capture_page', windowId, path,
-        ...(rect ? { clipX: rect.x, clipY: rect.y, clipWidth: rect.width, clipHeight: rect.height } : {}),
-      });
+    const r = await invoke<{ success?: boolean }>('__core__', {
+      cmd: 'capture_page', windowId, path,
+      ...(rect ? { clipX: rect.x, clipY: rect.y, clipWidth: rect.width, clipHeight: rect.height } : {}),
     });
+    return { success: r?.success === true };
   },
 };
 

--- a/packages/suji-node/tests/sdk.test.ts
+++ b/packages/suji-node/tests/sdk.test.ts
@@ -162,21 +162,33 @@ describe("windows.setUserAgent/getUserAgent (node)", () => {
   });
 });
 
-describe("windows.capturePage (node)", () => {
-  test("capture_page 라우팅 + page-captured 이벤트 resolve (path 매칭)", async () => {
+describe("windows.capturePage (node, #16 deferred Promise)", () => {
+  test("capture_page coreCall 응답이 곧 결과 (listener 없음)", async () => {
     const calls: string[] = [];
-    let evCb: ((ch: string, raw: string) => void) | null = null;
+    let onCalled = false;
     (globalThis as any).suji = {
       quit: () => {}, platform: () => "macos", handle: () => {},
-      invoke: async (_b: string, j: string) => { calls.push(j); return JSON.stringify({ ok: true }); },
+      invoke: async (_b: string, j: string) => { calls.push(j); return JSON.stringify({ success: true }); },
       invokeSync: () => "", send: () => {},
-      on: (_e: string, cb: (ch: string, raw: string) => void) => { evCb = cb; return () => {}; },
+      on: () => { onCalled = true; return () => {}; },
       off: () => {}, register: () => {},
     };
-    const p = BrowserWindow.fromId(4).capturePage("/t.png");
+    const r = await BrowserWindow.fromId(4).capturePage("/t.png");
     expect(JSON.parse(calls[0])).toEqual({ cmd: "capture_page", windowId: 4, path: "/t.png" });
-    evCb!("window:page-captured", JSON.stringify({ path: "/other.png", success: true })); // 무시
-    evCb!("window:page-captured", JSON.stringify({ path: "/t.png", success: true }));
-    expect(await p).toEqual({ success: true });
+    expect(r).toEqual({ success: true });
+    expect(onCalled).toBe(false);
+  });
+
+  test("printToPDF coreCall 응답이 곧 결과", async () => {
+    const calls: string[] = [];
+    (globalThis as any).suji = {
+      quit: () => {}, platform: () => "macos", handle: () => {},
+      invoke: async (_b: string, j: string) => { calls.push(j); return JSON.stringify({ success: false }); },
+      invokeSync: () => "", send: () => {},
+      on: () => () => {}, off: () => {}, register: () => {},
+    };
+    const r = await BrowserWindow.fromId(7).printToPDF("/x.pdf");
+    expect(JSON.parse(calls[0])).toEqual({ cmd: "print_to_pdf", windowId: 7, path: "/x.pdf" });
+    expect(r).toEqual({ success: false });
   });
 });

--- a/sdks/suji-go/windows/windows.go
+++ b/sdks/suji-go/windows/windows.go
@@ -174,7 +174,9 @@ func StopFindInPage(windowID uint32, clearSelection bool) string {
 	))
 }
 
-// PrintToPDF는 콜백 async — 결과는 `window:pdf-print-finished` 이벤트.
+// PrintToPDF — 코어가 CDP 완료까지 응답 보류 → 응답 JSON 에 `success` 직접 포함
+// (예: `{"from":"zig-core","cmd":"print_to_pdf","path":"...","success":true}`).
+// EventBus emit `window:pdf-print-finished` 도 동시 발화(다른 구독자 호환).
 func PrintToPDF(windowID uint32, path string) string {
 	return suji.Invoke("__core__", fmt.Sprintf(
 		`{"cmd":"print_to_pdf","windowId":%d,"path":"%s"}`,
@@ -183,8 +185,8 @@ func PrintToPDF(windowID uint32, path string) string {
 }
 
 // CapturePage — 페이지 스크린샷 PNG 저장 (Electron webContents.capturePage,
-// CDP Page.captureScreenshot). 즉시 ack + 완료는 window:page-captured
-// 이벤트({path,success}) — caller 가 on 으로 path 매칭(PrintToPDF 동형).
+// CDP Page.captureScreenshot). 코어 deferred response — 응답 JSON 에 `success`
+// 직접 포함. EventBus emit `window:page-captured` 도 동시 발화.
 func CapturePage(windowID uint32, path string) string {
 	return suji.Invoke("__core__", fmt.Sprintf(
 		`{"cmd":"capture_page","windowId":%d,"path":"%s"}`,

--- a/src/core/window_ipc.zig
+++ b/src/core/window_ipc.zig
@@ -8,6 +8,17 @@ const std = @import("std");
 const window = @import("window");
 const util = @import("util");
 
+// ============================================
+// Deferred response 콜백 (issue #16, Promise pattern)
+// ============================================
+//
+// 일부 핸들러(print_to_pdf/capture_page)는 CDP 콜백 완료 후에야 결과를 안다.
+// `g_defer_response_cb` 가 set 돼 있으면 핸들러가 path 키로 응답을 보류하고
+// (cef.zig pending registry 에 저장) CDP 콜백 시 송신. 미설정(테스트/모바일)
+// 이면 기존 ack-only 동작 fallback. main.zig 가 `cef.cefDeferResponse` 주입.
+pub const DeferResponseFn = *const fn (path: []const u8) bool;
+pub var g_defer_response_cb: ?DeferResponseFn = null;
+
 /// Phase 2.5 — 요청 JSON에 sender 컨텍스트 자동 주입.
 ///   - `__window`: 항상 (sender 창의 WM id)
 ///   - `__window_name`: name이 있고 JSON-safe할 때만
@@ -583,6 +594,13 @@ pub const PrintToPDFReq = struct {
 pub fn handlePrintToPDF(req: PrintToPDFReq, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
     if (response_buf.len < RESPONSE_MIN_LEN) return null;
     const ok = if (wm.printToPDF(req.window_id, req.path)) |_| true else |_| false;
+    // CDP 호출 성공 + defer 가능 → Promise 보류, CDP 콜백에서 응답 송신.
+    // 실패하거나 슬롯 풀이면 즉시 ack 응답(이전 동작 fallback).
+    if (ok) {
+        if (g_defer_response_cb) |cb| {
+            if (cb(req.path)) return null; // sentinel: caller skip immediate response
+        }
+    }
     return respondWindowOp(response_buf, "print_to_pdf", req.window_id, ok);
 }
 
@@ -598,6 +616,11 @@ pub const CapturePageReq = struct {
 pub fn handleCapturePage(req: CapturePageReq, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
     if (response_buf.len < RESPONSE_MIN_LEN) return null;
     const ok = if (wm.capturePage(req.window_id, req.path, req.clip)) |_| true else |_| false;
+    if (ok) {
+        if (g_defer_response_cb) |cb| {
+            if (cb(req.path)) return null; // deferred — emitPageCaptured 가 응답 송신
+        }
+    }
     return respondWindowOp(response_buf, "capture_page", req.window_id, ok);
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1674,6 +1674,9 @@ fn openWindow(
     // CEF IPC 콜백 연결
     cef.setInvokeHandler(&cefInvokeHandler);
     cef.setEmitHandler(&cefEmitHandler);
+    // Deferred response — print_to_pdf/capture_page 가 CDP 콜백 완료까지 응답 보류
+    // (issue #16, SDK 가 listener-leak 없는 단순 await 가능).
+    window_ipc.g_defer_response_cb = &cef.cefDeferResponse;
 
     // WindowManager 배선 (CefNative + EventBusSink)
     var cef_native = cef.CefNative.init(allocator);

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -2437,6 +2437,79 @@ pub const CefNative = struct {
     }
 };
 
+// ============================================
+// Deferred IPC response — Promise-style 직접 응답 (issue #16)
+//
+// 기본 IPC: handleBrowserInvoke → 핸들러 동기 응답 → sendInvokeResponse 즉시.
+// 일부 핸들러(print_to_pdf/capture_page)는 CDP 콜백을 기다려야 결과를 안다.
+// 이전 디자인: ack 즉시 + 별도 EventBus 이벤트(`window:pdf-print-finished` 등) →
+//   SDK 가 path 매칭 listener 로 await. 콜백 미발화 경로(#16)에서 listener leak.
+// 새 디자인: 핸들러가 `cefDeferResponse(path)` 호출 → 호출 컨텍스트(seq_id,
+//   browser, frame) 를 path 키로 보관 + handleBrowserInvoke 는 sendInvokeResponse
+//   skip. CDP 콜백에서 `cefCompletePending(path, result)` → 보관된 컨텍스트로
+//   응답 송신. EventBus emit 은 그대로(다른 구독자 호환).
+// ============================================
+
+/// invoke 핸들러 실행 동안 set — 호출 컨텍스트(응답 송신용).
+/// CEF IPC 가 UI 스레드 단일이라 thread_local 불필요(같은 스레드에서 직렬화).
+const CallCtx = struct {
+    browser: ?*c._cef_browser_t,
+    frame: ?*c._cef_frame_t,
+    seq_id: i32,
+    deferred: bool,
+};
+var g_current_call_ctx: ?CallCtx = null;
+
+const PendingResp = struct {
+    in_use: bool = false,
+    browser: ?*c._cef_browser_t = null,
+    frame: ?*c._cef_frame_t = null,
+    seq_id: i32 = 0,
+    path_buf: [PDF_PATH_STACK_BUF]u8 = undefined,
+    path_len: usize = 0,
+};
+/// CapturePending 과 동등한 16 슬롯 — 동시 deferred 16 까지. 초과 시 fallback
+/// (즉시 ok:false 응답). 헤드리스 e2e 도 동시 8 미만이라 여유.
+var g_pending_responses = [_]PendingResp{.{}} ** 16;
+
+/// 핸들러가 호출: 응답을 보류하고 path 키로 컨텍스트 보관. 슬롯 풀 OR 컨텍스트
+/// 미설정이면 false — 호출자가 즉시 ok:false 응답 fallback.
+pub fn cefDeferResponse(path: []const u8) bool {
+    if (path.len == 0 or path.len > PDF_PATH_STACK_BUF) return false;
+    var ctx = g_current_call_ctx orelse return false;
+    for (&g_pending_responses) |*slot| {
+        if (!slot.in_use) {
+            slot.in_use = true;
+            slot.browser = ctx.browser;
+            slot.frame = ctx.frame;
+            slot.seq_id = ctx.seq_id;
+            @memcpy(slot.path_buf[0..path.len], path);
+            slot.path_len = path.len;
+            ctx.deferred = true;
+            g_current_call_ctx = ctx;
+            return true;
+        }
+    }
+    return false;
+}
+
+/// CDP 콜백 등에서 호출: path 매칭 pending 에 응답 송신.
+/// `result_json` 은 `cefHandleSuji` 가 반환했을 본문 (e.g. `{"cmd":"print_to_pdf",
+/// "windowId":N,"ok":true}`). EventBus emit 은 호출자가 별도로 진행 — 이 함수는
+/// **deferred Promise resolve 만** 담당.
+pub fn cefCompletePending(path: []const u8, result_json: []const u8) bool {
+    for (&g_pending_responses) |*slot| {
+        if (!slot.in_use) continue;
+        const stored = slot.path_buf[0..slot.path_len];
+        if (!std.mem.eql(u8, stored, path)) continue;
+        sendInvokeResponse(slot.browser, slot.frame, slot.seq_id, true, result_json);
+        slot.in_use = false;
+        slot.path_len = 0;
+        return true;
+    }
+    return false;
+}
+
 /// 글로벌 cef_pdf_print_callback_t — 매 print 마다 alloc하면 ref-counted 수명 추적
 /// 부담. 콜백 자체는 stateless (path/success를 인자로 받음) → 글로벌 단일로 안전.
 /// 동시 print 여러 개 호출 시 EventBus emit이 각자 독립으로 발화 (path가 인자에 포함).
@@ -2450,22 +2523,30 @@ fn ensurePdfCallback() void {
     g_pdf_callback_initialized = true;
 }
 
-/// CEF print_to_pdf 완료 콜백 — `window:pdf-print-finished` 이벤트로 emit.
-/// payload: `{"path": "<utf8>", "success": true|false}`. main이 inject한
-/// g_emit_callback 활용 (cef.zig는 backends/loader에 dep 하지 않도록).
+/// CEF print_to_pdf 완료 콜백 — deferred Promise resolve + `window:pdf-print-finished` emit.
 fn onPdfPrintFinished(_: [*c]c.cef_pdf_print_callback_t, path: [*c]const c.cef_string_t, ok: c_int) callconv(.c) void {
-    const emit = g_emit_callback orelse return;
-
     var path_buf: [PDF_PATH_STACK_BUF]u8 = undefined;
     const path_str: []const u8 = if (path) |p| cefStringToUtf8(p, &path_buf) else "";
 
     var escaped_buf: [PDF_PATH_STACK_BUF]u8 = undefined;
     const escaped_n = window_mod.escapeJsonChars(path_str, &escaped_buf);
 
+    // 1) deferred Promise resolve — print_to_pdf 호출자가 await invoke 로 받는 응답.
+    // `ok:true` 는 IPC dispatch 성공(여기 도달한 자체), `success` 는 실 PDF 작성 결과.
+    // 기존 ack 응답 (`{cmd,windowId,ok}`) 의 `ok` 필드 유지 — 호환.
+    var resp_buf: [PDF_PATH_STACK_BUF + 160]u8 = undefined;
+    var rw = std.Io.Writer.fixed(&resp_buf);
+    rw.print(
+        "{{\"from\":\"zig-core\",\"cmd\":\"print_to_pdf\",\"ok\":true,\"path\":\"{s}\",\"success\":{}}}",
+        .{ escaped_buf[0..escaped_n], ok != 0 },
+    ) catch return;
+    _ = cefCompletePending(path_str, rw.buffered());
+
+    // 2) EventBus emit — 다른 SDK/백엔드 구독자 호환 보존.
+    const emit = g_emit_callback orelse return;
     var payload_buf: [PDF_PATH_STACK_BUF + 64]u8 = undefined;
     var w = std.Io.Writer.fixed(&payload_buf);
     w.print("{{\"path\":\"{s}\",\"success\":{}}}", .{ escaped_buf[0..escaped_n], ok != 0 }) catch return;
-
     emit(null, EVENT_PDF_PRINT_FINISHED, w.buffered());
 }
 
@@ -2488,11 +2569,22 @@ pub const EVENT_PDF_PRINT_FINISHED: []const u8 = "window:pdf-print-finished";
 // base64 는 IPC payload 한도(64KB) 초과 가능 → 파일 경로 방식(printToPDF 동일).
 pub const EVENT_PAGE_CAPTURED: []const u8 = "window:page-captured";
 
-/// `window:page-captured`{path,success} 발화 (결과 도착·요청 드롭 공용).
+/// `window:page-captured`{path,success} 발화 + deferred Promise resolve.
 fn emitPageCaptured(path: []const u8, ok: bool) void {
-    const emit = g_emit_callback orelse return;
     var esc: [PDF_PATH_STACK_BUF]u8 = undefined;
     const en = window_mod.escapeJsonChars(path, &esc);
+
+    // 1) deferred Promise resolve. `ok:true` = IPC 성공, `success` = 캡처 결과.
+    var resp_buf: [PDF_PATH_STACK_BUF + 160]u8 = undefined;
+    var rw = std.Io.Writer.fixed(&resp_buf);
+    rw.print(
+        "{{\"from\":\"zig-core\",\"cmd\":\"capture_page\",\"ok\":true,\"path\":\"{s}\",\"success\":{}}}",
+        .{ esc[0..en], ok },
+    ) catch return;
+    _ = cefCompletePending(path, rw.buffered());
+
+    // 2) EventBus emit.
+    const emit = g_emit_callback orelse return;
     var payload: [PDF_PATH_STACK_BUF + 64]u8 = undefined;
     var w = std.Io.Writer.fixed(&payload);
     w.print("{{\"path\":\"{s}\",\"success\":{}}}", .{ esc[0..en], ok }) catch return;
@@ -10915,6 +11007,10 @@ fn handleBrowserInvoke(
         }, &injected_buf) orelse data;
     };
 
+    // 핸들러가 deferred 응답을 등록할 수 있도록 컨텍스트 노출(`cefDeferResponse`).
+    g_current_call_ctx = .{ .browser = browser, .frame = frame, .seq_id = seq_id, .deferred = false };
+    defer g_current_call_ctx = null;
+
     // 백엔드 호출
     var response_buf: [16384]u8 = undefined;
     var success: bool = false;
@@ -10929,12 +11025,16 @@ fn handleBrowserInvoke(
         }
     }
 
+    // 핸들러가 deferred 응답 등록했다면 sendInvokeResponse skip — pending 컨텍스트
+    // 에 보관됐고, CDP 콜백 등에서 cefCompletePending 으로 송신될 것.
+    const deferred = if (g_current_call_ctx) |ctx| ctx.deferred else false;
     if (traceIpcEnabled()) {
-        std.debug.print("[suji:ipc] resp seq={d} success={} result_len={d}\n", .{ seq_id, success, result.len });
+        std.debug.print("[suji:ipc] resp seq={d} success={} result_len={d} deferred={}\n", .{ seq_id, success, result.len, deferred });
     }
 
-    // 응답 CefProcessMessage 생성
-    sendInvokeResponse(browser, frame, seq_id, success, result);
+    if (!deferred) {
+        sendInvokeResponse(browser, frame, seq_id, success, result);
+    }
     if (g_quit_after_next_response) {
         g_quit_after_next_response = false;
         quit();


### PR DESCRIPTION
## Summary
Issue #16 의 listener-leak 을 **IPC 아키텍처 격상**으로 해결. 이전엔 2단계(ack 즉시 + EventBus 이벤트) 디자인이라 이벤트 누락 경로에서 SDK Promise 영원히 unresolved. 이제 코어 IPC 가 **deferred response** 지원 — 핸들러가 CDP 콜백 완료까지 응답을 보류하고 콜백 시 송신. SDK 는 단순 \`await invoke(...)\` 한 줄(Electron 동형).

EventBus emit 은 그대로 유지 → 다른 백엔드/창이 이벤트 구독 가능 (정책 일관성). 호환 BREAK 없음(deferred 응답에 \`ok:true\` 필드 유지).

## 아키텍처
- \`cef.zig\` 새 API: \`cefDeferResponse(path)\` + \`cefCompletePending(path, result_json)\` (16 슬롯 동시 deferred)
- \`handleBrowserInvoke\` 는 invoke 동안 호출 컨텍스트(seq_id+browser+frame) 노출, defer 플래그 시 \`sendInvokeResponse\` skip
- \`onPdfPrintFinished\` / \`emitPageCaptured\` 가 \`cefCompletePending\` + 기존 \`emit\` 둘 다 호출
- \`window_ipc.zig\` 는 \`g_defer_response_cb\` 함수 포인터로 layer 분리 (테스트/모바일 미주입 시 ack-only fallback)

## SDK 변경
4 SDK 모두 \`printToPDF\`/\`capturePage\` 가 listener 패턴 제거 → 단일 \`await\`:
- \`@suji/api\` (JS): \`async\` + \`coreCall\` 응답이 \`success\` 직접 포함
- \`@suji/node\`: 동형
- Rust/Go: invoke 반환 JSON 에 \`success\` 포함 (doc comment 업데이트, 시그니처 무변)

## Test plan
- [x] \`zig build test\` — 863/872 (regression 0)
- [x] \`run-plugin-wrappers.sh\` — 175/175
- [x] \`packages/suji-js\`: 73/73 (capturePage 이벤트 시뮬 테스트를 deferred 단일 await 형태로 교체, printToPDF deferred 검증 추가)
- [x] \`packages/suji-node\`: 62/62
- [ ] e2e (macOS) — \`tests/e2e/run-capture-page.sh\` 동작 확인(ack.ok 호환 유지, EventBus emit 보존)