### PR TITLE
feat(cef): enable GPU acceleration on Linux/Windows (closes #12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -760,9 +760,11 @@ net-control 이라 데이터 유출 sink 아님 → 범위 제외. 모바일은 
   directory picker, custom dialog buttons, notification click)~~ **해결됨**
   (PR #27~#34). `win_pump` 백그라운드 스레드 + hidden message-only window +
   `src/suji.manifest` (Common-Controls v6 + PerMonitorV2) 로 macOS 동등 동작.
-- **Linux/Windows GPU 가속 미지원** (명시적 `--disable-gpu`): [#12](https://github.com/ohah/suji/issues/12)
-  - macOS만 ANGLE Metal 경로로 GPU 활성. Linux/Windows는 SwiftShader CPU 폴백.
-  - asset 배치 로직만 추가하면 됨. 우선순위 낮음.
+- ~~Linux/Windows GPU 가속 미지원 (`--disable-gpu`)~~ **해결됨** ([#12](https://github.com/ohah/suji/issues/12)).
+  CEF runtime asset (libEGL/libGLESv2/vk_swiftshader/vk_swiftshader_icd.json) 가
+  `addInstallCefRuntimeStep` 으로 zig-out/bin 옆에 자동 배치되어 ANGLE/SwiftShader
+  로딩 가능 → WebGL/CSS 합성/비디오 가속 활성. CI headless 환경은 GPU 없어
+  SwiftShader CPU fallback 자동(정상 동작).
 - **`@suji/plugin-notification-rich` macOS/Linux 액션 버튼 미구현**: 현재
   Windows WinRT toast 만 정식 구현. macOS/Linux 는 `unsupported_platform` 반환.
   - macOS: `UNUserNotificationCenter` + `UNNotificationCategory`/

--- a/src/platform/cef_command_line_policy.zig
+++ b/src/platform/cef_command_line_policy.zig
@@ -44,10 +44,12 @@ pub fn switches(platform: Platform, ci_env_value: ?[]const u8) SwitchSet {
     set.add(.{ .name = "disable-background-mode" });
     set.add(.{ .name = "remote-allow-origins", .value = "*" });
 
-    if (platform != .macos) {
-        set.add(.{ .name = "disable-gpu" });
-        set.add(.{ .name = "disable-gpu-compositing" });
-    }
+    // GPU 하드웨어 가속 — 3-OS 활성 (#12). 이전엔 Linux/Windows 에서
+    // disable-gpu/disable-gpu-compositing 명시. CEF 런타임 자산
+    // (libEGL/libGLESv2/vk_swiftshader/vk_swiftshader_icd.json) 이
+    // addInstallCefRuntimeStep 으로 zig-out/bin 옆에 배치되므로 ANGLE/SwiftShader
+    // 가 정상 로딩 → WebGL/CSS 합성/비디오 가속 활성. CI(headless)는 GPU 없어
+    // SwiftShader CPU fallback 으로 자동 전환 — 정상 동작.
 
     if (platform == .linux) {
         set.add(.{ .name = "no-sandbox" });
@@ -84,14 +86,19 @@ test "CEF command switches do not override network service mode in CI" {
     try std.testing.expect(!containsSwitch(macos, "disable-background-networking"));
 }
 
-test "CEF command switches disable GPU on non-macOS platforms" {
+test "CEF command switches enable GPU on all platforms (#12)" {
+    // GPU 가속 활성화 — CEF runtime asset 배치 완료(addInstallCefRuntimeStep).
+    // CI(GPU 없음) 는 SwiftShader CPU fallback 자동.
     const linux = switches(.linux, null).slice();
     const windows = switches(.windows, null).slice();
+    const macos = switches(.macos, null).slice();
 
-    try std.testing.expect(containsSwitch(linux, "disable-gpu"));
-    try std.testing.expect(containsSwitch(linux, "disable-gpu-compositing"));
-    try std.testing.expect(containsSwitch(windows, "disable-gpu"));
-    try std.testing.expect(containsSwitch(windows, "disable-gpu-compositing"));
+    try std.testing.expect(!containsSwitch(linux, "disable-gpu"));
+    try std.testing.expect(!containsSwitch(linux, "disable-gpu-compositing"));
+    try std.testing.expect(!containsSwitch(windows, "disable-gpu"));
+    try std.testing.expect(!containsSwitch(windows, "disable-gpu-compositing"));
+    try std.testing.expect(!containsSwitch(macos, "disable-gpu"));
+    try std.testing.expect(!containsSwitch(macos, "disable-gpu-compositing"));
 }
 
 test "CEF command switches add Linux CI headless guards only when requested" {


### PR DESCRIPTION
## Summary
이슈 #12 — Linux/Windows GPU 하드웨어 가속 활성화.

**핵심 발견**: 이슈가 지목한 \"asset 배치 로직 부재\" 는 PR d98aa1f (CEF runtime packaging, 2026-05-24) 에서 이미 해결되어 있었음. \`addInstallCefRuntimeStep\` 가 zig-out/bin 옆에 GPU asset 4종 자동 staging:
- Windows: \`libEGL.dll\` / \`libGLESv2.dll\` / \`vk_swiftshader.dll\` / \`vk_swiftshader_icd.json\` (+ \`vulkan-1.dll\`)
- Linux: \`libEGL.so\` / \`libGLESv2.so\` / \`libvk_swiftshader.so\` / \`vk_swiftshader_icd.json\` (+ \`libvulkan.so.1\`)

남은 작업은 \`disable-gpu\` 스위치 제거뿐.

## 변경
- \`src/platform/cef_command_line_policy.zig\`: non-macOS 의 \`disable-gpu\` / \`disable-gpu-compositing\` 스위치 제거
- 테스트 갱신: \"disable GPU on non-macOS\" 가드를 \"enable GPU on all platforms\" 회귀 가드로 전환 (3-OS 모두 disable-gpu 부재 확인)
- CLAUDE.md \"알려진 이슈\" 섹션에서 #12 해결됨 표시

## 동작
- 실 GPU 환경: ANGLE 이 D3D11/Vulkan/OpenGL 백엔드 자동 선택 → WebGL/CSS 합성/비디오 가속
- CI/headless: GPU 미감지 → SwiftShader CPU fallback 자동 (현재 동작 유지)

## Test plan
- [x] \`zig build test\` — 863/872 (regression 0)
- [ ] CI headless e2e — SwiftShader fallback 정상 동작 (스위치 부재로 영향 없을 예정)
- [ ] 실 GPU 검증 — 릴리스 체크리스트 (CI runner 에 GPU 없음, 이슈 본문 권고대로)