### PR TITLE
test(e2e): GPU acceleration verification (#12 regression guard)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ bash tests/e2e/run-splash.sh            # 스플래시 스크린 패턴 (windows
 bash tests/e2e/run-web-request.sh       # webRequest URL glob blocklist + completed 이벤트
 bash tests/e2e/run-system-integration.sh # screen/desktopCapturer/crashReporter/app 등 통합
 bash tests/e2e/run-capture-page.sh      # capture_page → 실 PNG 파일(매직바이트)
+bash tests/e2e/run-gpu-accel.sh         # GPU 가속 회귀 가드 (#12) — WebGL ANGLE/D3D11/SwiftShader fallback
 bash tests/e2e/run-set-user-agent.sh    # set_user_agent CDP override 실효(navigator.userAgent)
 bash tests/e2e/run-context-isolation.sh # window.__suji__ frozen/슬롯봉인/변조차단/기능보존
 bash tests/e2e/run-plugin-wrappers.sh   # 공식 플러그인 (state/sqlite/log/store/http/notification-rich) × {JS, Node} wrapper wire-contract (mock bridge)

--- a/tests/e2e/gpu-accel.test.ts
+++ b/tests/e2e/gpu-accel.test.ts
@@ -1,0 +1,67 @@
+// GPU 가속 검증 E2E (#12 회귀 가드)
+//
+// 목적: --disable-gpu 스위치 제거 후 CEF 가 GPU 초기화 정상 + WebGL context 획득.
+// 검증: WebGL 컨텍스트 생성 가능 + 렌더러 정보 추출(스모크). CI 헤드리스에선
+// SwiftShader CPU fallback, 실 GPU 환경에선 하드웨어 (ANGLE D3D11/Metal/...).
+// 어느 경우든 컨텍스트 자체는 살아 있어야 GPU 가속 패스가 정상.
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import puppeteer, { type Browser, type Page } from "puppeteer-core";
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => {
+  browser = await puppeteer.connect({
+    browserURL: "http://localhost:9222",
+    protocolTimeout: 30000,
+    defaultViewport: null,
+  });
+  // 첫 페이지(메인 창)
+  const targets = browser.targets().filter((t) => t.type() === "page");
+  if (targets.length === 0) throw new Error("no page target");
+  page = (await targets[0].page())!;
+});
+
+afterAll(async () => {
+  await browser?.disconnect();
+});
+
+describe("GPU acceleration (#12)", () => {
+  test("WebGL2 컨텍스트 획득 가능 (가속 OR SwiftShader fallback)", async () => {
+    const info = await page.evaluate(() => {
+      const canvas = document.createElement("canvas");
+      const gl = (canvas.getContext("webgl2") ?? canvas.getContext("webgl")) as
+        | WebGL2RenderingContext
+        | WebGLRenderingContext
+        | null;
+      if (!gl) return { ok: false, why: "context null" };
+      const ext = gl.getExtension("WEBGL_debug_renderer_info");
+      const vendor = ext ? gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) : gl.getParameter(gl.VENDOR);
+      const renderer = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER);
+      const version = gl.getParameter(gl.VERSION);
+      return { ok: true, vendor: String(vendor ?? ""), renderer: String(renderer ?? ""), version: String(version ?? "") };
+    });
+
+    console.log("[GPU] WebGL info:", info);
+
+    expect(info.ok).toBe(true);
+    // 어느 백엔드든 vendor/renderer 비어있지 않아야 — 진짜 컨텍스트가 살아있다는 증거
+    expect((info as any).renderer.length).toBeGreaterThan(0);
+  });
+
+  test("canvas 2D context 도 정상", async () => {
+    const ok = await page.evaluate(() => {
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return false;
+      canvas.width = 32;
+      canvas.height = 32;
+      ctx.fillStyle = "rgb(255,0,0)";
+      ctx.fillRect(0, 0, 32, 32);
+      const pixel = ctx.getImageData(0, 0, 1, 1).data;
+      return pixel[0] === 255 && pixel[1] === 0 && pixel[2] === 0;
+    });
+    expect(ok).toBe(true);
+  });
+});

--- a/tests/e2e/run-gpu-accel.sh
+++ b/tests/e2e/run-gpu-accel.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# GPU 가속 회귀 가드 E2E (#12). CEF 초기화 후 WebGL/Canvas2D 컨텍스트 획득
+# 확인 — 가속 활성 OR SwiftShader CPU fallback 둘 다 통과.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SUJI_LOG="${SUJI_LOG:-/tmp/suji-e2e-gpu-accel.log}"
+source "$ROOT/tests/e2e/_common.sh"
+
+e2e_run_test tests/e2e/gpu-accel.test.ts


### PR DESCRIPTION
## Summary
PR #55 가 실제로 GPU 패스를 활성화했는지 **E2E 로 직접 검증**. 처음 PR 머지할 때 unit test 만 돌리고 E2E 안 한 것 후행 보완.

## Windows 로컬 실행 결과
\`\`\`
[GPU] WebGL info: {
  vendor:   "Google Inc. (Microsoft)",
  renderer: "ANGLE (Microsoft, Microsoft Basic Render Driver, D3D11 vs_5_0 ps_5_0, D3D11)",
  version:  "WebGL 2.0 (OpenGL ES 3.0 Chromium)",
}
\`\`\`

**ANGLE → D3D11 백엔드 활성**, WebGL 2.0 컨텍스트 획득. SwiftShader CPU fallback 이 아닌 GPU 친화 패스 (\"Microsoft Basic Render Driver\" 는 실 GPU 드라이버 미설치 환경의 Windows software D3D 구현이지만 ANGLE D3D11 코드 경로 자체는 동일 — 실 GPU 환경에선 그대로 하드웨어 가속). 어느 경우든 컨텍스트 정상 획득을 회귀 가드로 고정.

## Test plan
- [x] Windows: \`bash tests/e2e/run-gpu-accel.sh\` — **2/2 pass** (WebGL2 + Canvas2D)
- [ ] macOS/Linux: CI 검증 (assertion 은 SwiftShader fallback 도 통과하도록 \"컨텍스트 살아있음\" 만 확인)

## 추가 작업
- CLAUDE.md E2E 섹션에 \`run-gpu-accel.sh\` 추가