### PR TITLE
fix(ipc): code-review max followup — eviction race + timer leak + harness robustness

### DIFF
--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -296,10 +296,12 @@ async function coreCall<T>(request: Record<string, unknown>): Promise<T> {
  *  이미 정해져 무해. getCookies 의 setTimeout 패턴과 동형. */
 function withDeferTimeout<T extends { success?: boolean }>(p: Promise<T>, timeoutMs?: number): Promise<T> {
   const ms = timeoutMs ?? 35_000;
-  return Promise.race([
-    p,
-    new Promise<T>((resolve) => setTimeout(() => resolve({ success: false } as T), ms)),
-  ]);
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve({ success: false } as T), ms);
+  });
+  // race 승자 결정 후 clearTimeout — 호출당 dangling 35s 타이머 누수 방지.
+  return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
 }
 
 export const windows = {

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -523,10 +523,12 @@ export interface GetChildViewsResponse {
  *  보내는 극단(렌더러/GPU 크래시) 에서도 Promise hang 방지. 코어 늦은 응답 무해. */
 function withDeferTimeout<T extends { success?: boolean }>(p: Promise<T>, timeoutMs?: number): Promise<T> {
   const ms = timeoutMs ?? 35_000;
-  return Promise.race([
-    p,
-    new Promise<T>((resolve) => setTimeout(() => resolve({ success: false } as T), ms)),
-  ]);
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve({ success: false } as T), ms);
+  });
+  // race 승자 결정 후 clearTimeout — 호출당 dangling 35s 타이머 누수 방지.
+  return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
 }
 
 export const windows = {

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -2486,21 +2486,20 @@ const PendingResp = struct {
     kind: window_ipc.DeferKind = .print,
     /// 창 close 시 purge 키 (PR #54 review #1, UAF). 0 은 실 browser 아님(CEF id ≥ 1).
     browser_handle: u64 = 0,
-    /// 단조 증가 토큰 — overflow lazy-eviction 시 가장 오래된 슬롯 식별(PR #54 review #5).
-    generation: u64 = 0,
     path_buf: [PDF_PATH_STACK_BUF]u8 = undefined,
     path_len: usize = 0,
 };
-/// CapturePending 과 동등한 16 슬롯 — 동시 deferred 16 까지. 초과 시 가장 오래된
-/// in_use 슬롯을 success:false 로 evict 후 재사용(pool leak bound). 헤드리스 e2e
-/// 도 동시 8 미만이라 정상 경로는 미발생.
+/// CapturePending 과 동등한 16 슬롯 — 동시 deferred 16 까지. 가득 차면 신규 defer
+/// 를 refuse(handler 가 success:false fallback) — 진행 중 슬롯을 evict·재사용하지
+/// 않아 evicted op 의 late CDP 가 새 occupant 와 (kind,path) 오매칭하는 race 회피
+/// (max code-review #57 후속). pool 은 onBeforeClose purge + SDK 타임아웃으로 bound.
+/// 헤드리스 e2e 도 동시 8 미만이라 정상 경로는 refuse 미발생.
 var g_pending_responses = [_]PendingResp{.{}} ** 16;
-var g_defer_generation: u64 = 0;
 
 /// 핸들러가 호출: 응답을 보류하고 (kind, path) 키로 컨텍스트 보관. 컨텍스트
-/// 미설정이면 false — 호출자가 fallback. 슬롯이 꽉 차면 가장 오래된(최소
-/// generation) 슬롯을 success:false 로 settle 후 재사용 → SDK Promise leak +
-/// 영구 pool 고갈 방지(PR #54 review #5; cef_task_t 타이머 없이 bound).
+/// 미설정/path 무효/슬롯 풀이면 false → 호출자(handler)가 success:false fallback.
+/// 슬롯 풀 시 evict 하지 않고 refuse — 진행 중 슬롯을 재사용하면 evicted op 의
+/// 늦은 CDP 콜백이 새 occupant 와 (kind,path) 오매칭할 수 있어 회피.
 pub fn cefDeferResponse(kind: window_ipc.DeferKind, path: []const u8) bool {
     if (path.len == 0 or path.len > PDF_PATH_STACK_BUF) return false;
     var ctx = g_current_call_ctx orelse return false;
@@ -2512,44 +2511,21 @@ pub fn cefDeferResponse(kind: window_ipc.DeferKind, path: []const u8) bool {
             break;
         }
     }
-    if (target == null) {
-        // 빈 슬롯 없음 — 가장 오래된 in_use 슬롯 evict.
-        var oldest: ?*PendingResp = null;
-        for (&g_pending_responses) |*slot| {
-            if (oldest == null or slot.generation < oldest.?.generation) oldest = slot;
-        }
-        const ev = oldest orelse return false;
-        // 버려지는 호출자 Promise 를 success:false 로 settle (영구 hang 방지).
-        var fb: [128]u8 = undefined;
-        const body = cmdFailureJson(ev.kind, &fb);
-        sendInvokeResponse(ev.browser, ev.frame, ev.seq_id, true, body);
-        target = ev;
-    }
+    // 빈 슬롯 없음(16 동시 미완료 — 비현실적) → refuse. 호출자(handler)가
+    // success:false fallback 송신. evict·재사용 안 함(cross-resolve race 회피).
+    const slot = target orelse return false;
 
-    const slot = target.?;
-    g_defer_generation +%= 1;
     slot.in_use = true;
     slot.browser = ctx.browser;
     slot.frame = ctx.frame;
     slot.seq_id = ctx.seq_id;
     slot.kind = kind;
     slot.browser_handle = ctx.browser_handle;
-    slot.generation = g_defer_generation;
     @memcpy(slot.path_buf[0..path.len], path);
     slot.path_len = path.len;
     ctx.deferred = true;
     g_current_call_ctx = ctx;
     return true;
-}
-
-/// `{from,cmd,ok:false,success:false}` 실패 본문 — evict/timeout 시 settle 용.
-fn cmdFailureJson(kind: window_ipc.DeferKind, buf: []u8) []const u8 {
-    const cmd = if (kind == .print) "print_to_pdf" else "capture_page";
-    return std.fmt.bufPrint(
-        buf,
-        "{{\"from\":\"zig-core\",\"cmd\":\"{s}\",\"ok\":false,\"success\":false}}",
-        .{cmd},
-    ) catch "{\"from\":\"zig-core\",\"ok\":false,\"success\":false}";
 }
 
 /// CDP 콜백 등에서 호출: (kind, path) 매칭 pending 에 응답 송신.

--- a/tests/e2e/_page.ts
+++ b/tests/e2e/_page.ts
@@ -57,10 +57,27 @@ export async function getMainPage(browser: Browser, timeoutMs = 25000): Promise<
   const deadline = Date.now() + timeoutMs;
   let lastUrls = "";
   while (Date.now() < deadline) {
-    const pages = await browser.pages();
+    let pages: Page[];
+    try {
+      pages = await browser.pages();
+    } catch {
+      // target 목록 자체가 attach 중 — 다음 루프에서 재시도.
+      await wait(100);
+      continue;
+    }
     const snapshots: string[] = [];
     for (const page of pages) {
-      const targetUrl = page.url() || "<empty>";
+      // page.url() 은 main frame 이 아직 attach 안 된 transient target 에서
+      // "Requesting main frame too early!" assert 를 던진다. Debug 빌드는
+      // 타이밍상 모든 frame 이 준비된 뒤 enumerate 되지만 ReleaseSafe/ReleaseFast
+      // 는 startup 이 빨라 attach 중 target 이 노출됨 → skip 후 다음 루프 재시도
+      // (바이너리 자체는 정상; 하니스를 binary-flavor 무관하게 하드닝).
+      let targetUrl: string;
+      try {
+        targetUrl = page.url() || "<empty>";
+      } catch {
+        continue;
+      }
       const href = await pageLocationHref(page);
       snapshots.push(`${targetUrl} -> ${href || "<unreadable>"}`);
       if (!isMainAppUrl(href)) continue;


### PR DESCRIPTION
PR #57 deferred-response 에 대한 `/code-review max` (9-angle) 후속. verify 통과한 findings 적용.

## Fixes
1. **eviction-reuse cross-resolve race 제거** (cef.zig) — Angle E: 슬롯 풀 시 evict·재사용하면 evicted op 의 늦은 CDP 가 새 occupant 와 (kind,path) 오매칭 → 엉뚱한 seq resolve. evict 대신 **refuse-when-full** (false → handler success:false fallback). onBeforeClose purge + SDK 타임아웃이 이미 pool bound → 순손실 없이 race·복잡도(generation/cmdFailureJson) 제거.
2. **withDeferTimeout 타이머 누수** (suji-js + suji-node) — `.finally(clearTimeout)`.
3. **getMainPage 하니스 robustness** (_page.ts) — not-ready target 의 `page.url()` "main frame too early" assert 를 try/catch skip.

## Test plan
- [x] `zig build` (Debug) + `-Doptimize=ReleaseSafe` — exit 0
- [x] `zig build test` — 891/900 (9 skip, 0 fail)
- [x] SDK 77+64, deferred-response e2e 2/2, capture-page 3/3 (Debug 바이너리)

## 별도 보고 — Windows ReleaseSafe 런타임 이슈 (이 PR 범위 밖)
조사 중 발견: Windows **ReleaseSafe/ReleaseFast 바이너리**가 `suji dev` 에서 렌더러 서브프로세스의 `onContextCreated` 를 안 띄움 → `window.__suji__` 미바인딩 (Debug 는 정상). render handler 는 정상 wiring·CEF 가 요청까지 함. e2e 하니스가 아니라 최적화 바이너리의 렌더러 V8 context 미생성이 근인. **별도 이슈로 추적** (PR #58 의 release.yml Windows=ReleaseSafe 영향 재검토 필요).