### PR TITLE
fix(build): Windows ReleaseSafe translate-c unused-local (closes #14)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,15 +183,12 @@ jobs:
       - name: Build suji CLI
         shell: bash
         run: |
-          # Windows 는 ReleaseSafe 에서 translate-c 가 cimport 'unused local
-          # constant' 를 내 컴파일 실패(ci.yml 의 Debug `zig build` 는 green).
-          # 검증된 경로 사용: Windows=Debug, mac/linux=ReleaseSafe. Windows
-          # release 최적화는 후속(translate-c quirk) — #14.
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            zig build
-          else
-            zig build -Doptimize=ReleaseSafe
-          fi
+          # 전 플랫폼 ReleaseSafe (#14 해결). 과거 Windows 는 translate-c 가
+          # MinGW fortify wcscat/wcscpy override 를 'unused local constant' 로
+          # 생성해 ReleaseSafe 실패 → Debug 로 우회했음. cef.zig @cImport 에
+          # `_FORTIFY_SOURCE=0` 추가로 override 게이트(_FORTIFY_SOURCE>0 &&
+          # __OPTIMIZE__>0)를 닫아 근본 해결 → Windows 도 최적화 빌드.
+          zig build -Doptimize=ReleaseSafe
       - name: Package (Unix)
         if: runner.os != 'Windows'
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -771,6 +771,17 @@ net-control 이라 데이터 유출 sink 아님 → 범위 제외. 모바일은 
   격리 — default 빌드에선 specta 없이 stable Rust 빌드 통과. TypeScript
   declaration 필요 시 `--features typescript` (nightly Rust 또는
   RUSTC_BOOTSTRAP=1 + 패치 필요). `test-state-rust` 가 0→11/11 pass.
+- ~~Windows ReleaseSafe translate-c 'unused local constant' 컴파일 실패~~
+  **해결됨** ([#14](https://github.com/ohah/suji/issues/14)). MinGW `<string.h>` 가
+  `__MINGW_FORTIFY_LEVEL > 0`(게이트 `_FORTIFY_SOURCE>0 && __OPTIMIZE__>0`,
+  `_mingw_mac.h:331`)일 때 `wcscat`/`wcscpy` 를 `wcscat_s`/`wcscpy_s` 호출하는
+  bos-check inline override 로 재정의. Zig 0.16 translate-c 가 그 fortified
+  wrapper struct(`extern_local_wcscat_s`)를 `_ = &` discard 없이 생성 →
+  ReleaseSafe(C 를 `__OPTIMIZE__>0` 로 번역) 의미분석에서 unused-local 실패.
+  Debug(-O0)는 `__OPTIMIZE__` 미정의라 override 미생성→통과. `cef.zig`
+  `@cImport` 에 Windows-only `@cDefine("_FORTIFY_SOURCE","0")` 로 게이트를 닫아
+  근본 해결(fortify 는 CEF 바인딩 무관 — prebuilt lib + 헤더 번역만). release.yml
+  Windows=Debug 워크어라운드 제거 → 전 플랫폼 ReleaseSafe.
 - ~~Windows 네이티브 API 격차 (tray click/menu, globalShortcut trigger,
   nativeTheme event, opacity/shadow non-Views, OS-initiated window state,
   directory picker, custom dialog buttons, notification click)~~ **해결됨**

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -7,6 +7,19 @@ pub const c = @cImport({
     if (is_macos) {
         @cDefine("char16_t", "unsigned short");
     }
+    // Windows(MinGW): _FORTIFY_SOURCE=0 강제 (#14). MinGW <string.h> 는
+    // `__MINGW_FORTIFY_LEVEL > 0` 일 때 wcscat/wcscpy 를 wcscat_s/wcscpy_s 호출
+    // 하는 bos-check inline override 로 재정의하고, 그 게이트는 _mingw_mac.h:331
+    // 에서 `_FORTIFY_SOURCE > 0 && __OPTIMIZE__ > 0`. Zig 의 ReleaseSafe 는 C 를
+    // 최적화 번역(`__OPTIMIZE__>0`)해 override 가 생성되는데, Zig 0.16 translate-c
+    // 가 그 fortified wrapper struct(`extern_local_wcscat_s`)를 `_ = &` discard
+    // 없이 생성 → "unused local constant" 로 의미분석 실패. Debug(-O0)는
+    // `__OPTIMIZE__` 미정의라 override 자체가 없어 통과. _FORTIFY_SOURCE=0 으로
+    // 게이트를 닫으면 두 모드 동형(override 미생성). fortify 는 우리 CEF 바인딩과
+    // 무관(prebuilt lib 사용, cimport 는 헤더 번역만) — 안전.
+    if (is_windows) {
+        @cDefine("_FORTIFY_SOURCE", "0");
+    }
     @cInclude("include/capi/cef_app_capi.h");
     @cInclude("include/capi/cef_browser_capi.h");
     @cInclude("include/capi/cef_client_capi.h");


### PR DESCRIPTION
## Summary
이슈 #14 가 요청한 **Windows 환경 evidence-based 재개**를 수행해 근본 해결. Windows 릴리스 바이너리가 이제 ReleaseSafe 최적화 적용(이전엔 Debug 워크어라운드).

## Root cause (Windows 로컬 재현)
`zig build -Doptimize=ReleaseSafe` 가 `cimport.zig:687/711: error: unused local constant` 로 실패. 해당 라인은 MinGW `<string.h>` 의 `wcscat`/`wcscpy` **fortify inline override** — `wcscat_s`/`wcscpy_s` 를 부르는 bos-check wrapper struct(`extern_local_wcscat_s`)를 Zig 0.16 translate-c 가 `_ = &` discard 없이 생성.

게이트(`_mingw_mac.h:331`): `_FORTIFY_SOURCE > 0 && __OPTIMIZE__ > 0`
- **Debug(-O0)**: `__OPTIMIZE__` 미정의 → override 미생성 → clean → 통과
- **ReleaseSafe**: C 를 `__OPTIMIZE__>0` 로 번역 → override 생성 → translate-c quirk → 실패

→ 이것이 Debug-green / Release-red 분기의 정체 (이전 조사가 macOS 라 재현 못 했던 부분).

## Fix
`cef.zig` `@cImport` 에 Windows-only `@cDefine("_FORTIFY_SOURCE", "0")` → 게이트를 닫아 두 모드 동형(override 미생성). fortify 는 CEF 바인딩과 무관(prebuilt lib + 헤더 번역만)이라 타입/레이아웃 영향 없어 안전. `release.yml` 의 Windows=Debug 분기 제거.

## Test plan (Windows 로컬 실측)
- [x] `zig build -Doptimize=ReleaseSafe` — exit 0, `suji.exe` 2.68MB 생성 (이전 실패→green)
- [x] `zig build` (Debug) — exit 0 (무회귀)
- [x] `zig build test` — 891/900 (9 skip, 0 fail)
- [ ] mac/linux ReleaseSafe — CI (`_FORTIFY_SOURCE` define 은 Windows-only 게이트라 무영향)