### PR TITLE
feat(python): packaged .app/CLI 번들 + PYTHONHOME 자립 해석 (후속 마감)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ permissions:
 
 env:
   NODE_VERSION: '24.14.1'
+  # embedded CPython (python-build-standalone install_only) — released CLI 가 python
+  # 백엔드를 batteries-included 로 지원(libnode 선례 동형). scripts/stage-python.sh.
+  PYTHON_VERSION: '3.13.13'
+  PYTHON_PBS_TAG: '20260602'
   RUST_TOOLCHAIN: '1.93.0'
   GO_VERSION: '1.26.0'
 
@@ -180,6 +184,14 @@ jobs:
           Copy-Item -Force -LiteralPath $importLib -Destination "$nodeDir\libnode.dll.a"
           Copy-Item -Recurse -Force -Path "$includeDir\*" -Destination "$nodeDir\include\"
           Write-Host "libnode staged from MSYS2: $nodeDir"
+      # Windows 는 python3.lib import-lib hard-link 이라 python313.dll 동반 staging 이
+      # 필요한데 addInstallPythonRuntimeStep Windows 분기가 후속(정직 경계) → macOS/Linux
+      # 에서만 staging 해 released CLI 가 python 지원. Windows 릴리스는 python off.
+      - name: Stage Python (python-build-standalone)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash scripts/stage-python.sh
+
       - name: Build suji CLI
         shell: bash
         run: |
@@ -203,6 +215,14 @@ jobs:
             [ -e "$f" ] || continue
             cp -P "$f" "$DIR/"
           done
+          # embedded CPython: libpython(@executable_path) + stdlib(PYTHONHOME). released
+          # CLI 는 평탄 배치라 suji 가 exe 옆 python/ 을 sentinel 없이 자립 해석
+          # (packaged_paths.exeRelativePythonHome) → Python 미설치 머신에서도 동작.
+          for f in zig-out/bin/libpython*; do
+            [ -e "$f" ] || continue
+            cp -P "$f" "$DIR/"
+          done
+          [ -d zig-out/bin/python ] && cp -R zig-out/bin/python "$DIR/python" || true
           # macOS: CLI 바이너리 서명. identity secret 있으면 그걸로(hardened
           # runtime+timestamp), 없으면 ad-hoc. 배포 식별자 상세는 RELEASING.md.
           if [ "${{ runner.os }}" = "macOS" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -958,17 +958,20 @@ suji.send("my-event", json.dumps({"x": 1}))         # 이벤트 발신
 suji.on("ping-all", lambda data: ...)                # 이벤트 수신
 ```
 
-**packaging(end-user 머신에 Python 미설치라도 동작)**: `build.zig`
-`addInstallPythonRuntimeStep` 이 libpython + stdlib 를 `zig-out/bin` 옆에 staging.
-libpython install_name 이 `@rpath/libpython3.13.dylib` 이고 suji 바이너리 rpath 에
-`@executable_path` 가 있어 exe 옆 복사본으로 해석된다. stdlib(json 등)은 런타임
-**PYTHONHOME=`<real-exe-dir>/python`**(`packaged_paths.pythonHome`)으로 로드.
-Linux/Windows 는 packaging 의 `copyDirContents` 가 bin 디렉토리를 통째 복사해
-자동 동반, macOS 는 `bundle_macos.zig` 가 libpython + `python/` 를 `Contents/MacOS`
-로 복사(packaged_paths.pythonHome 의 macOS 분기는 Resources sentinel 을 확인하되
-실 바이너리 위치 `Contents/MacOS` 기준으로 home 을 만든다). dev 는 이 복사본을 쓰지
-않고 staging(`python_config.python_home`)을 직접 참조 → 큰 stdlib 복사는 `dest`
-존재 시 skip(증분 빌드 비용 0).
+**packaging(end-user 머신에 Python 미설치라도 동작 — 실 `.app` 검증 완료)**:
+`build.zig` `addInstallPythonRuntimeStep` 이 libpython + stdlib 를 `zig-out/bin` 옆에
+staging. libpython install_name 이 `@rpath/libpython3.13.dylib` 이고 suji 바이너리
+rpath 에 `@executable_path` 가 있어 exe 옆 복사본으로 해석된다. stdlib(json 등)은
+런타임 **PYTHONHOME=`exeDir()/python`**(`packaged_paths.pythonHome`)으로 로드.
+Linux/Windows 는 packaging 의 `copyDirContents` 가 bin 디렉토리를 통째 복사해 자동
+동반(libpython+stdlib 둘 다 bin/). macOS 는 `bundle_macos.zig` 가 libpython(단일
+dylib)을 `Contents/MacOS`(@executable_path)로, **stdlib 트리는 `Contents/Resources/
+python`** 로 분리 복사한다 — stdlib 트리를 `Contents/MacOS` 안에 두면 메인 바이너리
+codesign 이 nested subcomponent 로 보고 "bundle format unrecognized" 로 실패하기
+때문(실측). 그래서 `pythonHome` 은 libpython 위치가 아니라 `exeDir()`(macOS=
+Contents/Resources) 기준. dev 는 이 복사본을 쓰지 않고 staging
+(`python_config.python_home`)을 직접 참조 → 큰 stdlib 복사는 `dest` 존재 시
+skip(증분 빌드 비용 0).
 
 구현 범위: `src/platform/python.zig`(lua.zig 복제 + Python C API),
 `build.zig`(staging weak-link auto-detect + `addInstallPythonRuntimeStep`),
@@ -984,16 +987,36 @@ schema/init/suji-cli `lang:"python"`, `examples/python-backend` +
 - `bash tests/e2e/run-python-e2e.sh` — 단독 python-backend: frontend invoke ↔
   Python handler 왕복 + json(nested/unicode/float) + **50 concurrent(GIL
   직렬화)** + **suji.send/on(이벤트 양방향)** (6 pass). CI(ci.yml/e2e.yml) 포함.
+- **packaged `.app` 실행(실측)** — `suji build` 로 `examples/python-backend` 를
+  `.app` 패키징 → codesign 통과 + 서명 valid → **staging 디렉토리를 치운 채**(=
+  Python 미설치 end-user 시뮬) 실행 → 번들 libpython(Contents/MacOS) + stdlib
+  (Contents/Resources/python) 로 `[suji-python] started`(Py_Initialize + bundled
+  json import + main.py 실행) 확인. macOS 한정 수동 검증.
 
-**정직 경계(후속)**: ① **release.yml 의 CLI 배포 python 번들**은 미결정 —
-released `suji` 바이너리에 python weak-link/40MB 런타임을 넣어 batteries-included
-로 할지, `suji build` 시점에 사용자 앱에만 staging 할지(CLI 아티팩트 크기 vs
-빌드타임 staging) 분배 결정 대기. ② **Windows packaging** 의 libpython 동반은
-Linux 자동복사 경로로 커버되나 실 패키지-런 미검증. ③ **packaged-app 실행**은
-build/번들 단계까지 검증(dev + e2e 는 staging 경로로 완전 실증) — 실 `.app`
-더블클릭 런은 CI/수동 후속. ④ **핫 리로드**: `Py_Initialize/Finalize` 가 프로세스당
-1회 안전이라 1차 미지원(프로세스 재시작). ⑤ **iOS**: V8 처럼 CPython JIT 아닌
-인터프리터라 가능성은 있으나 코드서명/샌드박스 검증 필요 — 미배선.
+**release / 배포(완료)**: released `suji` CLI 가 **batteries-included**(libnode 선례
+동형) — `release.yml` 이 macOS/Linux 빌드 전 `scripts/stage-python.sh` 로 staging,
+Package 가 libpython + `python/` stdlib 를 suji 옆에 평탄 동반, `install.sh` 가
+curl-install 시 그 sibling 들을 함께 설치. CLI suji 는 sentinel 없이 exe 옆 `python/`
+을 자립 해석(`packaged_paths.exeRelativePythonHome`) → Python 미설치 머신에서도 python
+백엔드 동작(dev e2e 가 이 경로로 실증).
+
+**핫 리로드(정직)**: node/lua/python 임베드 런타임은 **모두** in-process 핫 리로드
+미지원 — `reloadBackendCommon` 이 `getDylibPath`(rust/go/zig 만) 에서 graceful bail,
+파일 변경 시 dev 재시작 필요. python 은 node/lua 와 **동일 동작**(python 특이 결함
+아님) + 추가로 `Py_Initialize/Finalize` 가 프로세스당 1회 안전이라 in-process 재초기화
+자체가 불가(프로세스 재시작이 정답).
+
+**타입 스텁**: `packages/suji-python`(PEP 561 stub-only `suji-stubs`) — 런타임 주입
+빌트인 `suji` 모듈용 `.pyi`(handle/invoke/send/on). IDE/mypy/pyright 용, 런타임 코드
+없음. PyPI 발행만 후속(토큰 대기).
+
+**정직 경계(후속)**: ① **Windows packaging** — Windows 는 `python3.lib` import-lib
+hard-link 라 `python313.dll`+`Lib`/`DLLs` 동반 staging(PBS Windows 레이아웃)이
+필요해 build gate 에서 **python off 로 강제**(깨진 exe footgun 방지). `addInstall
+PythonRuntimeStep` Windows pwsh 분기 + Windows CI 반복이 필요한 별도 작업. CI/release
+의 python staging 도 macOS/Linux 한정. ② **iOS**: V8 처럼 CPython JIT 아닌
+인터프리터라 가능성은 있으나 iOS 용 python-build-standalone + 코드서명/샌드박스 +
+모바일 호스트(examples/ios) 배선이 필요 — 모바일 트랙 별도 작업, 미배선.
 
 ## 배포 / 설치
 

--- a/build.zig
+++ b/build.zig
@@ -524,13 +524,14 @@ pub fn build(b: *std.Build) void {
         else => "lib/libpython3.13.so",
     };
     const python_available = blk: {
+        // ⚠️ Windows 는 1차 미지원(정직 경계). python3.lib 는 import-lib hard-link 라
+        // python_available 을 켜면 python313.dll 동반 staging(addInstallPythonRuntimeStep
+        // Windows 분기 — PBS Windows 레이아웃 Lib/+DLLs/) 없이는 launch 시 crash 한다.
+        // staging 이 있어도 Windows 는 off 로 강제 → 깨진 exe footgun 방지. macOS/Linux
+        // 패키징·실 .app 런 검증 후, Windows CI 반복으로 별도 활성화.
+        if (os_tag == .windows) break :blk false;
         const lib_path = std.fmt.allocPrint(b.allocator, "{s}/{s}", .{ python_path, python_lib_rel }) catch break :blk false;
         if (!absolutePathExists(b, lib_path)) break :blk false;
-        if (os_tag == .windows) {
-            // MSVC import lib 가 있어야 zig clang(-msvc)로 링크 가능(node 의 .dll.a 게이트 동형).
-            const import_lib = std.fmt.allocPrint(b.allocator, "{s}/libs/python3.lib", .{python_path}) catch break :blk false;
-            if (!absolutePathExists(b, import_lib)) break :blk false;
-        }
         break :blk true;
     };
     const python_options = b.addOptions();
@@ -542,6 +543,9 @@ pub fn build(b: *std.Build) void {
     if (python_available) {
         root_module.link_libc = true;
         switch (os_tag) {
+            // ⚠️ UNREACHABLE: python_available 가 Windows 에서 false 로 강제됨(위 gate).
+            // Windows 활성화(addInstallPythonRuntimeStep Windows 분기 + CI 반복) 시
+            // 복구할 MSVC import-lib 링크 레시피 — 현재는 의도적 미실행.
             .windows => {
                 const py_include = std.fmt.allocPrint(b.allocator, "{s}/include", .{python_path}) catch @panic("OOM");
                 root_module.addIncludePath(.{ .cwd_relative = py_include });

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1103,9 +1103,20 @@ app.on("ready", () => {
 - [x] 검증 — python.zig 인라인 runtime test(staged 시) + `tests/python_test.zig`
       소스 계약 가드 + **`tests/e2e/run-python-e2e.sh`**(invoke 왕복/json/50
       concurrent GIL/send·on, 6 pass, CI 포함).
-- 정직 경계(후속): release.yml CLI 배포 python 번들 분배 결정 / Windows·packaged-app
-  실 런 검증 / 핫 리로드(Py init·finalize 프로세스당 1회) / iOS(코드서명·샌드박스).
-  `@suji/python`(pip 패키지) 도 후속 — 현재는 raw `import suji` 빌트인 모듈.
+- [x] packaged `.app` 실행 검증(macOS 실측) — `suji build` → codesign 통과 →
+      staging 제거(Python 미설치 시뮬) 상태로 `.app` 실행 → 번들 libpython
+      (Contents/MacOS) + stdlib(Contents/Resources/python, codesign 회피 위해
+      MacOS 아닌 Resources) 로 `[suji-python] started` 확인.
+- [x] release / 배포 — `release.yml` 이 macOS/Linux 빌드에 python staging + Package
+      가 libpython+stdlib 동반, `install.sh` 가 curl-install 시 sibling 동반. CLI suji
+      가 exe 옆 `python/` 자립 해석(`exeRelativePythonHome`) → batteries-included.
+- [x] `@suji/python` — `packages/suji-python`(PEP 561 stub-only `suji-stubs`) 스캐폴드
+      (handle/invoke/send/on `.pyi`). PyPI 발행만 후속(토큰 대기).
+- 핫 리로드(정직): node/lua/python 임베드 런타임 모두 in-process 핫 리로드 미지원
+      (dev 재시작) — python 특이 결함 아님. Py init·finalize 프로세스당 1회라 구조적.
+- 정직 경계(후속): Windows packaging(import-lib hard-link → build gate 에서 python off
+      강제, footgun 방지; PBS Windows 레이아웃 + Windows CI 반복 필요) / iOS(iOS용
+      python-build-standalone + 코드서명·샌드박스 + 모바일 호스트 배선, 모바일 트랙).
 
 **Lua 임베드** (vendored Lua 5.4 + cjson — 마감 완료):
 

--- a/examples/python-backend/frontend/package.json
+++ b/examples/python-backend/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "suji-lua-backend-example",
+  "name": "suji-python-backend-example",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/suji-python/README.md
+++ b/packages/suji-python/README.md
@@ -1,0 +1,39 @@
+# suji-stubs
+
+[PEP 561](https://peps.python.org/pep-0561/) **type stubs** for the `suji` module
+used inside a [Suji](https://github.com/ohah/suji) embedded-Python backend.
+
+The `suji` module is **provided by the Suji host at runtime** (embedded CPython,
+injected via `PyImport_AppendInittab`) — it is *not* a normal pip package. There
+is no runtime code here: this distribution only ships `.pyi` stubs so that
+editors and type checkers (mypy/pyright) understand `suji.handle` /
+`suji.invoke` / `suji.send` / `suji.on` in your backend source.
+
+```sh
+pip install suji-stubs   # dev-only; type info for your IDE
+```
+
+```python
+import suji
+import json
+
+def ping(request_json: str) -> str:        # type-checked against the stub
+    return json.dumps({"msg": "pong"})
+
+suji.handle("ping", ping)
+```
+
+> Installing this package does **not** make `import suji` work in a plain Python
+> process — it only resolves when your code runs inside a Suji app (`suji dev` /
+> packaged app). Run the backend with Suji, not bare `python`.
+
+## API
+
+| function | signature | purpose |
+|----------|-----------|---------|
+| `handle` | `(channel: str, handler: Callable[[str], str]) -> None` | 인바운드 핸들러 등록 |
+| `invoke` | `(target: str, request_json: str) -> str` | outbound cross-call (동기) |
+| `send` | `(channel: str, data: str) -> None` | 이벤트 발신 |
+| `on` | `(channel: str, callback: Callable[[str], None]) -> int` | 이벤트 수신 |
+
+Publishing is handled by the SDK release workflow (PyPI token pending).

--- a/packages/suji-python/pyproject.toml
+++ b/packages/suji-python/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "suji-stubs"
+version = "0.1.0"
+description = "Type stubs (PEP 561) for the Suji embedded-Python backend `suji` module"
+readme = "README.md"
+requires-python = ">=3.13"
+license = { text = "MIT" }
+authors = [{ name = "ohah" }]
+keywords = ["suji", "desktop", "stubs", "typing"]
+classifiers = [
+  "Typing :: Stubs Only",
+  "Programming Language :: Python :: 3.13",
+]
+
+[project.urls]
+Homepage = "https://github.com/ohah/suji"
+Documentation = "https://ohah.github.io/suji"
+
+# PEP 561 stub-only distribution: ships `suji-stubs/` providing type info for the
+# runtime-injected built-in `suji` module (no runtime code — see README).
+[tool.setuptools]
+packages = ["suji-stubs"]
+
+[tool.setuptools.package-data]
+"suji-stubs" = ["__init__.pyi"]

--- a/packages/suji-python/suji-stubs/__init__.pyi
+++ b/packages/suji-python/suji-stubs/__init__.pyi
@@ -1,0 +1,24 @@
+"""Type stubs for Suji's embedded-Python backend `suji` module.
+
+The `suji` module is **injected at runtime** by the Suji host
+(`PyImport_AppendInittab("suji", ...)` in `src/platform/python.zig`) — it is not
+a regular importable package. These stubs give IDEs / type checkers the API
+surface; at runtime `import suji` resolves to the host-provided module.
+
+See https://ohah.github.io/suji for the backend guide.
+"""
+
+from typing import Callable
+
+# 인바운드 핸들러 등록 — handler 는 raw 요청 JSON 문자열을 받아 JSON 문자열을 반환.
+# 요청은 {"cmd": <channel>, ...frontend data} 형태로 직렬화되어 온다.
+def handle(channel: str, handler: Callable[[str], str]) -> None: ...
+
+# outbound cross-call — 다른 백엔드(zig/rust/go/node/lua)를 동기 호출, 응답 JSON 반환.
+def invoke(target: str, request_json: str) -> str: ...
+
+# 이벤트 발신 — frontend / 다른 백엔드가 같은 channel 을 on 으로 수신.
+def send(channel: str, data: str) -> None: ...
+
+# 이벤트 수신 — callback 은 payload 문자열을 받는다. listener id 반환.
+def on(channel: str, callback: Callable[[str], None]) -> int: ...

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -183,6 +183,17 @@ mkdir -p "$install_dir"
 cp "$binary_path" "${install_dir}/${binary_name}"
 chmod 0755 "${install_dir}/${binary_name}"
 
+# embedded runtime 동반 — release 패키지가 suji 옆에 평탄 배치한 libnode/libpython +
+# python stdlib 를 함께 설치(없으면 skip). 이게 있어야 curl-install 한 suji 가
+# node/python 백엔드를 Node/Python 미설치 머신에서도 실행한다(exe 옆 자립 해석:
+# libnode/libpython=@executable_path, python stdlib=exeRelativePythonHome).
+bin_src_dir="$(dirname "$binary_path")"
+for lib in "$bin_src_dir"/libnode* "$bin_src_dir"/libpython*; do
+  [ -e "$lib" ] || continue
+  cp -P "$lib" "${install_dir}/" 2>/dev/null || true
+done
+[ -d "${bin_src_dir}/python" ] && cp -R "${bin_src_dir}/python" "${install_dir}/python" 2>/dev/null || true
+
 echo "Installed ${binary_name} to ${install_dir}/${binary_name}"
 case ":${PATH:-}:" in
   *":${install_dir}:"*) ;;

--- a/src/bundle_macos.zig
+++ b/src/bundle_macos.zig
@@ -124,11 +124,14 @@ pub fn createBundle(
     };
 
     // 2.5. embedded CPython runtime — exe 옆에 staging(addInstallPythonRuntimeStep)된
-    //   libpython + stdlib 를 Contents/MacOS 로 동반해 end-user 머신에 Python 미설치라도
-    //   동작하게 한다. libpython 은 install_name `@rpath/libpython3.13.dylib` + 메인
-    //   바이너리 rpath `@executable_path` 로 해석되고, stdlib(json 등)은 런타임
-    //   PYTHONHOME=`<exe-dir>/python`(packaged_paths.pythonHome)으로 로드된다. python
-    //   백엔드가 아니면 staging 이 없어 자동 skip(copy-if-exists).
+    //   libpython + stdlib 를 동반해 end-user 머신에 Python 미설치라도 동작하게 한다.
+    //   libpython(단일 Mach-O dylib)은 Contents/MacOS — install_name
+    //   `@rpath/libpython3.13.dylib` + 메인 바이너리 rpath `@executable_path` 로 해석.
+    //   ⚠️ stdlib(수천 .py + lib-dynload .so 트리)은 **Contents/Resources** 에 둔다 —
+    //   Contents/MacOS 안에 두면 메인 바이너리 codesign 이 그 디렉토리를 nested
+    //   subcomponent 로 보고 "bundle format unrecognized" 로 실패한다(실측). Resources
+    //   는 data 로 sealing 돼 안전. 런타임 PYTHONHOME=exeDir()/python(macOS=
+    //   Resources/python, packaged_paths.pythonHome). python 백엔드가 아니면 자동 skip.
     {
         const src_dir = std.fs.path.dirname(exe_path) orelse ".";
         const libpy_src = try std.fmt.allocPrint(allocator, "{s}/libpython3.13.dylib", .{src_dir});
@@ -138,7 +141,7 @@ pub fn createBundle(
             try copyFile(allocator, libpy_src, libpy_dst); // copyFile 이 dst free
             const stdlib_src = try std.fmt.allocPrint(allocator, "{s}/python", .{src_dir});
             defer allocator.free(stdlib_src);
-            const stdlib_dst = try std.fmt.allocPrint(allocator, "{s}/Contents/MacOS/python", .{app_name});
+            const stdlib_dst = try std.fmt.allocPrint(allocator, "{s}/Contents/Resources/python", .{app_name});
             try copyDir(allocator, stdlib_src, stdlib_dst); // copyDir 이 dst free
         } else |_| {}
     }
@@ -663,11 +666,11 @@ fn generateMacIcon(allocator: std.mem.Allocator, app_name: []const u8, icon_path
 
     const Spec = struct { px: u16, name: []const u8 };
     const sizes = [_]Spec{
-        .{ .px = 16, .name = "icon_16x16" },     .{ .px = 32, .name = "icon_16x16@2x" },
-        .{ .px = 32, .name = "icon_32x32" },     .{ .px = 64, .name = "icon_32x32@2x" },
-        .{ .px = 128, .name = "icon_128x128" },  .{ .px = 256, .name = "icon_128x128@2x" },
-        .{ .px = 256, .name = "icon_256x256" },  .{ .px = 512, .name = "icon_256x256@2x" },
-        .{ .px = 512, .name = "icon_512x512" },  .{ .px = 1024, .name = "icon_512x512@2x" },
+        .{ .px = 16, .name = "icon_16x16" },    .{ .px = 32, .name = "icon_16x16@2x" },
+        .{ .px = 32, .name = "icon_32x32" },    .{ .px = 64, .name = "icon_32x32@2x" },
+        .{ .px = 128, .name = "icon_128x128" }, .{ .px = 256, .name = "icon_128x128@2x" },
+        .{ .px = 256, .name = "icon_256x256" }, .{ .px = 512, .name = "icon_256x256@2x" },
+        .{ .px = 512, .name = "icon_512x512" }, .{ .px = 1024, .name = "icon_512x512@2x" },
     };
     for (sizes) |s| {
         var pxbuf: [8]u8 = undefined;

--- a/src/core/backend_lifecycle.zig
+++ b/src/core/backend_lifecycle.zig
@@ -329,11 +329,15 @@ pub fn startPython(allocator: std.mem.Allocator, backend_name: [:0]const u8, ent
         PythonRuntime.setCore(g.core_api.invoke, g.core_api.free, g.core_api.emit, g.core_api.on, g.core_api.off);
     }
 
-    // PYTHONHOME: packaged(.app/sentinel)면 실 실행파일 옆 번들 stdlib
-    // (`<real-exe-dir>/python/lib/pythonX.Y`). dev 면 null → python_config 의
-    // staging 경로 사용(run-python-e2e 로 실증된 경로). start() 가 home 을 즉시
-    // PyConfig 로 dupe 하므로 start 이후 해제 가능.
-    const py_home = packaged_paths.pythonHome(allocator);
+    // PYTHONHOME 해석(우선순위): ① packaged(.app/sentinel) → exeDir()/python
+    // (macOS=Resources/python). ② 포터블/CLI 평탄 배치 → 실 exe 옆 python/
+    // (released suji CLI + dev zig-out/bin 자립). ③ 둘 다 없으면 null → python.zig
+    // 가 python_config staging 경로 사용. start() 가 home 을 즉시 PyConfig 로 dupe
+    // 하므로 start 이후 해제 가능.
+    // 불변식: ①②는 레이아웃상 상호배타 — .app 은 stdlib 이 Resources 라 ②(exe 옆
+    // python/)가 안 걸리고, 평탄 배치는 sentinel 이 없어 ①이 안 걸린다. 그래서
+    // orelse 순서는 "둘 중 존재하는 하나"를 고르는 것이지 우선순위 의존이 아니다.
+    const py_home = packaged_paths.pythonHome(allocator) orelse packaged_paths.exeRelativePythonHome(allocator);
     defer if (py_home) |h| allocator.free(h);
 
     try rt.start(py_home);

--- a/src/core/packaged_paths.zig
+++ b/src/core/packaged_paths.zig
@@ -6,14 +6,21 @@ const std = @import("std");
 const builtin = @import("builtin");
 const runtime = @import("runtime");
 
+/// 실 실행파일이 있는 디렉토리(`@executable_path`) — `buf` 에 exe path 를 읽고
+/// dirname slice 를 반환(반환값 수명은 `buf` 에 묶임). sentinel/레이아웃 판정 없는
+/// raw 헬퍼. packagedRealExeDir(sentinel 게이트) 와 exeRelativePythonHome(probe) 가 공유.
+fn realExeDir(buf: []u8) ?[]const u8 {
+    const ep_len = std.process.executablePath(runtime.io, buf) catch return null;
+    return std.fs.path.dirname(buf[0..ep_len]);
+}
+
 /// packaged(.app/sentinel) 면 실제 실행파일이 있는 디렉토리(`@executable_path`)를,
 /// 아니면(dev) null 을 반환. is-packaged 판정(sentinel 위치는 macOS=Contents/Resources,
 /// else=exe dir)을 단일 출처로 둔다 — exeDir/pythonHome 가 반환 디렉토리만 다를 뿐
 /// 같은 판정을 공유. caller free.
 fn packagedRealExeDir(allocator: std.mem.Allocator) ?[]const u8 {
     var exe_buf: [1024]u8 = undefined;
-    const ep_len = std.process.executablePath(runtime.io, &exe_buf) catch return null;
-    const dir = std.fs.path.dirname(exe_buf[0..ep_len]) orelse return null;
+    const dir = realExeDir(&exe_buf) orelse return null;
 
     const sentinel = if (comptime builtin.os.tag == .macos) blk: {
         // <exe_dir>=<app>.app/Contents/MacOS → sentinel 은 sibling Resources 에.
@@ -24,6 +31,21 @@ fn packagedRealExeDir(allocator: std.mem.Allocator) ?[]const u8 {
     std.Io.Dir.cwd().access(runtime.io, sentinel, .{}) catch return null;
 
     return allocator.dupe(u8, dir) catch null;
+}
+
+/// 포터블/CLI 레이아웃: 실 실행파일 옆에 `python/`(libpython 도 옆) 이 실제로
+/// 있으면 그 경로를 반환. sentinel 불요 — released suji CLI(suji+libpython+python/
+/// 평탄 배치) 와 dev(zig-out/bin) 가 자기 옆 번들 stdlib 을 자립적으로 찾는다.
+/// 없으면 null. (`.app` 은 stdlib 이 Resources 라 여기 안 걸리고 pythonHome 이 처리.)
+pub fn exeRelativePythonHome(allocator: std.mem.Allocator) ?[]const u8 {
+    var exe_buf: [1024]u8 = undefined;
+    const dir = realExeDir(&exe_buf) orelse return null;
+    const home = std.fmt.allocPrint(allocator, "{s}/python", .{dir}) catch return null;
+    std.Io.Dir.cwd().access(runtime.io, home, .{}) catch {
+        allocator.free(home);
+        return null;
+    };
+    return home;
 }
 
 /// packaged 면 backend/plugin dylib 이 사는 디렉토리(macOS=Contents/Resources,
@@ -38,14 +60,14 @@ pub fn exeDir(allocator: std.mem.Allocator) ?[]const u8 {
     return allocator.dupe(u8, dir) catch null;
 }
 
-/// packaged 면 번들 CPython home(`<real-exe-dir>/python`)을 반환.
-/// addInstallPythonRuntimeStep(Linux/Windows) + bundle_macos(macOS) 가 stdlib 을
-/// 실 실행파일 옆 `python/lib/pythonX.Y` 로 둔다. libpython 은 `@executable_path`
-/// 로, stdlib 은 PYTHONHOME 로 같은 디렉토리에서 로드되므로 exeDir() 와 달리 macOS
-/// 도 Contents/MacOS(실 바이너리 위치)를 기준으로 한다. dev(sentinel 없음)면 null →
-/// python.zig 가 python_config 의 staging 경로(run-python-e2e 실증)를 쓴다.
+/// packaged 면 번들 CPython stdlib home(`exeDir()/python`)을 반환.
+/// stdlib 트리는 backend/plugin dylib 과 같은 곳에 둔다 — Linux/Windows=bin/python,
+/// **macOS=Contents/Resources/python**(Contents/MacOS 안의 디렉토리 트리는 메인
+/// 바이너리 codesign 을 깨므로 Resources 에 둠 — bundle_macos 참조). 그래서 libpython
+/// 위치(macOS=Contents/MacOS, `@executable_path`)와 달리 stdlib home 은 exeDir() 기준.
+/// dev(sentinel 없음)면 null → python.zig 가 python_config 의 staging 경로 사용.
 pub fn pythonHome(allocator: std.mem.Allocator) ?[]const u8 {
-    const dir = packagedRealExeDir(allocator) orelse return null;
+    const dir = exeDir(allocator) orelse return null;
     defer allocator.free(dir);
     return std.fmt.allocPrint(allocator, "{s}/python", .{dir}) catch null;
 }


### PR DESCRIPTION
PR #70(embedded CPython 백엔드)의 후속 — end-user 머신(Python 미설치)에서 동작하도록 패키징을 완성하고 정직 경계를 닫는다. **실 macOS `.app` 실행으로 검증**.

## 패키징 버그 수정 (실측)
macOS `.app` codesign 이 `Contents/MacOS` 안의 stdlib 디렉토리 트리를 nested subcomponent 로 보고 **"bundle format unrecognized"** 로 실패. → libpython(단일 dylib)만 `Contents/MacOS`, **stdlib 트리는 `Contents/Resources/python`** 으로 분리(`bundle_macos.zig`). `pythonHome` 을 `exeDir()` 기준으로 정정.

## PYTHONHOME 자립 해석
- `packaged_paths.exeRelativePythonHome` — sentinel 없이 실 exe 옆 `python/` 을 찾는다(포터블/CLI/dev).
- `backend_lifecycle` 가 `pythonHome(.app) orelse exeRelativePythonHome` 로 해석. ①②는 레이아웃상 상호배타(.app=Resources, 평탄=exe-sibling).

## release 배포 (batteries-included — libnode 선례)
- `release.yml` 이 macOS/Linux 빌드에 python staging + Package 가 libpython+stdlib 동반.
- `install.sh` 가 curl-install 시 sibling(libnode/libpython/python) 동반 → **released CLI 가 python 백엔드를 Python 미설치 머신에서도 실행**.

## Windows footgun 차단
`python3.lib` 는 import-lib **hard-link** 라 dll 동반 없이는 launch crash → build gate 에서 Windows `python_available=false` 강제(CI/release staging 도 macOS/Linux 한정). PBS Windows 레이아웃 배선은 후속(정직 경계, in-place 마커).

## @suji/python
`packages/suji-python`(PEP 561 stub-only `suji-stubs`) — 런타임 주입 빌트인 `suji` 모듈용 `.pyi`(handle/invoke/send/on). IDE/mypy/pyright 용, 런타임 코드 없음. PyPI 발행만 후속.

## 핫 리로드 (정직 결론)
node/lua/python 임베드 런타임 **모두** in-process 핫 리로드 미지원(`getDylibPath` 가 rust/go/zig 만, graceful bail → dev 재시작) — python 특이 결함 아님. `Py_Initialize`/`Finalize` 프로세스당 1회라 구조적.

## 검증
- macOS `suji build` → codesign 통과/서명 valid → **staging 디렉토리를 치운 채**(Python 미설치 시뮬) `.app` 실행 → 번들 libpython(Contents/MacOS)+stdlib(Contents/Resources/python) 로 `[suji-python] started`(Py_Initialize + bundled json import + main.py) 확인.
- `zig build`/`zig build test` green, `zig fmt` clean, **python e2e 6/6 + lua e2e 6/6**(회귀 없음).

## 리팩터 (/simplify)
`realExeDir` 공통 추출(`packagedRealExeDir`/`exeRelativePythonHome` 중복 prologue), Windows 미실행 분기 in-place 마커, `orelse` 상호배타 불변식 명시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)