### PR TITLE
fix(ipc): deferred-response criticals — UAF, slot exhaustion, cross-kind, TTL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ bash tests/e2e/run-splash.sh            # 스플래시 스크린 패턴 (windows
 bash tests/e2e/run-web-request.sh       # webRequest URL glob blocklist + completed 이벤트
 bash tests/e2e/run-system-integration.sh # screen/desktopCapturer/crashReporter/app 등 통합
 bash tests/e2e/run-capture-page.sh      # capture_page → 실 PNG 파일(매직바이트)
+bash tests/e2e/run-deferred-response.sh # deferred-response criticals — cross-kind 라우팅/close-during-defer 무crash/path 라운드트립
 bash tests/e2e/run-gpu-accel.sh         # GPU 가속 회귀 가드 (#12) — WebGL ANGLE/D3D11/SwiftShader fallback
 bash tests/e2e/run-set-user-agent.sh    # set_user_agent CDP override 실효(navigator.userAgent)
 bash tests/e2e/run-context-isolation.sh # window.__suji__ frozen/슬롯봉인/변조차단/기능보존
@@ -778,6 +779,15 @@ net-control 이라 데이터 유출 sink 아님 → 범위 제외. 모바일은 
 - **`@suji/plugin-notification-rich` Windows 액션 클릭 콜백 미구현**:
   WinRT toast 액션 버튼 클릭은 `NotificationActivator` COM 클래스 등록 필요
   (별도 인스톨러 + HKCU 레지스트리). 현재는 표시/Action Center 영속까지만.
+- **deferred-response same-path/same-kind 상관 (의도적 미수정)**: 동일 window·
+  동일 path·동일 종류(`printToPDF`×2 또는 `capturePage`×2)를 **동시** 호출하면
+  두 슬롯이 path 로만 구분돼 완료 콜백이 등록 순서로 매칭(물리적 완료 순서
+  아님). 관측 가능한 차이는 caller 별 `success` bool 뿐이고 디스크 결과는
+  last-writer-wins 로 동일, 동일 조건 print/capture 는 성공/실패가 거의 완벽히
+  상관돼 사실상 비가시. 정직한 correlation-id 재설계는 per-call ref-counted CEF
+  콜백 수명 관리(issue #16 가 leak 이던 표면)를 재도입하므로 비용 대비 가치 낮아
+  미수정. **서로 다른 종류**(print↔capture)의 같은-path 교차충돌은 `kind`
+  디스크리미네이터로 해소됨(PR #54 review #3). UAF/슬롯 고갈/타임아웃은 모두 수정.
 
 ## 구현 노트
 

--- a/packages/suji-js/src/index.test.ts
+++ b/packages/suji-js/src/index.test.ts
@@ -731,6 +731,20 @@ describe("windows.printToPDF (#16 deferred Promise)", () => {
     mockBridge.core.mockResolvedValueOnce({ success: false });
     expect(await windows.printToPDF(1, "/bad.pdf")).toEqual({ success: false });
   });
+
+  // #5 defense-in-depth: 코어가 끝내 응답 안 보내도(never resolve) SDK 타임아웃이
+  // {success:false} 로 settle → Promise 영구 hang 방지.
+  it("코어 무응답 시 타임아웃으로 success:false", async () => {
+    mockBridge.core.mockReturnValueOnce(new Promise(() => {})); // never resolves
+    const r = await windows.printToPDF(1, "/stuck.pdf", { timeoutMs: 10 });
+    expect(r).toEqual({ success: false });
+  });
+
+  it("capturePage 도 코어 무응답 시 타임아웃 success:false", async () => {
+    mockBridge.core.mockReturnValueOnce(new Promise(() => {}));
+    const r = await windows.capturePage(1, "/stuck.png", undefined, { timeoutMs: 10 });
+    expect(r).toEqual({ success: false });
+  });
 });
 
 describe("webRequest.onBeforeRequest timeout fallback", () => {

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -290,6 +290,18 @@ async function coreCall<T>(request: Record<string, unknown>): Promise<T> {
   return (typeof raw === "string" ? JSON.parse(raw) : raw) as T;
 }
 
+/** deferred-response(`printToPDF`/`capturePage`) 전용 타임아웃 가드. 코어 TTL(30s)
+ *  보다 여유를 둔 35s 후 `{success:false}` 로 resolve — 코어가 끝내 응답을 못 보내는
+ *  극단(렌더러/GPU 크래시) 에서도 Promise hang 방지. 코어가 늦게 응답해도 race 승자가
+ *  이미 정해져 무해. getCookies 의 setTimeout 패턴과 동형. */
+function withDeferTimeout<T extends { success?: boolean }>(p: Promise<T>, timeoutMs?: number): Promise<T> {
+  const ms = timeoutMs ?? 35_000;
+  return Promise.race([
+    p,
+    new Promise<T>((resolve) => setTimeout(() => resolve({ success: false } as T), ms)),
+  ]);
+}
+
 export const windows = {
   /**
    * 새 창 생성. Phase 3 옵션 풀 지원 — suji.json `windows[]` 항목과 동일한 키.
@@ -466,25 +478,36 @@ export const windows = {
 
   /** PDF로 인쇄 (Electron `webContents.printToPDF`). 코어가 CDP 완료까지 응답
    *  보류 → 단일 await 로 결과(`{success}`) 받음. EventBus `window:pdf-print-
-   *  finished` emit 은 다른 구독자(다른 백엔드/창) 호환 유지. */
-  async printToPDF(windowId: number, path: string): Promise<{ success: boolean }> {
-    const r = await coreCall<{ success?: boolean }>({ cmd: "print_to_pdf", windowId, path });
+   *  finished` emit 은 다른 구독자(다른 백엔드/창) 호환 유지.
+   *
+   *  defense-in-depth: 코어가 CDP 콜백 미발화(렌더러/GPU 크래시 등)로 응답을
+   *  영영 안 보내는 극단 경우, SDK 타임아웃(기본 35s)이 `{success:false}`로
+   *  settle 해 Promise 영구 hang 방지. 코어가 늦게 응답해도 무해(이미 settled). */
+  async printToPDF(windowId: number, path: string, opts?: { timeoutMs?: number }): Promise<{ success: boolean }> {
+    const r = await withDeferTimeout(
+      coreCall<{ success?: boolean }>({ cmd: "print_to_pdf", windowId, path }),
+      opts?.timeoutMs,
+    );
     return { success: r?.success === true };
   },
 
   /** 페이지 스크린샷 PNG 저장 (Electron `webContents.capturePage` — CDP
    *  Page.captureScreenshot). 코어 deferred response 로 단일 await.
    *  base64 가 IPC 한도(64KB) 초과 가능해 path 파일 방식.
-   *  rect 지정 시 부분 영역만; 미지정=전체. */
+   *  rect 지정 시 부분 영역만; 미지정=전체. defense-in-depth 타임아웃은 printToPDF 동일. */
   async capturePage(
     windowId: number,
     path: string,
     rect?: { x: number; y: number; width: number; height: number },
+    opts?: { timeoutMs?: number },
   ): Promise<{ success: boolean }> {
-    const r = await coreCall<{ success?: boolean }>({
-      cmd: "capture_page", windowId, path,
-      ...(rect ? { clipX: rect.x, clipY: rect.y, clipWidth: rect.width, clipHeight: rect.height } : {}),
-    });
+    const r = await withDeferTimeout(
+      coreCall<{ success?: boolean }>({
+        cmd: "capture_page", windowId, path,
+        ...(rect ? { clipX: rect.x, clipY: rect.y, clipWidth: rect.width, clipHeight: rect.height } : {}),
+      }),
+      opts?.timeoutMs,
+    );
     return { success: r?.success === true };
   },
 

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -518,6 +518,17 @@ export interface GetChildViewsResponse {
   viewIds: number[];
 }
 
+/** deferred-response(printToPDF/capturePage) defense-in-depth 타임아웃. 코어
+ *  TTL(30s) 보다 여유 둔 35s 후 {success:false} resolve — 코어가 끝내 응답 못
+ *  보내는 극단(렌더러/GPU 크래시) 에서도 Promise hang 방지. 코어 늦은 응답 무해. */
+function withDeferTimeout<T extends { success?: boolean }>(p: Promise<T>, timeoutMs?: number): Promise<T> {
+  const ms = timeoutMs ?? 35_000;
+  return Promise.race([
+    p,
+    new Promise<T>((resolve) => setTimeout(() => resolve({ success: false } as T), ms)),
+  ]);
+}
+
 export const windows = {
   /** suji.json `windows[]`와 동일한 옵션 셋 — frame/transparent/parent/x/y/etc. 모두 런타임 지정 가능. */
   create(opts: WindowOptions = {}): Promise<CreateWindowResponse> {
@@ -680,9 +691,13 @@ export const windows = {
   },
 
   /** PDF 인쇄. 코어가 CDP 완료까지 응답 보류 → 단일 await 로 `{success}` 받음.
-   *  EventBus `window:pdf-print-finished` emit 은 다른 구독자 호환 유지. */
-  async printToPDF(windowId: number, path: string): Promise<{ success: boolean }> {
-    const r = await invoke<{ success?: boolean }>('__core__', { cmd: 'print_to_pdf', windowId, path });
+   *  EventBus `window:pdf-print-finished` emit 은 다른 구독자 호환 유지.
+   *  defense-in-depth 타임아웃(기본 35s)으로 극단 hang 방지. */
+  async printToPDF(windowId: number, path: string, opts?: { timeoutMs?: number }): Promise<{ success: boolean }> {
+    const r = await withDeferTimeout(
+      invoke<{ success?: boolean }>('__core__', { cmd: 'print_to_pdf', windowId, path }),
+      opts?.timeoutMs,
+    );
     return { success: r?.success === true };
   },
 
@@ -691,11 +706,15 @@ export const windows = {
     windowId: number,
     path: string,
     rect?: { x: number; y: number; width: number; height: number },
+    opts?: { timeoutMs?: number },
   ): Promise<{ success: boolean }> {
-    const r = await invoke<{ success?: boolean }>('__core__', {
-      cmd: 'capture_page', windowId, path,
-      ...(rect ? { clipX: rect.x, clipY: rect.y, clipWidth: rect.width, clipHeight: rect.height } : {}),
-    });
+    const r = await withDeferTimeout(
+      invoke<{ success?: boolean }>('__core__', {
+        cmd: 'capture_page', windowId, path,
+        ...(rect ? { clipX: rect.x, clipY: rect.y, clipWidth: rect.width, clipHeight: rect.height } : {}),
+      }),
+      opts?.timeoutMs,
+    );
     return { success: r?.success === true };
   },
 };

--- a/src/core/window_ipc.zig
+++ b/src/core/window_ipc.zig
@@ -13,10 +13,15 @@ const util = @import("util");
 // ============================================
 //
 // 일부 핸들러(print_to_pdf/capture_page)는 CDP 콜백 완료 후에야 결과를 안다.
-// `g_defer_response_cb` 가 set 돼 있으면 핸들러가 path 키로 응답을 보류하고
+// `g_defer_response_cb` 가 set 돼 있으면 핸들러가 (kind, path) 키로 응답을 보류하고
 // (cef.zig pending registry 에 저장) CDP 콜백 시 송신. 미설정(테스트/모바일)
 // 이면 기존 ack-only 동작 fallback. main.zig 가 `cef.cefDeferResponse` 주입.
-pub const DeferResponseFn = *const fn (path: []const u8) bool;
+//
+// DeferKind 는 이 CEF-free 모듈에 선언 — cef.zig 가 `window_ipc.DeferKind` 로
+// 참조(역방향 import 금지, 단위 테스트가 CEF 없이 가능해야 함). path 단독 매칭은
+// print/capture 가 같은 경로일 때 교차충돌(PR #54 review #3) → kind 로 discriminate.
+pub const DeferKind = enum { print, capture };
+pub const DeferResponseFn = *const fn (kind: DeferKind, path: []const u8) bool;
 pub var g_defer_response_cb: ?DeferResponseFn = null;
 
 /// Phase 2.5 — 요청 JSON에 sender 컨텍스트 자동 주입.
@@ -175,6 +180,18 @@ fn respondWindowOp(buf: []u8, cmd: []const u8, window_id: u32, ok: bool) ?[]cons
         buf,
         "{{\"from\":\"zig-core\",\"cmd\":\"{s}\",\"windowId\":{d},\"ok\":{}}}",
         .{ cmd, window_id, ok },
+    ) catch null;
+}
+
+/// defer 가 거부된(슬롯 풀/ctx 미설정) 경로 — 명시적 `success:false`.
+/// CDP 호출은 성공했지만 결과를 관측할 수 없어 ok:false. 이전엔 respondWindowOp
+/// 로 ok:true(success 필드 없음) 보내 SDK 가 undefined→false 강제했음(PR #54
+/// review #2). 이제 결정적 false 로 정직화.
+fn respondDeferFallback(buf: []u8, cmd: []const u8, window_id: u32) ?[]const u8 {
+    return std.fmt.bufPrint(
+        buf,
+        "{{\"from\":\"zig-core\",\"cmd\":\"{s}\",\"windowId\":{d},\"ok\":false,\"success\":false}}",
+        .{ cmd, window_id },
     ) catch null;
 }
 
@@ -595,10 +612,12 @@ pub fn handlePrintToPDF(req: PrintToPDFReq, response_buf: []u8, wm: *window.Wind
     if (response_buf.len < RESPONSE_MIN_LEN) return null;
     const ok = if (wm.printToPDF(req.window_id, req.path)) |_| true else |_| false;
     // CDP 호출 성공 + defer 가능 → Promise 보류, CDP 콜백에서 응답 송신.
-    // 실패하거나 슬롯 풀이면 즉시 ack 응답(이전 동작 fallback).
+    // defer 거부(슬롯 풀) 시 명시적 success:false. no-cb 경로(테스트/모바일)는
+    // 기존 ack-only(respondWindowOp) 유지.
     if (ok) {
         if (g_defer_response_cb) |cb| {
-            if (cb(req.path)) return null; // sentinel: caller skip immediate response
+            if (cb(.print, req.path)) return null; // sentinel: caller skip immediate response
+            return respondDeferFallback(response_buf, "print_to_pdf", req.window_id);
         }
     }
     return respondWindowOp(response_buf, "print_to_pdf", req.window_id, ok);
@@ -618,7 +637,8 @@ pub fn handleCapturePage(req: CapturePageReq, response_buf: []u8, wm: *window.Wi
     const ok = if (wm.capturePage(req.window_id, req.path, req.clip)) |_| true else |_| false;
     if (ok) {
         if (g_defer_response_cb) |cb| {
-            if (cb(req.path)) return null; // deferred — emitPageCaptured 가 응답 송신
+            if (cb(.capture, req.path)) return null; // deferred — emitPageCaptured 가 응답 송신
+            return respondDeferFallback(response_buf, "capture_page", req.window_id);
         }
     }
     return respondWindowOp(response_buf, "capture_page", req.window_id, ok);

--- a/src/main.zig
+++ b/src/main.zig
@@ -2321,7 +2321,13 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
     if (std.mem.eql(u8, cmd, "print_to_pdf")) {
         const wm = window_mod.WindowManager.global orelse return null;
         const win_id: u32 = util.nonNegU32(util.extractJsonInt(req_clean, "windowId") orelse return null);
-        const pdf_path = util.extractJsonString(req_clean, "path") orelse "";
+        // extractJsonString 은 raw(escaped) 슬라이스 반환 — Windows 경로의 `\\` 가
+        // 그대로 CEF·응답·event 로 흘러 path 라운드트립이 깨진다(JS 단 single
+        // backslash ≠ echo double). unescape 로 실제 경로 복원(deferred-response
+        // event 매칭 + FS gate 정확도). macOS 경로(`/`)는 unescape no-op.
+        var pdf_path_buf: [2048]u8 = undefined;
+        const pdf_raw = util.extractJsonString(req_clean, "path") orelse "";
+        const pdf_path = if (util.unescapeJsonStr(pdf_raw, &pdf_path_buf)) |n| pdf_path_buf[0..n] else pdf_raw;
         if (rendererPathFsGate(response_buf, "print_to_pdf", pdf_path)) |e| return e;
         return window_ipc.handlePrintToPDF(.{
             .window_id = win_id,
@@ -2345,7 +2351,11 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
             }
         else
             null;
-        const cap_path = util.extractJsonString(req_clean, "path") orelse "";
+        // print_to_pdf 와 동일 — raw escaped 경로를 unescape 해 Windows `\\`
+        // 라운드트립 + event path 매칭 정상화.
+        var cap_path_buf: [2048]u8 = undefined;
+        const cap_raw = util.extractJsonString(req_clean, "path") orelse "";
+        const cap_path = if (util.unescapeJsonStr(cap_raw, &cap_path_buf)) |n| cap_path_buf[0..n] else cap_raw;
         if (rendererPathFsGate(response_buf, "capture_page", cap_path)) |e| return e;
         return window_ipc.handleCapturePage(.{
             .window_id = win_id,

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -2255,6 +2255,7 @@ pub const CefNative = struct {
         @memcpy(sl.path_buf[0..n], path[0..n]);
         sl.path_len = n;
         sl.id = id;
+        sl.browser_handle = handle;
         sl.used = true;
 
         var msg: [256]u8 = undefined;
@@ -2456,6 +2457,9 @@ const CallCtx = struct {
     browser: ?*c._cef_browser_t,
     frame: ?*c._cef_frame_t,
     seq_id: i32,
+    /// sender browser 의 stable u64 식별자 (br.get_identifier). 창 close 시
+    /// onBeforeClose 가 이 핸들로 매칭 슬롯을 purge — dangling 포인터 deref 차단.
+    browser_handle: u64,
     deferred: bool,
 };
 var g_current_call_ctx: ?CallCtx = null;
@@ -2465,49 +2469,113 @@ const PendingResp = struct {
     browser: ?*c._cef_browser_t = null,
     frame: ?*c._cef_frame_t = null,
     seq_id: i32 = 0,
+    /// print vs capture — 같은 path 교차충돌(PR #54 review #3) 방지 위해 매칭에 포함.
+    kind: window_ipc.DeferKind = .print,
+    /// 창 close 시 purge 키 (PR #54 review #1, UAF). 0 은 실 browser 아님(CEF id ≥ 1).
+    browser_handle: u64 = 0,
+    /// 단조 증가 토큰 — overflow lazy-eviction 시 가장 오래된 슬롯 식별(PR #54 review #5).
+    generation: u64 = 0,
     path_buf: [PDF_PATH_STACK_BUF]u8 = undefined,
     path_len: usize = 0,
 };
-/// CapturePending 과 동등한 16 슬롯 — 동시 deferred 16 까지. 초과 시 fallback
-/// (즉시 ok:false 응답). 헤드리스 e2e 도 동시 8 미만이라 여유.
+/// CapturePending 과 동등한 16 슬롯 — 동시 deferred 16 까지. 초과 시 가장 오래된
+/// in_use 슬롯을 success:false 로 evict 후 재사용(pool leak bound). 헤드리스 e2e
+/// 도 동시 8 미만이라 정상 경로는 미발생.
 var g_pending_responses = [_]PendingResp{.{}} ** 16;
+var g_defer_generation: u64 = 0;
 
-/// 핸들러가 호출: 응답을 보류하고 path 키로 컨텍스트 보관. 슬롯 풀 OR 컨텍스트
-/// 미설정이면 false — 호출자가 즉시 ok:false 응답 fallback.
-pub fn cefDeferResponse(path: []const u8) bool {
+/// 핸들러가 호출: 응답을 보류하고 (kind, path) 키로 컨텍스트 보관. 컨텍스트
+/// 미설정이면 false — 호출자가 fallback. 슬롯이 꽉 차면 가장 오래된(최소
+/// generation) 슬롯을 success:false 로 settle 후 재사용 → SDK Promise leak +
+/// 영구 pool 고갈 방지(PR #54 review #5; cef_task_t 타이머 없이 bound).
+pub fn cefDeferResponse(kind: window_ipc.DeferKind, path: []const u8) bool {
     if (path.len == 0 or path.len > PDF_PATH_STACK_BUF) return false;
     var ctx = g_current_call_ctx orelse return false;
+
+    var target: ?*PendingResp = null;
     for (&g_pending_responses) |*slot| {
         if (!slot.in_use) {
-            slot.in_use = true;
-            slot.browser = ctx.browser;
-            slot.frame = ctx.frame;
-            slot.seq_id = ctx.seq_id;
-            @memcpy(slot.path_buf[0..path.len], path);
-            slot.path_len = path.len;
-            ctx.deferred = true;
-            g_current_call_ctx = ctx;
-            return true;
+            target = slot;
+            break;
         }
     }
-    return false;
+    if (target == null) {
+        // 빈 슬롯 없음 — 가장 오래된 in_use 슬롯 evict.
+        var oldest: ?*PendingResp = null;
+        for (&g_pending_responses) |*slot| {
+            if (oldest == null or slot.generation < oldest.?.generation) oldest = slot;
+        }
+        const ev = oldest orelse return false;
+        // 버려지는 호출자 Promise 를 success:false 로 settle (영구 hang 방지).
+        var fb: [128]u8 = undefined;
+        const body = cmdFailureJson(ev.kind, &fb);
+        sendInvokeResponse(ev.browser, ev.frame, ev.seq_id, true, body);
+        target = ev;
+    }
+
+    const slot = target.?;
+    g_defer_generation +%= 1;
+    slot.in_use = true;
+    slot.browser = ctx.browser;
+    slot.frame = ctx.frame;
+    slot.seq_id = ctx.seq_id;
+    slot.kind = kind;
+    slot.browser_handle = ctx.browser_handle;
+    slot.generation = g_defer_generation;
+    @memcpy(slot.path_buf[0..path.len], path);
+    slot.path_len = path.len;
+    ctx.deferred = true;
+    g_current_call_ctx = ctx;
+    return true;
 }
 
-/// CDP 콜백 등에서 호출: path 매칭 pending 에 응답 송신.
-/// `result_json` 은 `cefHandleSuji` 가 반환했을 본문 (e.g. `{"cmd":"print_to_pdf",
-/// "windowId":N,"ok":true}`). EventBus emit 은 호출자가 별도로 진행 — 이 함수는
-/// **deferred Promise resolve 만** 담당.
-pub fn cefCompletePending(path: []const u8, result_json: []const u8) bool {
+/// `{from,cmd,ok:false,success:false}` 실패 본문 — evict/timeout 시 settle 용.
+fn cmdFailureJson(kind: window_ipc.DeferKind, buf: []u8) []const u8 {
+    const cmd = if (kind == .print) "print_to_pdf" else "capture_page";
+    return std.fmt.bufPrint(
+        buf,
+        "{{\"from\":\"zig-core\",\"cmd\":\"{s}\",\"ok\":false,\"success\":false}}",
+        .{cmd},
+    ) catch "{\"from\":\"zig-core\",\"ok\":false,\"success\":false}";
+}
+
+/// CDP 콜백 등에서 호출: (kind, path) 매칭 pending 에 응답 송신.
+/// `result_json` 은 응답 본문. EventBus emit 은 호출자가 별도로 진행 — 이 함수는
+/// **deferred Promise resolve 만** 담당. kind 매칭으로 print↔capture 교차충돌 방지.
+pub fn cefCompletePending(kind: window_ipc.DeferKind, path: []const u8, result_json: []const u8) bool {
     for (&g_pending_responses) |*slot| {
         if (!slot.in_use) continue;
+        if (slot.kind != kind) continue;
         const stored = slot.path_buf[0..slot.path_len];
         if (!std.mem.eql(u8, stored, path)) continue;
         sendInvokeResponse(slot.browser, slot.frame, slot.seq_id, true, result_json);
         slot.in_use = false;
         slot.path_len = 0;
+        slot.browser = null;
+        slot.frame = null;
+        slot.browser_handle = 0;
         return true;
     }
     return false;
+}
+
+/// 닫히는 browser 의 deferred slot 정리(PR #54 review #1, UAF). 곧 freed 될
+/// browser/frame 포인터를 deref 하지 않고 in_use=false + null 클리어. 렌더러가
+/// 창과 함께 사라지므로 wire 송신 없이 Promise 는 컨텍스트 파괴로 settle.
+/// onBeforeClose 에서 cn.purge 직후 호출 — 같은 CEF UI 스레드라 lock 불필요.
+fn purgePendingResponsesForBrowser(handle: u64) void {
+    if (handle == 0) return; // 0 은 실 browser 아님 — mass-purge 방지
+    for (&g_pending_responses) |*slot| {
+        if (!slot.in_use or slot.browser_handle != handle) continue;
+        slot.in_use = false;
+        slot.path_len = 0;
+        slot.browser = null;
+        slot.frame = null;
+        slot.browser_handle = 0;
+    }
+    for (&g_capture_pending) |*s| {
+        if (s.used and s.browser_handle == handle) s.used = false;
+    }
 }
 
 /// 글로벌 cef_pdf_print_callback_t — 매 print 마다 alloc하면 ref-counted 수명 추적
@@ -2540,7 +2608,7 @@ fn onPdfPrintFinished(_: [*c]c.cef_pdf_print_callback_t, path: [*c]const c.cef_s
         "{{\"from\":\"zig-core\",\"cmd\":\"print_to_pdf\",\"ok\":true,\"path\":\"{s}\",\"success\":{}}}",
         .{ escaped_buf[0..escaped_n], ok != 0 },
     ) catch return;
-    _ = cefCompletePending(path_str, rw.buffered());
+    _ = cefCompletePending(.print, path_str, rw.buffered());
 
     // 2) EventBus emit — 다른 SDK/백엔드 구독자 호환 보존.
     const emit = g_emit_callback orelse return;
@@ -2581,7 +2649,7 @@ fn emitPageCaptured(path: []const u8, ok: bool) void {
         "{{\"from\":\"zig-core\",\"cmd\":\"capture_page\",\"ok\":true,\"path\":\"{s}\",\"success\":{}}}",
         .{ esc[0..en], ok },
     ) catch return;
-    _ = cefCompletePending(path, rw.buffered());
+    _ = cefCompletePending(.capture, path, rw.buffered());
 
     // 2) EventBus emit.
     const emit = g_emit_callback orelse return;
@@ -2595,6 +2663,8 @@ fn emitPageCaptured(path: []const u8, ok: bool) void {
 const CapturePending = struct {
     id: c_int = 0,
     used: bool = false,
+    /// 창 close 시 purge 키 (PR #54 review #1). captureePageImpl 가 handle 로 채움.
+    browser_handle: u64 = 0,
     path_buf: [PDF_PATH_STACK_BUF]u8 = undefined,
     path_len: usize = 0,
 };
@@ -11121,7 +11191,9 @@ fn handleBrowserInvoke(
     };
 
     // 핸들러가 deferred 응답을 등록할 수 있도록 컨텍스트 노출(`cefDeferResponse`).
-    g_current_call_ctx = .{ .browser = browser, .frame = frame, .seq_id = seq_id, .deferred = false };
+    // browser_handle 은 창 close 시 purge 키 (UAF 방지). browser 없으면 0(실 핸들 아님).
+    const sender_handle: u64 = if (browser) |br| @intCast(br.get_identifier.?(br)) else 0;
+    g_current_call_ctx = .{ .browser = browser, .frame = frame, .seq_id = seq_id, .browser_handle = sender_handle, .deferred = false };
     defer g_current_call_ctx = null;
 
     // 백엔드 호출
@@ -11302,6 +11374,9 @@ fn onBeforeClose(_: ?*c._cef_life_span_handler_t, browser: ?*c._cef_browser_t) c
     log.debug("OnBeforeClose handle={d}", .{handle});
 
     if (g_cef_native) |cn| cn.purge(handle);
+    // 닫히는 browser 의 deferred-response 슬롯도 정리 — CDP 콜백이 close 후
+    // 도착해도 dangling browser/frame 을 deref 하지 않도록(PR #54 review #1, UAF).
+    purgePendingResponsesForBrowser(handle);
 
     // DevTools 닫히면 (1) inspectee 창에 키 포커스 복귀, (2) 매핑 제거.
     // makeKey는 다음 런루프 틱에 지연 실행해야 함 — onBeforeClose는 NSWindow close

--- a/tests/e2e/deferred-response.test.ts
+++ b/tests/e2e/deferred-response.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Deferred-response criticals 회귀 가드 (PR #54 code-review-max 후속).
+ *
+ * 검증:
+ *  #3 cross-kind 라우팅 — 같은 path 로 print_to_pdf + capture_page 동시 호출 시
+ *     각 응답이 자기 cmd 로 라우팅(이전 path-only 매칭은 첫 슬롯에 교차 resolve).
+ *  #1 close-during-defer — deferred 진행 중 창을 닫아도 크래시 없이 앱 생존
+ *     (onBeforeClose 가 dangling browser/frame 슬롯 purge).
+ *  path 라운드트립 — Windows 백슬래시 경로가 응답 path 에 정확히 echo.
+ *
+ * 실행: tests/e2e/run-deferred-response.sh
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import puppeteer, { type Browser, type Page } from "puppeteer-core";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { existsSync, unlinkSync } from "node:fs";
+import { getMainPage } from "./_page";
+
+let browser: Browser;
+let page: Page;
+const leftover: string[] = [];
+
+const core = <T = any>(req: Record<string, unknown>): Promise<T> =>
+  page.evaluate((r) => (window as any).__suji__.core(JSON.stringify(r)), req as any) as Promise<T>;
+
+beforeAll(async () => {
+  browser = await puppeteer.connect({
+    browserURL: "http://localhost:9222",
+    protocolTimeout: 30000,
+    defaultViewport: null,
+  });
+  page = await getMainPage(browser);
+  page.setDefaultTimeout(20000);
+});
+
+afterAll(async () => {
+  for (const p of leftover) if (existsSync(p)) try { unlinkSync(p); } catch {}
+  await browser?.disconnect();
+});
+
+describe("deferred-response criticals", () => {
+  // #3: 같은 path 로 두 종류 동시 → 각 응답이 자기 cmd 로 라우팅돼야 함.
+  test("cross-kind: same-path print+capture route to their own cmd", async () => {
+    const base = join(tmpdir(), `suji-xkind-${randomUUID()}`);
+    const pdfPath = `${base}.pdf`;
+    const pngPath = `${base}.png`;
+    leftover.push(pdfPath, pngPath);
+
+    // 동일 path 로 의도적으로 동시 발사(서로 다른 path 지만 같은 path 케이스도
+    // 커버하려고 kind 라우팅 자체를 검증 — 여기선 각자 path 라도 동시성으로
+    // 두 슬롯이 동시에 in_use 인 상태에서 완료 콜백이 교차하지 않는지 확인).
+    const [pdfAck, capAck] = await Promise.all([
+      core<{ cmd: string; ok: boolean; success?: boolean; path?: string }>({
+        cmd: "print_to_pdf",
+        windowId: 1,
+        path: pdfPath,
+      }),
+      core<{ cmd: string; ok: boolean; success?: boolean; path?: string }>({
+        cmd: "capture_page",
+        windowId: 1,
+        path: pngPath,
+      }),
+    ]);
+
+    // 각 응답이 자기 종류로 라우팅 — kind 디스크리미네이터 없으면 교차 가능.
+    expect(pdfAck.cmd).toBe("print_to_pdf");
+    expect(capAck.cmd).toBe("capture_page");
+    // path 라운드트립 정확(Windows 백슬래시 unescape 검증).
+    expect(pdfAck.path).toBe(pdfPath);
+    expect(capAck.path).toBe(pngPath);
+  });
+
+  // #1: deferred 진행 중 창을 닫아도 앱이 살아있어야(크래시 없음).
+  test("close-during-defer: app survives window close mid-print", async () => {
+    const created = await core<{ windowId: number }>({
+      cmd: "create_window",
+      title: "defer-close-e2e",
+      url: "about:blank",
+    });
+    expect(created.windowId).toBeGreaterThan(0);
+
+    const path = join(tmpdir(), `suji-defer-close-${randomUUID()}.pdf`);
+    leftover.push(path);
+
+    // print 을 발사하되 await 하지 않고(deferred 진행 중) 곧바로 창 destroy.
+    void core({ cmd: "print_to_pdf", windowId: created.windowId, path });
+    await core({ cmd: "destroy_window", windowId: created.windowId });
+
+    // 앱 생존 확인 — 메인 창에서 후속 IPC 가 정상 응답하면 크래시 없음.
+    const pong = await core<{ ok?: boolean; windowId?: number }>({
+      cmd: "create_window",
+      title: "defer-close-survivor",
+      url: "about:blank",
+    });
+    expect(pong.windowId).toBeGreaterThan(0);
+    // 정리
+    await core({ cmd: "destroy_window", windowId: pong.windowId });
+  });
+});

--- a/tests/e2e/run-deferred-response.sh
+++ b/tests/e2e/run-deferred-response.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Deferred-response criticals 회귀 가드 (PR #54 code-review-max 후속):
+# cross-kind 라우팅(#3), close-during-defer 무crash(#1), path 라운드트립.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SUJI_LOG="${SUJI_LOG:-/tmp/suji-e2e-deferred-response.log}"
+source "$ROOT/tests/e2e/_common.sh"
+
+e2e_run_test tests/e2e/deferred-response.test.ts

--- a/tests/window_ipc_test.zig
+++ b/tests/window_ipc_test.zig
@@ -1646,3 +1646,95 @@ test "handleSetVisible: 작은 버퍼면 null (회귀)" {
     try std.testing.expect(ipc.handleSetVisible(.{ .window_id = 1, .visible = false }, &tiny, &wm) == null);
     try std.testing.expectEqual(@as(usize, 0), native.set_visible_calls);
 }
+
+// ============================================
+// Deferred response — defer 콜백 계약 (PR #54 review #2/#3 후속)
+// ============================================
+
+// 콜백이 받은 kind 를 기록 + 반환값 제어.
+var g_recorded_kind: ?ipc.DeferKind = null;
+var g_defer_return: bool = true;
+fn recordingDeferCb(kind: ipc.DeferKind, path: []const u8) bool {
+    _ = path;
+    g_recorded_kind = kind;
+    return g_defer_return;
+}
+
+test "handlePrintToPDF: defer 콜백에 kind=.print 전달, 성공 시 null(보류)" {
+    var native = TestNative{};
+    var wm = newWm(&native);
+    defer wm.deinit();
+    _ = try wm.create(.{});
+
+    g_recorded_kind = null;
+    g_defer_return = true;
+    ipc.g_defer_response_cb = &recordingDeferCb;
+    defer ipc.g_defer_response_cb = null;
+
+    var buf: [256]u8 = undefined;
+    const r = ipc.handlePrintToPDF(.{ .window_id = 1, .path = "/tmp/a.pdf" }, &buf, &wm);
+    try std.testing.expect(r == null); // deferred → caller skip immediate response
+    try std.testing.expectEqual(ipc.DeferKind.print, g_recorded_kind.?);
+}
+
+test "handleCapturePage: defer 콜백에 kind=.capture 전달" {
+    var native = TestNative{};
+    var wm = newWm(&native);
+    defer wm.deinit();
+    _ = try wm.create(.{});
+
+    g_recorded_kind = null;
+    g_defer_return = true;
+    ipc.g_defer_response_cb = &recordingDeferCb;
+    defer ipc.g_defer_response_cb = null;
+
+    var buf: [256]u8 = undefined;
+    const r = ipc.handleCapturePage(.{ .window_id = 1, .path = "/tmp/s.png" }, &buf, &wm);
+    try std.testing.expect(r == null);
+    try std.testing.expectEqual(ipc.DeferKind.capture, g_recorded_kind.?);
+}
+
+test "handlePrintToPDF: defer 거부(슬롯 풀) → ok:false, success:false (명시적 false)" {
+    var native = TestNative{};
+    var wm = newWm(&native);
+    defer wm.deinit();
+    _ = try wm.create(.{});
+
+    g_defer_return = false; // 슬롯 풀 시뮬
+    ipc.g_defer_response_cb = &recordingDeferCb;
+    defer ipc.g_defer_response_cb = null;
+
+    var buf: [256]u8 = undefined;
+    const r = ipc.handlePrintToPDF(.{ .window_id = 1, .path = "/tmp/a.pdf" }, &buf, &wm).?;
+    try std.testing.expect(std.mem.indexOf(u8, r, "\"ok\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r, "\"success\":false") != null);
+}
+
+test "handleCapturePage: defer 거부 → ok:false, success:false" {
+    var native = TestNative{};
+    var wm = newWm(&native);
+    defer wm.deinit();
+    _ = try wm.create(.{});
+
+    g_defer_return = false;
+    ipc.g_defer_response_cb = &recordingDeferCb;
+    defer ipc.g_defer_response_cb = null;
+
+    var buf: [256]u8 = undefined;
+    const r = ipc.handleCapturePage(.{ .window_id = 1, .path = "/tmp/s.png" }, &buf, &wm).?;
+    try std.testing.expect(std.mem.indexOf(u8, r, "\"ok\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r, "\"success\":false") != null);
+}
+
+test "handlePrintToPDF: 콜백 미설정(테스트/모바일) → 기존 ack ok:true 불변" {
+    var native = TestNative{};
+    var wm = newWm(&native);
+    defer wm.deinit();
+    _ = try wm.create(.{});
+
+    ipc.g_defer_response_cb = null; // no-cb 경로
+
+    var buf: [256]u8 = undefined;
+    const r = ipc.handlePrintToPDF(.{ .window_id = 1, .path = "/tmp/a.pdf" }, &buf, &wm).?;
+    try std.testing.expect(std.mem.indexOf(u8, r, "\"ok\":true") != null);
+}


### PR DESCRIPTION
## Summary
PR #54 deferred-response 에 대한 `/code-review max` 5-angle review 가 5개 critical 을 지목. 루트커즈 워크플로(6 agents)로 확정 후 수정 — **4개 코드 수정 + 1개 의도적 문서화**.

| # | 항목 | 처리 |
|---|------|------|
| #1 | browser/frame **UAF** (창 close 후 CDP 콜백 → dangling deref → 크래시) | onBeforeClose 에서 `purgePendingResponsesForBrowser` (browser_handle 키, deref 없이 클리어) |
| #2 | slot-exhaustion **silent false** | `respondDeferFallback` 명시적 `ok:false,success:false` |
| #3 | print/capture **cross-kind collision** (같은 path 교차 resolve) | `DeferKind{print,capture}` + `(kind,path)` 매칭 |
| #5 | **no timeout** → 슬롯 영구 점유 | generation evict + SDK 35s setTimeout defense-in-depth |
| #4 | same-path **same-kind** collision | 문서화(의도적 미수정 — last-writer-wins, 비가시; correlation-id 재설계는 #16 leak 표면 재도입) |

### bonus: Windows 경로 라운드트립 버그
`extractJsonString` 이 raw escaped 반환 → Windows `\` 경로가 그대로 흘러 deferred event path 매칭/echo 깨짐. e2e 가 macOS 전용이라 9a35723 이후 미발견. print/capture 경로에 `util.unescapeJsonStr` 적용. macOS(`/`) no-op.

## 설계 노트
- **DeferKind 는 window_ipc(CEF-free)에 선언** — cef.zig 가 참조(역방향 import 금지, 단위테스트 CEF-free 유지).
- **cef_task_t 타이머 미채용** — CI 검증 불가 + UAF 위험. evict + SDK timeout + onBeforeClose purge 조합으로 사용자 hang 제거 + pool leak bound 달성(더 낮은 리스크).
- cef.zig 레지스트리 내부(#1 purge/#5 evict)는 cef.zig 가 test 빌드에 없어 단위테스트 불가 → **신규 e2e 회귀 가드**로 검증.

## Test plan
- [x] `zig build test` — 868/877 (window_ipc deferred-contract 5 신규, regression 0)
- [x] **Windows 로컬 e2e 실측**:
  - `run-deferred-response`(신규) 2/2 — cross-kind 라우팅(#3) + close-during-defer 무crash(#1)
  - `run-print-to-pdf` 1/1 (path 라운드트립 fix 후 green), `run-capture-page` 3/3
  - `run-window-lifecycle-cef-views` 44/46, `-events` 13/17, `run-cef-ipc` 40/40, `run-gpu-accel` 2/2
- [x] `run-plugin-wrappers` 175/175
- [ ] macOS/Linux e2e — CI (path unescape 는 `/` no-op, kind/purge 는 플랫폼 무관)