### PR TITLE
feat(config): suji.config.ts 빌드 훅 + 플랫폼별 빌드 + dev.env (mode/command 스레딩)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,6 +433,21 @@ suji.platform                                                // "macos" | "linux
 
 `suji.config.ts`가 생성 프로젝트의 source config이고, `suji.json`은 materialized JSON입니다. 네이티브 로더는 `suji.config.ts`/`.mts`/`.cts`/`.js`/`.mjs`/`.cjs`를 먼저 찾고, `@suji/cli`의 JS/TS config loader로 실제 코드를 평가한 뒤 JSON만 Zig 파서에 넘깁니다. 로더가 없는 직접 native 실행 환경에서는 JSON-compatible `defineConfig({ ... })` 정적 fallback만 사용합니다. config 파일은 신뢰한 프로젝트 코드로 실행됩니다. JSON Schema 제공: [`suji.schema.json`](./suji.schema.json) — IDE 자동완성 + 검증 지원.
 
+**프로그래밍 기능 (vite/rspack식 — 정적 JSON 미표현):** 함수형 config `defineConfig(({mode,command})=>({...}))`, **빌드 라이프사이클 훅** `build.beforeBuild`/`afterBuild`/`beforeDev`, **플랫폼별 빌드 오버라이드** `build.{mac,win,linux}`(현재 OS로 fold), **dev.env**(dev 서버 spawn 시 주입), `window` 단축(→`windows[]`)·`dev.devUrl`(→`frontend.dev_url`). loader가 평가 시 현재 플랫폼 build를 fold + 훅 함수를 `build._hooks` 마커로 strip(함수 직렬화 불가)해 JSON으로 emit하고, CLI(`config.zig`가 `--command/--mode` 전달)가 라이프사이클 지점에서 `node load-config.js --hook <name>` 로 훅을 재실행한다. 서명 우선순위: CLI 플래그 > env > `config.build.*` > adhoc. 회귀: `tests/config-loader/run.sh`(loader normalize/hook) + `tests/config_test.zig`(Zig build/dev 파싱).
+
+```ts
+// suji.config.ts
+import { defineConfig } from "@suji/cli";
+export default defineConfig(({ mode }) => ({
+  app: { name: "My App", version: "1.0.0" },
+  build: {
+    async beforeBuild() { /* … */ },
+    mac: { sign: "identity", notarize: mode === "production" },
+  },
+  dev: { devUrl: "http://localhost:12300", env: { VITE_API: "http://localhost:8787" } },
+}));
+```
+
 ```json
 {
   "$schema": "./suji.schema.json",

--- a/packages/suji-cli/bin/load-config.js
+++ b/packages/suji-cli/bin/load-config.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { configToJson, loadConfig } from "../lib/config-loader.js";
+import { configToJson, loadConfig, runHook } from "../lib/config-loader.js";
 
 function parseArgs(argv) {
   const options = {};
@@ -40,6 +40,11 @@ function parseArgs(argv) {
       options.mode = mode;
       continue;
     }
+    const hook = readValue("--hook");
+    if (hook !== null) {
+      options.hook = hook;
+      continue;
+    }
 
     throw new Error(`Unknown argument: ${arg}`);
   }
@@ -49,7 +54,12 @@ function parseArgs(argv) {
 try {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
-    process.stdout.write("Usage: suji-config [--cwd <dir>] [--config <file>] [--command <cmd>] [--mode <mode>]\n");
+    process.stdout.write("Usage: suji-config [--cwd <dir>] [--config <file>] [--command <cmd>] [--mode <mode>] [--hook <name>]\n");
+    process.exit(0);
+  }
+  if (options.hook) {
+    // Build lifecycle hook mode: run config.build.<hook>(env). No stdout config emit.
+    await runHook(options);
     process.exit(0);
   }
   const config = await loadConfig(options);

--- a/packages/suji-cli/index.d.ts
+++ b/packages/suji-cli/index.d.ts
@@ -1,10 +1,62 @@
-export type SujiConfig = Record<string, unknown>;
-
 export interface ConfigEnv {
   command: string;
   mode: string;
   cwd: string;
   configPath: string;
+}
+
+/** Code-signing mode (matches the `--sign` CLI flag). */
+export type SigningMode = "adhoc" | "identity" | "none";
+
+/** Per-platform build overrides (folded for the current OS at load time). */
+export interface PlatformBuild {
+  sign?: SigningMode;
+  identity?: string;
+  notarize?: boolean;
+  dmg?: boolean;
+  sandbox?: boolean;
+  entitlements?: string;
+}
+
+/**
+ * Build configuration + lifecycle hooks. Hooks are functions (programmatic — JSON
+ * cannot express them); they are stripped from the resolved config and re-invoked by
+ * the CLI at the matching lifecycle point. Per-platform overrides (mac/win/linux) are
+ * folded over the top-level fields for the current OS.
+ */
+export interface BuildConfig extends PlatformBuild {
+  beforeBuild?: (env: ConfigEnv) => void | Promise<void>;
+  afterBuild?: (env: ConfigEnv) => void | Promise<void>;
+  beforeDev?: (env: ConfigEnv) => void | Promise<void>;
+  mac?: PlatformBuild;
+  win?: PlatformBuild;
+  linux?: PlatformBuild;
+}
+
+/** Dev server options. */
+export interface DevConfig {
+  /** Folds into `frontend.dev_url`. */
+  devUrl?: string;
+  /** Extra env vars injected when spawning the frontend dev server. */
+  env?: Record<string, string>;
+}
+
+/**
+ * Suji project config. Known fields are typed for autocomplete; the index signature
+ * keeps it open for fields the Zig core consumes (app/windows/backend/frontend/fs/…).
+ */
+export interface SujiConfig {
+  app?: Record<string, unknown>;
+  /** Single-window shorthand — normalized to `windows: [window]`. */
+  window?: Record<string, unknown>;
+  windows?: Record<string, unknown>[];
+  backend?: Record<string, unknown>;
+  backends?: Record<string, unknown>[];
+  frontend?: Record<string, unknown>;
+  plugins?: unknown[];
+  build?: BuildConfig;
+  dev?: DevConfig;
+  [key: string]: unknown;
 }
 
 export type SujiConfigFactory<T extends SujiConfig = SujiConfig> = (env: ConfigEnv) => T | Promise<T>;
@@ -18,10 +70,15 @@ export interface LoadConfigOptions {
   config?: string;
   command?: string;
   mode?: string;
+  /** Run a single build lifecycle hook (beforeBuild/afterBuild/beforeDev) instead of resolving. */
+  hook?: string;
 }
 
 export declare function findConfigFile(cwd?: string): string | null;
 
 export declare function loadConfig(options?: LoadConfigOptions): Promise<SujiConfig>;
+
+/** Run a build lifecycle hook (config.build.<hook>). Used by the CLI; no stdout. */
+export declare function runHook(options?: LoadConfigOptions): Promise<void>;
 
 export declare function configToJson(config: SujiConfig): string;

--- a/packages/suji-cli/index.js
+++ b/packages/suji-cli/index.js
@@ -4,4 +4,5 @@ export {
   defineConfig,
   findConfigFile,
   loadConfig,
+  runHook,
 } from "./lib/config-loader.js";

--- a/packages/suji-cli/lib/config-loader.js
+++ b/packages/suji-cli/lib/config-loader.js
@@ -41,8 +41,88 @@ export async function loadConfig(options = {}) {
       cwd,
     });
 
-  assertConfigObject(value);
-  return value;
+  // Normalize ergonomic/programmatic keys into the canonical shape the Zig core
+  // consumes (window→windows, dev.devUrl→frontend.dev_url, per-platform build fold,
+  // build hooks stripped to a `_hooks` marker). Strips functions so assertConfigObject
+  // (JSON-only) passes — hooks are re-loaded with functions intact via runHook().
+  const normalized = normalizeConfig(value, configPath);
+  assertConfigObject(normalized);
+  return normalized;
+}
+
+/**
+ * Run a build lifecycle hook (build.beforeBuild / afterBuild / beforeDev). Loads the
+ * config with functions intact (no normalize/strip) and invokes the named hook.
+ */
+export async function runHook(options = {}) {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const configPath = resolveConfigPath(cwd, options.config);
+  if (!configPath) throw new Error(`Suji config not found in ${cwd}`);
+  if (basename(configPath) === "suji.json") return; // JSON config has no hooks
+  const context = {
+    command: options.command ?? "dev",
+    mode: options.mode ?? process.env.NODE_ENV ?? "development",
+    cwd,
+    configPath,
+  };
+  const config = await loadCodeConfig(configPath, context);
+  const hook = config && config.build && config.build[options.hook];
+  if (typeof hook === "function") await hook(context);
+}
+
+function currentPlatformKey() {
+  if (process.platform === "darwin") return "mac";
+  if (process.platform === "win32") return "win";
+  return "linux";
+}
+
+function isPlainObject(v) {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+/** Canonicalize config.ts ergonomics + strip non-serializable build hooks. */
+function normalizeConfig(config, configPath) {
+  if (!isPlainObject(config)) return config;
+  const out = { ...config };
+
+  // window (singular shorthand) → windows: [window]
+  if (isPlainObject(out.window) && out.windows === undefined) {
+    out.windows = [out.window];
+  }
+  delete out.window;
+
+  // dev.devUrl → frontend.dev_url (config.ts ergonomic; only fills a gap)
+  if (isPlainObject(out.dev) && out.dev.devUrl) {
+    out.frontend = { ...(out.frontend || {}) };
+    if (out.frontend.dev_url === undefined) out.frontend.dev_url = out.dev.devUrl;
+  }
+  // keep only serializable dev.env for the CLI dev-server spawn
+  if (isPlainObject(out.dev)) {
+    out.dev = { env: isPlainObject(out.dev.env) ? out.dev.env : {} };
+  }
+
+  // build: fold current-platform overrides over top-level fields; strip hook functions.
+  if (isPlainObject(out.build)) {
+    const b = out.build;
+    const platOverride = isPlainObject(b[currentPlatformKey()]) ? b[currentPlatformKey()] : {};
+    const flat = {};
+    for (const k of ["sign", "identity", "notarize", "dmg", "sandbox", "entitlements"]) {
+      const v = platOverride[k] !== undefined ? platOverride[k] : b[k];
+      if (v !== undefined) flat[k] = v;
+    }
+    flat._hooks = {
+      beforeBuild: typeof b.beforeBuild === "function",
+      afterBuild: typeof b.afterBuild === "function",
+      beforeDev: typeof b.beforeDev === "function",
+    };
+    flat._configFile = configPath;
+    out.build = flat;
+    if (flat.entitlements && (!out.app || out.app.entitlements === undefined)) {
+      out.app = { ...(out.app || {}), entitlements: flat.entitlements };
+    }
+  }
+
+  return out;
 }
 
 export function configToJson(config) {

--- a/src/cli/types_cmd.zig
+++ b/src/cli/types_cmd.zig
@@ -57,8 +57,8 @@ pub fn run(allocator: std.mem.Allocator, types_args: []const [:0]const u8) !void
         }
     }
 
-    var config = suji.Config.load(allocator) catch {
-        std.debug.print("Error: suji.json not found (프로젝트 루트에서 실행).\n", .{});
+    var config = suji.Config.loadCmd(allocator, .types) catch {
+        std.debug.print("Error: suji.config.ts / suji.json not found (프로젝트 루트에서 실행).\n", .{});
         return;
     };
     defer config.deinit();

--- a/src/core/config.zig
+++ b/src/core/config.zig
@@ -20,6 +20,11 @@ pub const Config = struct {
     shell: Shell = .{},
     dialog: Dialog = .{},
     security: Security = .{},
+    /// 빌드 설정 + 라이프사이클 훅 메타 (`suji.config.ts` build 전용 — JSON 미표현).
+    /// loader `normalize` 가 현재 플랫폼 오버라이드를 fold + 훅을 _hooks 마커로 strip 한 결과.
+    build: Build = .{},
+    /// dev 서버 설정 (`suji.config.ts` dev 전용 — dev.env 주입).
+    dev: Dev = .{},
 
     // _arena는 포인터로 보관. 값으로 담으면 `Config { ._arena = arena }` 시점에 arena의
     // 내부 state(buffer 리스트 head)가 COPY되고, 이후 동일 arena를 거치는 할당(예:
@@ -180,13 +185,64 @@ pub const Config = struct {
         iframe_allowed_origins: []const [:0]const u8 = &.{},
     };
 
+    /// `suji.config.ts` `build` 의 resolved 결과 (loader 가 현재 플랫폼 mac/win/linux
+    /// 오버라이드를 이미 fold). CLI 플래그/env > 이 값 > adhoc default. 훅은 함수 직렬화
+    /// 불가라 존재 플래그만 (loader `--hook` 모드가 config 재로드·실행).
+    pub const Build = struct {
+        /// "adhoc" | "identity" | "none" (release_opts.parseSigningMode 입력).
+        sign: ?[:0]const u8 = null,
+        identity: ?[:0]const u8 = null,
+        notarize: bool = false,
+        dmg: bool = false,
+        sandbox: bool = false,
+        has_before_build: bool = false,
+        has_after_build: bool = false,
+        has_before_dev: bool = false,
+        /// suji.config.* 절대경로 (loader `_configFile`). null = json 출처(훅 불가).
+        config_file: ?[:0]const u8 = null,
+    };
+
+    /// dev 서버 spawn 시 주입할 env (`suji.config.ts` `dev.env`).
+    pub const Dev = struct {
+        env: []const EnvPair = &.{},
+        pub const EnvPair = struct { name: [:0]const u8, value: [:0]const u8 };
+    };
+
+    /// 어떤 CLI 명령에서 로드되는지 — JS 로더에 mode/command 전달 (함수형 config 분기용).
+    pub const Command = enum {
+        dev,
+        build,
+        run,
+        types,
+
+        pub fn modeStr(self: Command) []const u8 {
+            return switch (self) {
+                .dev, .types => "development",
+                .build, .run => "production",
+            };
+        }
+        pub fn commandStr(self: Command) []const u8 {
+            return switch (self) {
+                .dev => "dev",
+                .build => "build",
+                .run => "run",
+                .types => "dev",
+            };
+        }
+    };
+
     /// 시작 시 자동 생성할 창의 최대 개수.
     /// 사용자가 실수로 큰 배열을 넣어도 시작 hang/OOM 방지 (각 창은 NSWindow + GPU surface 생성).
     /// 런타임에 추가 창이 필요하면 wm.create / create_window IPC로 만들 수 있음.
     pub const MAX_STARTUP_WINDOWS: usize = 32;
 
     pub fn load(allocator: std.mem.Allocator) !Config {
-        return loadConfigFile(allocator);
+        return loadConfigFile(allocator, .dev);
+    }
+
+    /// 명시 명령으로 로드 — `suji.config.ts` 함수형 config 에 mode/command 를 전달.
+    pub fn loadCmd(allocator: std.mem.Allocator, cmd: Command) !Config {
+        return loadConfigFile(allocator, cmd);
     }
 
     pub fn deinit(self: *Config) void {
@@ -285,10 +341,10 @@ pub const Config = struct {
     const CONFIG_LOADER_STDERR_MAX_BYTES = 1024 * 64;
     const DEFAULT_CONFIG_LOADER_PATH = "node_modules/@suji/cli/bin/load-config.js";
 
-    fn loadConfigFile(allocator: std.mem.Allocator) !Config {
+    fn loadConfigFile(allocator: std.mem.Allocator, cmd: Command) !Config {
         const config_path = findConfigFilePath() orelse return error.ConfigNotFound;
         if (isJsonConfigPath(config_path)) return loadJsonConfigFile(allocator, config_path);
-        return loadCodeConfigFile(allocator, config_path);
+        return loadCodeConfigFile(allocator, config_path, cmd);
     }
 
     fn findConfigFilePath() ?[]const u8 {
@@ -309,9 +365,9 @@ pub const Config = struct {
         return loadFromJsonBytes(allocator, content);
     }
 
-    fn loadCodeConfigFile(allocator: std.mem.Allocator, path: []const u8) !Config {
+    fn loadCodeConfigFile(allocator: std.mem.Allocator, path: []const u8, cmd: Command) !Config {
         if (resolveConfigLoader()) |loader_path| {
-            return loadFromCodeConfigWithLoader(allocator, path, loader_path);
+            return loadFromCodeConfigWithLoader(allocator, path, loader_path, cmd);
         }
 
         std.debug.print(
@@ -331,11 +387,15 @@ pub const Config = struct {
         return DEFAULT_CONFIG_LOADER_PATH;
     }
 
-    fn loadFromCodeConfigWithLoader(allocator: std.mem.Allocator, path: []const u8, loader_path: []const u8) !Config {
+    fn loadFromCodeConfigWithLoader(allocator: std.mem.Allocator, path: []const u8, loader_path: []const u8, cmd: Command) !Config {
         const node_bin = runtime.env("SUJI_NODE_BIN") orelse "node";
         const argv = [_][]const u8{
             node_bin,
             loader_path,
+            "--command",
+            cmd.commandStr(),
+            "--mode",
+            cmd.modeStr(),
             "--cwd",
             ".",
             "--config",
@@ -642,7 +702,78 @@ pub const Config = struct {
             }
         }
 
+        // build — loader `normalize` 가 현재 플랫폼 오버라이드를 이미 fold 한 평탄 객체.
+        if (root.get("build")) |bv| {
+            if (bv == .object) {
+                const b = bv.object;
+                if (getStr(b, "sign")) |s| config.build.sign = dupeStr(a, s);
+                if (getStr(b, "identity")) |s| config.build.identity = dupeStr(a, s);
+                if (getBool(b, "notarize")) |x| config.build.notarize = x;
+                if (getBool(b, "dmg")) |x| config.build.dmg = x;
+                if (getBool(b, "sandbox")) |x| config.build.sandbox = x;
+                if (getStr(b, "_configFile")) |s| config.build.config_file = dupeStr(a, s);
+                if (b.get("_hooks")) |hv| {
+                    if (hv == .object) {
+                        const h = hv.object;
+                        if (getBool(h, "beforeBuild")) |x| config.build.has_before_build = x;
+                        if (getBool(h, "afterBuild")) |x| config.build.has_after_build = x;
+                        if (getBool(h, "beforeDev")) |x| config.build.has_before_dev = x;
+                    }
+                }
+            }
+        }
+
+        // dev.env — dev 서버 spawn 시 주입.
+        if (root.get("dev")) |dv| {
+            if (dv == .object) {
+                if (dv.object.get("env")) |ev| {
+                    if (ev == .object) {
+                        var list = std.ArrayList(Dev.EnvPair).empty;
+                        var it = ev.object.iterator();
+                        while (it.next()) |e| {
+                            if (e.value_ptr.* != .string) continue;
+                            list.append(a, .{
+                                .name = dupeStr(a, e.key_ptr.*),
+                                .value = dupeStr(a, e.value_ptr.*.string),
+                            }) catch continue;
+                        }
+                        config.dev.env = list.toOwnedSlice(a) catch &.{};
+                    }
+                }
+            }
+        }
+
         return config;
+    }
+
+    /// `suji.config.ts` build 훅 실행 (CLI 라이프사이클 지점에서 호출). 훅 부재/로더
+    /// 부재/오류는 graceful (빌드 자체는 진행). loader `--hook` 모드가 config 를 재로드·실행.
+    pub fn runBuildHook(self: *const Config, hook_name: []const u8, cmd: Command) void {
+        const config_file = self.build.config_file orelse return;
+        const loader_path = resolveConfigLoader() orelse {
+            std.debug.print("[suji] config: JS loader not found; skipping {s} hook\n", .{hook_name});
+            return;
+        };
+        const node_bin = runtime.env("SUJI_NODE_BIN") orelse "node";
+        std.debug.print("[suji] running {s} hook...\n", .{hook_name});
+        const argv = [_][]const u8{
+            node_bin,        loader_path,           "--command", cmd.commandStr(),
+            "--mode",        cmd.modeStr(),          "--cwd",     ".",
+            "--config",      config_file,           "--hook",    hook_name,
+        };
+        // stdio 상속 → 훅 출력이 그대로 보인다. exit code 만 검사.
+        var child = std.process.spawn(runtime.io, .{ .argv = &argv }) catch |e| {
+            std.debug.print("[suji] config: {s} hook spawn failed ({s})\n", .{ hook_name, @errorName(e) });
+            return;
+        };
+        const term = child.wait(runtime.io) catch |e| {
+            std.debug.print("[suji] config: {s} hook wait failed ({s})\n", .{ hook_name, @errorName(e) });
+            return;
+        };
+        switch (term) {
+            .exited => |code| if (code != 0) std.debug.print("[suji] config: {s} hook exited {d}\n", .{ hook_name, code }),
+            else => std.debug.print("[suji] config: {s} hook terminated abnormally\n", .{hook_name}),
+        }
     }
 
     pub fn isMultiBackend(self: *const Config) bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -300,25 +300,28 @@ fn flagOrEnv(args: []const [:0]const u8, flag: []const u8, env_name: []const u8)
 }
 
 fn runBuild(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
-    var config = suji.Config.load(allocator) catch {
-        std.debug.print("Error: suji.toml or suji.json not found.\n", .{});
+    var config = suji.Config.loadCmd(allocator, .build) catch {
+        std.debug.print("Error: suji.config.ts / suji.json not found.\n", .{});
         return;
     };
     defer config.deinit();
 
     std.debug.print("[suji] production build - {s}\n", .{config.app.name});
 
+    // suji.config.ts beforeBuild 훅 — 빌드 전 사용자 스크립트 (no-op if absent).
+    if (config.build.has_before_build) config.runBuildHook("beforeBuild", .build);
+
     // 서명/공증/패키징 옵션 (zero-native `--signing/--identity` 패리티).
-    // 플래그 > env(CI secret) 우선. 기본 adhoc(기존 동작 유지).
-    const signing = release_opts.parseSigningMode(flagOrEnv(args, "--sign", "SUJI_SIGN"));
-    const identity = flagOrEnv(args, "--identity", "SUJI_SIGN_IDENTITY");
-    const want_notarize = release_opts.hasFlag(args, "--notarize") or runtime.env("SUJI_NOTARIZE") != null;
-    const want_dmg = release_opts.hasFlag(args, "--dmg") or runtime.env("SUJI_DMG") != null;
+    // 우선순위: CLI 플래그 > env(CI secret) > suji.config.ts build.* > adhoc default.
+    const signing = release_opts.parseSigningMode(flagOrEnv(args, "--sign", "SUJI_SIGN") orelse config.build.sign);
+    const identity = flagOrEnv(args, "--identity", "SUJI_SIGN_IDENTITY") orelse config.build.identity;
+    const want_notarize = release_opts.hasFlag(args, "--notarize") or runtime.env("SUJI_NOTARIZE") != null or config.build.notarize;
+    const want_dmg = release_opts.hasFlag(args, "--dmg") or runtime.env("SUJI_DMG") != null or config.build.dmg;
     const want_deb = release_opts.hasFlag(args, "--deb") or runtime.env("SUJI_DEB") != null;
     const want_appimage = release_opts.hasFlag(args, "--appimage") or runtime.env("SUJI_APPIMAGE") != null;
     // App Sandbox(MAS) vs non-sandbox(Developer ID, 기본). 기본 false 라
     // 기존 Developer ID/notarize 배포 무회귀.
-    const want_sandbox = release_opts.hasFlag(args, "--sandbox") or runtime.env("SUJI_SANDBOX") != null;
+    const want_sandbox = release_opts.hasFlag(args, "--sandbox") or runtime.env("SUJI_SANDBOX") != null or config.build.sandbox;
     // Strict mode: 1 개 이상 backend/plugin dylib 가 packaging 에서 누락되면
     // process exit code 를 non-zero 로 만든다. 기본은 lenient + WARN (기존 동작
     // 무회귀). CI 가 silent miss 를 검출 못 하던 문제(`/code-review max PR#41`
@@ -550,6 +553,9 @@ fn runBuild(allocator: std.mem.Allocator, args: []const [:0]const u8) !void {
         else => std.debug.print("[suji] packaging unsupported on this OS\n", .{}),
     }
     _ = .{ signing, identity, want_notarize, want_dmg, want_deb, want_appimage, want_sandbox, want_strict }; // 비-Windows/macOS arm 미사용 해소
+
+    // suji.config.ts afterBuild 훅 — 번들 산출 후 사용자 스크립트 (no-op if absent).
+    if (config.build.has_after_build) config.runBuildHook("afterBuild", .build);
 }
 
 // ============================================
@@ -611,21 +617,26 @@ fn runCmdEnv(allocator: std.mem.Allocator, argv: []const []const u8, env_pairs: 
 // 프론트엔드
 // ============================================
 
-fn startFrontendDev(allocator: std.mem.Allocator, frontend: suji.Config.Frontend) !std.process.Child {
-    _ = allocator;
-    return try spawnShellInDir(frontend.dev_command, frontend.dir);
+fn startFrontendDev(allocator: std.mem.Allocator, frontend: suji.Config.Frontend, dev_env: []const suji.Config.Dev.EnvPair) !std.process.Child {
+    if (dev_env.len == 0) return try spawnShellInDir(frontend.dev_command, frontend.dir, null);
+    // suji.config.ts dev.env — 부모 환경 clone 위에 주입. env_map 은 spawn 된 dev 서버가
+    // dev 세션 내내 살아있어야 하므로 heap 에 두고 의도적으로 유지(deinit X — 1회성 dev 스폰).
+    const env_map = try allocator.create(std.process.Environ.Map);
+    env_map.* = if (runtime.environ_map) |m| try m.clone(allocator) else std.process.Environ.Map.init(allocator);
+    for (dev_env) |pair| env_map.put(pair.name, pair.value) catch {};
+    return try spawnShellInDir(frontend.dev_command, frontend.dir, env_map);
 }
 
-fn spawnShellInDir(command: []const u8, cwd_path: []const u8) !std.process.Child {
+fn spawnShellInDir(command: []const u8, cwd_path: []const u8, env_map: ?*const std.process.Environ.Map) !std.process.Child {
     const argv: []const []const u8 = if (builtin.os.tag == .windows)
         &.{ "cmd", "/C", command }
     else
         &.{ "sh", "-c", command };
-    return try std.process.spawn(runtime.io, .{ .argv = argv, .cwd = .{ .path = cwd_path } });
+    return try std.process.spawn(runtime.io, .{ .argv = argv, .cwd = .{ .path = cwd_path }, .environ_map = env_map });
 }
 
 fn runShellInDir(command: []const u8, cwd_path: []const u8) !void {
-    var child = try spawnShellInDir(command, cwd_path);
+    var child = try spawnShellInDir(command, cwd_path, null);
     const result = try child.wait(runtime.io);
     switch (result) {
         .exited => |code| if (code != 0) return error.CommandFailed,
@@ -643,12 +654,16 @@ fn buildFrontend(allocator: std.mem.Allocator, frontend: suji.Config.Frontend) !
 // ============================================
 
 fn runDev(allocator: std.mem.Allocator) !void {
-    var config = suji.Config.load(allocator) catch {
-        std.debug.print("Error: suji.toml or suji.json not found.\n", .{});
+    var config = suji.Config.loadCmd(allocator, .dev) catch {
+        std.debug.print("Error: suji.config.ts / suji.json not found.\n", .{});
         return;
     };
     defer config.deinit();
     setGlobalConfig(&config);
+
+    // suji.config.ts beforeDev 훅 — dev 서버/창 기동 전 사용자 스크립트 (no-op if absent).
+    if (config.build.has_before_dev) config.runBuildHook("beforeDev", .dev);
+
     var owned_csp: ?[]u8 = null;
     defer if (owned_csp) |csp| allocator.free(csp);
 
@@ -702,7 +717,7 @@ fn runDev(allocator: std.mem.Allocator) !void {
 
     // 프론트엔드 dev 서버
     std.debug.print("[suji] starting frontend dev server...\n", .{});
-    var frontend_proc = startFrontendDev(allocator, config.frontend) catch |err| {
+    var frontend_proc = startFrontendDev(allocator, config.frontend, config.dev.env) catch |err| {
         std.debug.print("[suji] frontend dev server failed: {}, opening without frontend\n", .{err});
         try openWindow(allocator, &config, event_bus, .dev, main_url);
         return;
@@ -832,8 +847,8 @@ fn startBackendWatcher(allocator: std.mem.Allocator, config: *const suji.Config,
 }
 
 fn runProd(allocator: std.mem.Allocator) !void {
-    var config = suji.Config.load(allocator) catch {
-        std.debug.print("Error: suji.toml or suji.json not found.\n", .{});
+    var config = suji.Config.loadCmd(allocator, .run) catch {
+        std.debug.print("Error: suji.config.ts / suji.json not found.\n", .{});
         return;
     };
     defer config.deinit();

--- a/tests/config-loader/run.sh
+++ b/tests/config-loader/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# @suji/cli config-loader 회귀 테스트 — config.ts 빌드 훅/플랫폼 빌드/dev.env normalize.
+# CEF/Zig 무관, node 만 필요. (build hooks/platform-build/dev.env 후속 작업 가드)
+#
+# 검증:
+#  1. 함수형 config 가 mode/command 로 평가
+#  2. window 단축 → windows 배열, dev.devUrl → frontend.dev_url
+#  3. 플랫폼별 build 오버라이드 fold(현재 OS) + build._hooks 플래그 + _configFile
+#  4. dev.env 보존, 함수(훅) strip 후 유효 JSON
+#  5. --hook 모드가 해당 훅을 mode/command 와 실행, 부재 훅은 no-op
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOADER="$ROOT/packages/suji-cli/bin/load-config.js"
+command -v node >/dev/null || { echo "FAIL: node not found"; exit 1; }
+[ -f "$LOADER" ] || { echo "FAIL: loader not found at $LOADER"; exit 1; }
+
+PASS=0
+ok() { PASS=$((PASS+1)); echo "  ok: $1"; }
+fail() { echo "FAIL: $1"; exit 1; }
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+cat > "$T/suji.config.js" <<'EOF'
+export default ({ mode, command }) => ({
+  app: { name: "CfgApp", version: "1.0.0" },
+  window: { title: "TS", width: 1280, height: 800 },
+  build: {
+    sign: "adhoc",
+    mac: { sign: "identity", notarize: mode === "production", entitlements: "my.entitlements" },
+    win: { sign: "none" }, linux: { sign: "none" },
+    async beforeBuild({ mode }) { console.error("HOOK:beforeBuild:" + mode); },
+    async afterBuild() { console.error("HOOK:afterBuild"); },
+  },
+  dev: { devUrl: "http://localhost:4321", env: { MY_VAR: "yes" } },
+});
+EOF
+
+# ---- 1-4: resolve (production/build) ----
+OUT="$(node "$LOADER" --command build --mode production --cwd "$T" --config "$T/suji.config.js")"
+echo "$OUT" | node -e '
+const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
+const a = (c, m) => { if (!c) { console.error("ASSERT FAIL: " + m); process.exit(1); } };
+a(Array.isArray(j.windows) && j.windows[0].width === 1280, "window shorthand -> windows array");
+a(j.frontend.dev_url === "http://localhost:4321", "dev.devUrl -> frontend.dev_url");
+a(j.build && j.build._hooks.beforeBuild === true && j.build._hooks.afterBuild === true && j.build._hooks.beforeDev === false, "build._hooks flags");
+a(typeof j.build._configFile === "string", "_configFile recorded");
+a(j.dev && j.dev.env && j.dev.env.MY_VAR === "yes", "dev.env preserved");
+const plat = process.platform === "darwin" ? "mac" : process.platform === "win32" ? "win" : "linux";
+if (plat === "mac") {
+  a(j.build.sign === "identity", "mac build override folded (sign)");
+  a(j.build.notarize === true, "mac notarize = (mode===production)");
+  a(j.app.entitlements === "my.entitlements", "build.mac.entitlements -> app.entitlements");
+} else {
+  a(j.build.sign === "none", plat + " build override folded");
+}
+// functions must be stripped (valid JSON already parsed above)
+a(typeof j.build.beforeBuild === "undefined", "hook functions stripped from emitted config");
+console.error("resolve assertions passed (platform=" + plat + ")");
+' || fail "resolve assertions"
+ok "resolve: window/devUrl/platform-build/hooks/dev.env normalization"
+
+# ---- 5: hook execution ----
+HB="$(node "$LOADER" --command build --mode production --cwd "$T" --config "$T/suji.config.js" --hook beforeBuild 2>&1 || true)"
+echo "$HB" | grep -q "HOOK:beforeBuild:production" || fail "beforeBuild hook did not run with mode=production (got: $HB)"
+ok "beforeBuild hook runs with env (mode=production)"
+
+HM="$(node "$LOADER" --cwd "$T" --config "$T/suji.config.js" --hook beforeDev 2>&1 || true)"
+[ -z "$HM" ] || fail "missing hook should be silent no-op (got: $HM)"
+ok "missing hook is a no-op"
+
+echo "PASS: $PASS config-loader checks"

--- a/tests/config_test.zig
+++ b/tests/config_test.zig
@@ -540,3 +540,58 @@ test "회귀: main.zig가 config.app.quit_on_all_windows_closed 분기 + listene
         try std.testing.expect(std.mem.indexOf(u8, source, needle) != null);
     }
 }
+
+// ============================================
+// suji.config.ts build/dev (loader 가 normalize 해서 emit 하는 키)
+// ============================================
+
+test "Config.loadFromJsonBytes parses build object (sign/notarize/_hooks/_configFile)" {
+    var cfg = try config.Config.loadFromJsonBytes(std.testing.allocator,
+        \\{
+        \\  "app": { "name": "x" },
+        \\  "build": {
+        \\    "sign": "identity", "identity": "Developer ID: Acme",
+        \\    "notarize": true, "dmg": true, "sandbox": false,
+        \\    "_configFile": "/abs/suji.config.ts",
+        \\    "_hooks": { "beforeBuild": true, "afterBuild": false, "beforeDev": true }
+        \\  }
+        \\}
+    );
+    defer cfg.deinit();
+    try std.testing.expectEqualStrings("identity", cfg.build.sign.?);
+    try std.testing.expectEqualStrings("Developer ID: Acme", cfg.build.identity.?);
+    try std.testing.expect(cfg.build.notarize);
+    try std.testing.expect(cfg.build.dmg);
+    try std.testing.expect(!cfg.build.sandbox);
+    try std.testing.expectEqualStrings("/abs/suji.config.ts", cfg.build.config_file.?);
+    try std.testing.expect(cfg.build.has_before_build);
+    try std.testing.expect(!cfg.build.has_after_build);
+    try std.testing.expect(cfg.build.has_before_dev);
+}
+
+test "Config.loadFromJsonBytes: build 부재 시 기본값" {
+    var cfg = try config.Config.loadFromJsonBytes(std.testing.allocator, "{ \"app\": { \"name\": \"x\" } }");
+    defer cfg.deinit();
+    try std.testing.expect(cfg.build.sign == null);
+    try std.testing.expect(cfg.build.config_file == null);
+    try std.testing.expect(!cfg.build.has_before_build);
+    try std.testing.expectEqual(@as(usize, 0), cfg.dev.env.len);
+}
+
+test "Config.loadFromJsonBytes parses dev.env (순서 보존)" {
+    var cfg = try config.Config.loadFromJsonBytes(std.testing.allocator,
+        \\{ "app": { "name": "x" }, "dev": { "env": { "FOO": "bar", "BAZ": "qux" } } }
+    );
+    defer cfg.deinit();
+    try std.testing.expectEqual(@as(usize, 2), cfg.dev.env.len);
+    try std.testing.expectEqualStrings("FOO", cfg.dev.env[0].name);
+    try std.testing.expectEqualStrings("bar", cfg.dev.env[0].value);
+    try std.testing.expectEqualStrings("BAZ", cfg.dev.env[1].name);
+}
+
+test "Config.Command modeStr/commandStr 매핑" {
+    try std.testing.expectEqualStrings("production", config.Config.Command.build.modeStr());
+    try std.testing.expectEqualStrings("build", config.Config.Command.build.commandStr());
+    try std.testing.expectEqualStrings("development", config.Config.Command.dev.modeStr());
+    try std.testing.expectEqualStrings("dev", config.Config.Command.types.commandStr());
+}


### PR DESCRIPTION
PR #66(설계 조율)의 후속 — config 설계의 **additive 파트**. main 의 `@suji/cli` 노드 config 로더(함수형 config 이미 지원)에 vite/rspack식 프로그래밍 기능을 추가합니다. 정적 JSON 이 표현 못 하는 것만, 기존 config 로딩 **무회귀**(함수 없는 config 불변).

## `@suji/cli` 로더 (canonical)
- `lib/config-loader.js` — `normalizeConfig`: `window`→`windows`, `dev.devUrl`→`frontend.dev_url`, 현재 플랫폼 `build.{mac,win,linux}` fold, build 훅 함수 strip→`build._hooks` 마커 + `_configFile`, `build.entitlements`→`app.entitlements`. `assertConfigObject`(JSON-only) 전에 적용(함수 strip 후 통과).
- `bin/load-config.js` — `--hook <name>` 모드: `runHook` 이 config 재로드(함수 intact)·실행.
- `index.{js,d.ts}` — `runHook` export + `BuildConfig`/`PlatformBuild`/`DevConfig`/`SujiConfig` 타입(autocomplete).

## Zig 코어
- `config.zig` — `Build`/`Dev`/`Command` 구조체 + `loadFromJsonBytes` build/dev 파싱 + `loadCmd(cmd)`(로더에 `--command/--mode` 전달 → 함수형 config 빌드별 분기) + `runBuildHook`(node `--hook` 재실행).
- `main.zig` — runBuild/runDev/runProd + types `loadCmd` 사용. runBuild `beforeBuild`/`afterBuild` 훅 + 서명 폴백(**플래그 > env > `config.build.*` > adhoc**). runDev `beforeDev` 훅 + `dev.env` 를 dev 서버 spawn 에 주입.

## 검증
- `tests/config-loader/run.sh`(node, 3 케이스: normalize/hook) · `tests/config_test.zig`(build/dev/Command 4 케이스, 37/37) · e2e `suji types` config.ts 해석 · `zig build`/`lib`(모바일) 통과.

## 정직
- 따옴표 든 store 키처럼, config 의 함수형 표현은 신뢰한 프로젝트 코드로 실행됨(기존 모델 유지).
- esbuild 미설치 환경의 `.ts` config 는 node type-stripping 또는 정적 fallback 경로(기존 main 동작 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)