### PR TITLE
feat(python): iOS embedded CPython 백엔드 (실 시뮬레이터 e2e 5/5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ examples/android/*/local.properties
 examples/ios/backends/rust/target/
 examples/ios/backends/go/libsuji_go_backend.a
 examples/ios/backends/go/libsuji_go_backend.h
+examples/ios/backends/*/out/
 tests/mobile-backends/.build/
 
 # OS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,11 @@ bash tests/mobile-backends/ios-sim-smoke.sh  # iOS 시뮬레이터 변형별 빌
 bash tests/mobile-backends/ios-e2e.sh   # iOS 시뮬 *기능* e2e — e2e.html 이 실
                                         # UIPasteboard clipboard 8케이스 자가검증
                                         # → 데이터컨테이너 파일 회수·assert
+bash scripts/stage-python-ios.sh        # iOS embedded CPython staging (BeeWare
+                                        # Python-Apple-support 3.13 → ~/.suji/python-ios)
+bash tests/mobile-backends/ios-e2e.sh python  # iOS 시뮬 embedded CPython e2e —
+                                        # ping/echo(json)/unicode/nested/20x stress
+                                        # (실 libpython+번들 stdlib, 5케이스 자가검증)
 bash tests/mobile-backends/android-e2e.sh # Android 에뮬 *기능* e2e — 실
                                         # ClipboardManager 8케이스 → logcat 회수
                                         # (ANDROID SDK+에뮬+JDK17~21 필요)
@@ -686,6 +691,22 @@ c-shared(Android는 Go c-archive 미지원 → JNI `.so`가 정적/공유 혼합
 (verify.c·JNI 공유, iOS는 Swift 동형). **Node 만 iOS 미지원** — V8 JIT 가
 iOS 코드서명 샌드박스에서 금지(정적 링크해도 런타임 코드 생성 불가).
 Android Node 는 NDK로 가능하나 예제 미배선(후속).
+
+**embedded CPython 은 iOS 동작**(Node 와 결정적 대조 — 인터프리터라 JIT/코드생성
+불요, CPython 3.13 PEP 730 공식 iOS 지원). `src/platform/python.zig` 데스크탑
+런타임을 모바일 백엔드(`examples/ios/backends/python/src/backend.zig`,
+`suji_python_backend_*`)로 포팅 — `@cImport(Python.h)` 를 zig 가 직접 컴파일,
+outbound `suji.invoke/send/on` 은 정적 링크된 `suji_core_*` extern 으로 배선. iOS
+libpython/stdlib 는 BeeWare **Python-Apple-support**(`Python.xcframework` + stdlib)를
+`scripts/stage-python-ios.sh` 로 staging → `examples/ios/python` 변형이 framework 를
+앱에 임베드 + stdlib 을 `<bundle>/python/lib/python3.13`(PYTHONHOME) 으로 번들 +
+main.py 를 `<bundle>/main.py` 로. main.py 가 `suji.handle` 로 등록한 핸들러 이름을
+`suji_python_backend_channels` 로 받아 호스트(Swift)가 각 채널을
+`suji_core_register_handler` 로 등록(데스크탑 채널=핸들러 의미 보존 →
+`suji.invoke("ping")` 동형). **iOS 시뮬레이터 실 e2e 검증**: `bash
+tests/mobile-backends/ios-e2e.sh python`(ping/echo json·unicode·nested·20x, 5/5).
+정직 경계: 검증 천장은 시뮬레이터(실기기 미검증, clipboard 모바일 e2e 와 동일 바);
+**Android Python**(PEP 738)는 NDK 크로스컴파일 + JNI 배선 후속(이 환경 SDK/NDK 부재).
 
 ## 앱별 cache / 사용자 데이터 (Electron `app.getPath('userData')` 동등)
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1112,11 +1112,19 @@ app.on("ready", () => {
       가 exe 옆 `python/` 자립 해석(`exeRelativePythonHome`) → batteries-included.
 - [x] `@suji/python` — `packages/suji-python`(PEP 561 stub-only `suji-stubs`) 스캐폴드
       (handle/invoke/send/on `.pyi`). PyPI 발행만 후속(토큰 대기).
+- [x] **모바일 iOS** — embedded CPython iOS(PEP 730). `examples/ios/backends/python`
+      (python.zig 포팅 + `suji_python_backend_*` C ABI + outbound `suji_core_*` extern),
+      BeeWare Python-Apple-support `Python.xcframework`+stdlib staging
+      (`scripts/stage-python-ios.sh`), `examples/ios/python` 변형(framework 임베드 +
+      stdlib `<bundle>/python` PYTHONHOME + main.py + channels→register). Node iOS
+      불가(V8 JIT)와 대조 — 인터프리터라 가능. **실 시뮬레이터 e2e 5/5**
+      (`tests/mobile-backends/ios-e2e.sh python`: ping/echo json·unicode·nested·20x).
 - 핫 리로드(정직): node/lua/python 임베드 런타임 모두 in-process 핫 리로드 미지원
       (dev 재시작) — python 특이 결함 아님. Py init·finalize 프로세스당 1회라 구조적.
 - 정직 경계(후속): Windows packaging(import-lib hard-link → build gate 에서 python off
-      강제, footgun 방지; PBS Windows 레이아웃 + Windows CI 반복 필요) / iOS(iOS용
-      python-build-standalone + 코드서명·샌드박스 + 모바일 호스트 배선, 모바일 트랙).
+      강제, footgun 방지; PBS Windows 레이아웃 + Windows CI 반복 필요) / iOS 실기기
+      (시뮬레이터 검증 천장 — clipboard 모바일 e2e 와 동일 바) / **Android Python**(PEP
+      738, NDK 크로스컴파일 + JNI — SDK/NDK/에뮬 있는 머신/CI 후속).
 
 **Lua 임베드** (vendored Lua 5.4 + cjson — 마감 완료):
 

--- a/examples/ios/_shared/Suji-Bridging-Header.h
+++ b/examples/ios/_shared/Suji-Bridging-Header.h
@@ -23,3 +23,12 @@ extern void suji_sqlite_backend_init(const void *core);
 extern char *suji_sqlite_backend_handle_ipc(const char *request);
 extern void suji_sqlite_backend_free(char *ptr);
 extern void suji_sqlite_backend_destroy(void);
+
+// Python(embedded CPython): init=no-op, start=Py_Initialize+main.py(번들 PYTHONHOME/
+// entry), channels=등록 핸들러 이름 JSON 배열(호스트가 각 채널 register), 나머지 동형.
+extern void suji_python_backend_init(const void *core);
+extern int suji_python_backend_start(const char *home, const char *entry);
+extern char *suji_python_backend_channels(void);
+extern char *suji_python_backend_handle_ipc(const char *request);
+extern void suji_python_backend_free(char *ptr);
+extern void suji_python_backend_destroy(void);

--- a/examples/ios/backends/python/build-lib.sh
+++ b/examples/ios/backends/python/build-lib.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# 모바일 정적 embedded CPython 백엔드 (suji_python_backend_*) 빌드.
+#
+# 데스크탑 src/platform/python.zig 모바일 대응. backend.zig 는 Python.xcframework
+# 헤더로 컴파일만 한다 — libpython 심볼(Py*)과 suji_core_* 는 정적 .a 에 undefined
+# 로 남고 앱 링크 단계에서 Python.framework + libsuji_core.a 가 해소(sqlite 는
+# sqlite3.c 를 .a 에 포함하지만 Python 은 외부 framework 라 헤더만 필요).
+#
+# 사용: ./build-lib.sh <ios-sim|ios-device> [out_dir]
+# 사전: bash scripts/stage-python-ios.sh (Python.xcframework staging)
+set -euo pipefail
+
+MODE="${1:?사용: $0 <ios-sim|ios-device> [out_dir]}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="${2:-$HERE/out}"
+mkdir -p "$OUT"
+
+PY_APPLE_TAG="${PY_APPLE_TAG:-3.13-b13}"
+PYROOT="$HOME/.suji/python-ios/$PY_APPLE_TAG/Python.xcframework"
+
+TARGET_ARGS=()
+case "$MODE" in
+  ios-sim)
+    SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+    INC="$PYROOT/ios-arm64_x86_64-simulator/include/python3.13"
+    TARGET_ARGS=(-target aarch64-ios-simulator --sysroot "$SDK" -I"$SDK/usr/include") ;;
+  ios-device)
+    SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
+    INC="$PYROOT/ios-arm64/include/python3.13"
+    TARGET_ARGS=(-target aarch64-ios --sysroot "$SDK" -I"$SDK/usr/include") ;;
+  *) echo "unknown mode: $MODE" >&2; exit 1 ;;
+esac
+
+[ -d "$INC" ] || { echo "python iOS 헤더 없음: $INC — 먼저 bash scripts/stage-python-ios.sh" >&2; exit 1; }
+
+zig build-lib -O ReleaseSmall -fPIC -lc "${TARGET_ARGS[@]+"${TARGET_ARGS[@]}"}" \
+  -I"$INC" \
+  -femit-bin="$OUT/libsuji_python_backend.a" --name suji_python_backend \
+  "$HERE/src/backend.zig"
+rm -f "$OUT/libsuji_python_backend.a.o"
+echo "built ($MODE): $OUT/libsuji_python_backend.a"

--- a/examples/ios/backends/python/main.py
+++ b/examples/ios/backends/python/main.py
@@ -1,0 +1,24 @@
+import suji
+import json
+
+# iOS/Android embedded CPython 백엔드 — 데스크탑 examples/python-backend 와 동형.
+# 핸들러는 raw 요청 JSON({"cmd":<channel>,...})을 받아 JSON 문자열을 반환한다.
+# suji.handle 로 등록한 이름이 그대로 프론트 invoke 채널이 된다(호스트가
+# suji_python_backend_channels 로 목록을 받아 suji_core_register_handler 로 등록).
+
+
+def ping(request_json):
+    return json.dumps({"runtime": "python", "msg": "pong"})
+
+
+def echo(request_json):
+    req = json.loads(request_json)
+    return json.dumps({
+        "runtime": "python",
+        "echo": req,
+        "value": req.get("value") or req.get("message"),
+    })
+
+
+suji.handle("ping", ping)
+suji.handle("echo", echo)

--- a/examples/ios/backends/python/src/backend.zig
+++ b/examples/ios/backends/python/src/backend.zig
@@ -1,0 +1,353 @@
+//! iOS/Android 정적 링크 embedded CPython 3.13 백엔드 (suji_python_backend_*).
+//!
+//! 데스크탑 `src/platform/python.zig` 의 모바일 대응판. 데스크탑은 BackendRegistry
+//! +CEF 호스트로 임베드하지만, 모바일은 정적 링크 모델이라(sqlite 백엔드가 데스크탑
+//! plugins/sqlite 와 동형인 것과 동일 방식) 코어/SDK/CEF 비의존으로 재구성한다.
+//! 단일 바이너리 심볼 충돌을 피하려 고유 네임스페이스 `suji_python_backend_*`.
+//!
+//! 차이(다른 모바일 백엔드는 init=no-op): Python `start` 가 Py_Initialize + main.py
+//! 실행(핸들러 등록), `handle_ipc` 가 cmd 추출 → GIL → Python 핸들러 디스패치.
+//! outbound `suji.invoke/send/on` 은 같은 앱에 정적 링크된 suji_core C ABI(extern)로
+//! 직접 배선. 핸들러 이름은 main.py 가 `suji.handle` 로 등록 → 호스트(Swift)가
+//! `suji_python_backend_channels` 로 목록을 받아 각 채널을 `suji_core_register_handler`
+//! 로 등록 → 프론트가 `suji.invoke("ping")` 처럼 데스크탑과 동일하게 호출(채널=핸들러).
+//!
+//! 데스크탑 교훈 그대로: variadic PyArg_ParseTuple/CallFunction 은 zig C variadic
+//! 전달에서 깨지므로 non-variadic(PyTuple_GetItem/AsUTF8/CallOneArg) 사용,
+//! pyatomic.h 는 `_Py_USE_GCC_BUILTIN_ATOMICS` 로 GCC builtin 분기 강제.
+
+const std = @import("std");
+
+const c = @cImport({
+    @cDefine("PY_SSIZE_T_CLEAN", {});
+    @cDefine("_Py_USE_GCC_BUILTIN_ATOMICS", "1");
+    @cInclude("Python.h");
+});
+
+const alloc = std.heap.c_allocator;
+
+// 같은 앱에 정적 링크된 suji_core C ABI (include/suji_core.h) — outbound 전용.
+// 데스크탑 setCore(함수 포인터 주입) 대신 모바일은 링크 심볼을 직접 호출.
+extern fn suji_core_invoke(channel: [*:0]const u8, json: [*:0]const u8) ?[*:0]const u8;
+extern fn suji_core_free(ptr: ?[*:0]const u8) void;
+extern fn suji_core_emit(event_name: [*:0]const u8, json: [*:0]const u8) void;
+const CoreEventCb = *const fn ([*c]const u8, [*c]const u8, ?*anyopaque) callconv(.c) void;
+extern fn suji_core_on(event_name: [*:0]const u8, callback: ?CoreEventCb, arg: ?*anyopaque) u64;
+extern fn suji_core_off(listener_id: u64) void;
+
+// suji.on 리스너 — EventBus C 콜백 arg 로 받아 어느 Python 콜러블을 부를지 식별.
+const PyListener = struct {
+    callback: *c.PyObject,
+    id: u64 = 0,
+};
+
+// 모바일은 단일 전역 인터프리터(데스크탑도 Py_Initialize 가 프로세스당 1회). sqlite
+// 백엔드의 전역 Registry 패턴 동형 — self 대신 전역 rt.
+const Runtime = struct {
+    handlers: std.StringHashMap(*c.PyObject) = std.StringHashMap(*c.PyObject).init(alloc),
+    event_listeners: std.ArrayList(*PyListener) = .empty,
+    main_thread_state: ?*c.PyThreadState = null,
+    initialized: bool = false,
+};
+var rt: Runtime = .{};
+
+// ============================================
+// suji 모듈 (handle/invoke/send/on) — 데스크탑 python.zig 와 동일 의미
+// ============================================
+
+// variadic 회피 인자 추출(데스크탑 tupleStr/tupleObj 와 동일).
+fn tupleStr(args: ?*c.PyObject, idx: c.Py_ssize_t) ?[*:0]const u8 {
+    const args_c: [*c]c.PyObject = @ptrCast(args);
+    if (c.PyTuple_Size(args_c) <= idx) return null;
+    const item = c.PyTuple_GetItem(args_c, idx);
+    if (item == null) return null;
+    const s = c.PyUnicode_AsUTF8(item);
+    if (s == null) return null;
+    return @ptrCast(s);
+}
+
+fn tupleObj(args: ?*c.PyObject, idx: c.Py_ssize_t) ?*c.PyObject {
+    const args_c: [*c]c.PyObject = @ptrCast(args);
+    if (c.PyTuple_Size(args_c) <= idx) return null;
+    const item = c.PyTuple_GetItem(args_c, idx);
+    if (item == null) return null;
+    return @ptrCast(item);
+}
+
+fn pyNone() ?*c.PyObject {
+    const none: *c.PyObject = @ptrCast(&c._Py_NoneStruct);
+    c.Py_IncRef(none);
+    return none;
+}
+
+fn pyStr(s: [:0]const u8) ?*c.PyObject {
+    return c.PyUnicode_FromStringAndSize(@ptrCast(s.ptr), @intCast(s.len));
+}
+
+fn pyHandle(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const ch_z = tupleStr(args, 0) orelse return pyNone();
+    const callable = tupleObj(args, 1) orelse return pyNone();
+    if (c.PyCallable_Check(callable) == 0) {
+        c.PyErr_SetString(c.PyExc_TypeError, "suji.handle: handler must be callable");
+        return null;
+    }
+    const channel = std.mem.span(ch_z);
+    c.Py_IncRef(callable);
+    if (rt.handlers.getPtr(channel)) |old| {
+        c.Py_DecRef(old.*);
+        old.* = callable;
+    } else {
+        const owned = alloc.dupe(u8, channel) catch {
+            c.Py_DecRef(callable);
+            return pyNone();
+        };
+        rt.handlers.put(owned, callable) catch {
+            alloc.free(owned);
+            c.Py_DecRef(callable);
+            return pyNone();
+        };
+    }
+    return pyNone();
+}
+
+fn pyInvoke(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const target = tupleStr(args, 0) orelse return pyStr("{\"error\":\"invoke: target must be a string\"}");
+    const req = tupleStr(args, 1) orelse return pyStr("{\"error\":\"invoke: request must be a string\"}");
+    const resp = suji_core_invoke(@ptrCast(target), @ptrCast(req));
+    if (resp) |r| {
+        const span = std.mem.span(@as([*:0]const u8, @ptrCast(r)));
+        const out = c.PyUnicode_FromStringAndSize(@ptrCast(span.ptr), @intCast(span.len));
+        suji_core_free(r);
+        return out;
+    }
+    return pyStr("{}");
+}
+
+fn pySend(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const ch = tupleStr(args, 0) orelse return pyNone();
+    const data = tupleStr(args, 1) orelse return pyNone();
+    suji_core_emit(@ptrCast(ch), @ptrCast(data));
+    return pyNone();
+}
+
+fn pyOn(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    const ch_z = tupleStr(args, 0) orelse return pyNone();
+    const callable = tupleObj(args, 1) orelse return pyNone();
+    if (c.PyCallable_Check(callable) == 0) {
+        c.PyErr_SetString(c.PyExc_TypeError, "suji.on: callback must be callable");
+        return null;
+    }
+    c.Py_IncRef(callable);
+    const listener = alloc.create(PyListener) catch {
+        c.Py_DecRef(callable);
+        return pyNone();
+    };
+    listener.* = .{ .callback = callable };
+    rt.event_listeners.append(alloc, listener) catch {
+        c.Py_DecRef(callable);
+        alloc.destroy(listener);
+        return pyNone();
+    };
+    listener.id = suji_core_on(@ptrCast(ch_z), pyEventCallback, listener);
+    return c.PyLong_FromUnsignedLongLong(listener.id);
+}
+
+// EventBus 가 emit 한 스레드에서 호출. arg=*PyListener.
+fn pyEventCallback(_: [*c]const u8, data: [*c]const u8, arg: ?*anyopaque) callconv(.c) void {
+    const listener: *PyListener = @ptrCast(@alignCast(arg orelse return));
+    const d = std.mem.span(@as([*:0]const u8, @ptrCast(data)));
+    dispatchEvent(listener.callback, d);
+}
+
+fn dispatchEvent(callback: *c.PyObject, data: []const u8) void {
+    if (!rt.initialized) return;
+    const gil = c.PyGILState_Ensure();
+    defer c.PyGILState_Release(gil);
+    const arg = c.PyUnicode_FromStringAndSize(@ptrCast(data.ptr), @intCast(data.len)) orelse {
+        if (c.PyErr_Occurred() != null) c.PyErr_Print();
+        return;
+    };
+    defer c.Py_DecRef(arg);
+    const r = c.PyObject_CallOneArg(callback, arg);
+    if (r) |rp| {
+        c.Py_DecRef(rp);
+    } else if (c.PyErr_Occurred() != null) {
+        c.PyErr_Print();
+    }
+}
+
+var suji_methods = [_]c.PyMethodDef{
+    .{ .ml_name = "handle", .ml_meth = pyHandle, .ml_flags = c.METH_VARARGS, .ml_doc = null },
+    .{ .ml_name = "invoke", .ml_meth = pyInvoke, .ml_flags = c.METH_VARARGS, .ml_doc = null },
+    .{ .ml_name = "send", .ml_meth = pySend, .ml_flags = c.METH_VARARGS, .ml_doc = null },
+    .{ .ml_name = "on", .ml_meth = pyOn, .ml_flags = c.METH_VARARGS, .ml_doc = null },
+    .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
+};
+var suji_module_def: c.PyModuleDef = std.mem.zeroes(c.PyModuleDef);
+
+fn pyInitSujiModule() callconv(.c) ?*c.PyObject {
+    suji_module_def.m_name = "suji";
+    suji_module_def.m_size = -1;
+    suji_module_def.m_methods = &suji_methods;
+    return c.PyModule_Create(&suji_module_def);
+}
+
+// ============================================
+// 인터프리터 부팅 / 핸들러 디스패치
+// ============================================
+
+// PYTHONHOME(home)/main.py(entry)는 호스트가 앱 번들 경로로 전달. testbed
+// iOSTestbed 참조: IsolatedConfig + config.home + write_bytecode=0(번들 read-only).
+fn startRuntime(home: [*:0]const u8, entry: [*:0]const u8) bool {
+    if (rt.initialized) return true;
+
+    // iOS: 컬러/버퍼 출력 비활성(testbed 동형 — 샌드박스 stdout 안정).
+    _ = c.setenv("NO_COLOR", "1", 1);
+    _ = c.setenv("PYTHON_COLORS", "0", 1);
+
+    if (c.PyImport_AppendInittab("suji", &pyInitSujiModule) != 0) return false;
+
+    var config: c.PyConfig = undefined;
+    c.PyConfig_InitIsolatedConfig(&config);
+    defer c.PyConfig_Clear(&config);
+    config.write_bytecode = 0; // 번들은 read-only → .pyc 쓰기 시도 회피.
+
+    const st = c.PyConfig_SetBytesString(&config, &config.home, home);
+    if (c.PyStatus_Exception(st) != 0) return false;
+
+    const status = c.Py_InitializeFromConfig(&config);
+    if (c.PyStatus_Exception(status) != 0) return false;
+
+    const fp = c.fopen(entry, "rb") orelse return false;
+    const rc = c.PyRun_SimpleFileExFlags(fp, entry, 1, null); // closeit=1 → fclose
+    if (rc != 0) {
+        if (c.PyErr_Occurred() != null) c.PyErr_Print();
+        return false;
+    }
+
+    // 메인 스레드 GIL 해제 → 이후 handle_ipc/이벤트가 PyGILState_Ensure 로 진입.
+    rt.main_thread_state = c.PyEval_SaveThread();
+    rt.initialized = true;
+    return true;
+}
+
+// 경량 `"key":"<value>"` 추출(zig 형제 백엔드 field() 동형) — 전체 JSON DOM 파싱
+// 없이 cmd 한 필드만. 요청은 호스트 브리지가 만든 compact JSON({"cmd":"..",..}).
+fn field(json: []const u8, key: []const u8) ?[]const u8 {
+    var buf: [64]u8 = undefined;
+    const pat = std.fmt.bufPrint(&buf, "\"{s}\":\"", .{key}) catch return null;
+    const i = std.mem.indexOf(u8, json, pat) orelse return null;
+    const start = i + pat.len;
+    const rel = std.mem.indexOfScalar(u8, json[start..], '"') orelse return null;
+    return json[start .. start + rel];
+}
+
+fn dupZ(s: []const u8) [*:0]u8 {
+    const b = alloc.allocSentinel(u8, s.len, 0) catch return @constCast("{}");
+    @memcpy(b, s);
+    return b.ptr;
+}
+
+// 핸들러 호출(데스크탑 invoke 와 동일 — GIL + CallOneArg). 반환은 c_allocator
+// 버퍼(호스트가 suji_python_backend_free 로 반납).
+fn invokeHandler(channel: []const u8, data: []const u8) ?[*:0]u8 {
+    if (!rt.initialized) return null;
+    const handler = rt.handlers.get(channel) orelse return null;
+
+    const gil = c.PyGILState_Ensure();
+    defer c.PyGILState_Release(gil);
+
+    const arg = c.PyUnicode_FromStringAndSize(@ptrCast(data.ptr), @intCast(data.len)) orelse {
+        if (c.PyErr_Occurred() != null) c.PyErr_Print();
+        return dupZ("{\"error\":\"python arg encode failed\"}");
+    };
+    defer c.Py_DecRef(arg);
+    const result = c.PyObject_CallOneArg(handler, arg) orelse {
+        if (c.PyErr_Occurred() != null) c.PyErr_Print();
+        return dupZ("{\"error\":\"python handler failed\"}");
+    };
+    defer c.Py_DecRef(result);
+
+    var out_len: c.Py_ssize_t = 0;
+    const out_ptr = c.PyUnicode_AsUTF8AndSize(result, &out_len) orelse {
+        if (c.PyErr_Occurred() != null) c.PyErr_Print();
+        return dupZ("{\"error\":\"python handler returned non-string\"}");
+    };
+    return dupZ(out_ptr[0..@intCast(out_len)]);
+}
+
+// ============================================
+// C ABI (모바일 정적 링크 — 고유 심볼 suji_python_backend_*)
+// ============================================
+
+export fn suji_python_backend_init(core: ?*const anyopaque) callconv(.c) void {
+    _ = core; // outbound 는 extern suji_core_* 직접 사용 — core 인자 불요(sqlite 동형).
+}
+
+// 호스트가 앱 번들의 PYTHONHOME(stdlib 상위)과 main.py 절대경로로 1회 호출.
+export fn suji_python_backend_start(home: [*:0]const u8, entry: [*:0]const u8) callconv(.c) c_int {
+    return if (startRuntime(home, entry)) 0 else -1;
+}
+
+// start 후 등록된 핸들러 이름 JSON 배열(호스트가 각 채널을 suji_core_register_handler).
+// 핸들러 이름은 suji.handle 인자(개발자 식별자)라 단순 직렬화로 충분.
+export fn suji_python_backend_channels() callconv(.c) ?[*:0]u8 {
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var out = std.ArrayList(u8).empty;
+    out.append(a, '[') catch return dupZ("[]");
+    var it = rt.handlers.keyIterator();
+    var first = true;
+    while (it.next()) |k| {
+        if (!first) out.append(a, ',') catch return dupZ("[]");
+        first = false;
+        out.append(a, '"') catch return dupZ("[]");
+        out.appendSlice(a, k.*) catch return dupZ("[]");
+        out.append(a, '"') catch return dupZ("[]");
+    }
+    out.append(a, ']') catch return dupZ("[]");
+    return dupZ(out.items);
+}
+
+export fn suji_python_backend_handle_ipc(req: [*:0]const u8) callconv(.c) ?[*:0]u8 {
+    const r = std.mem.span(req);
+    // cmd 만 경량 추출(핸들러가 전체 요청을 json.loads 로 재파싱하므로 여기서 DOM
+    // 파싱 불요 — 데스크탑과 동일하게 핸들러는 `{"cmd":..,..}` 전체를 받는다).
+    const cmd = field(r, "cmd") orelse return dupZ("{\"error\":\"missing cmd\"}");
+    return invokeHandler(cmd, r) orelse dupZ("{\"error\":\"unknown handler\"}");
+}
+
+export fn suji_python_backend_free(p: ?[*:0]u8) callconv(.c) void {
+    if (p) |ptr| {
+        const s = std.mem.span(ptr);
+        if (s.len == 0 or std.mem.eql(u8, s, "{}")) return; // static fallback
+        alloc.free(s);
+    }
+}
+
+export fn suji_python_backend_destroy() callconv(.c) void {
+    for (rt.event_listeners.items) |listener| suji_core_off(listener.id);
+    if (rt.main_thread_state) |ts| {
+        c.PyEval_RestoreThread(ts); // 정리는 GIL 필요.
+        rt.main_thread_state = null;
+        for (rt.event_listeners.items) |listener| {
+            c.Py_DecRef(listener.callback);
+            alloc.destroy(listener);
+        }
+        var it = rt.handlers.iterator();
+        while (it.next()) |entry| {
+            c.Py_DecRef(entry.value_ptr.*);
+            alloc.free(entry.key_ptr.*);
+        }
+        rt.handlers.deinit();
+        _ = c.Py_FinalizeEx();
+    } else {
+        for (rt.event_listeners.items) |listener| alloc.destroy(listener);
+        var it = rt.handlers.iterator();
+        while (it.next()) |entry| alloc.free(entry.key_ptr.*);
+        rt.handlers.deinit();
+    }
+    rt.event_listeners.deinit(alloc);
+    rt.initialized = false;
+}

--- a/examples/ios/python/Backends.swift
+++ b/examples/ios/python/Backends.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+// python 변형 — embedded CPython 백엔드(suji_python_backend_*)만 등록.
+// 데스크탑 src/platform/python.zig 모바일 대응. 공용 sujiBridgeRequest/sujiReg 는
+// _shared/BackendBridge.swift. 반환 포인터는 백엔드 소유 — 코어가 복사 후 pythonFree
+// 로 반납(register_handler 계약).
+
+private func pythonHandler(
+    _ channel: UnsafePointer<CChar>?, _ json: UnsafePointer<CChar>?
+) -> UnsafePointer<CChar>? {
+    sujiBridgeRequest(channel, json).withCString { UnsafePointer(suji_python_backend_handle_ipc($0)) }
+}
+private func pythonFree(_ p: UnsafePointer<CChar>?) {
+    suji_python_backend_free(UnsafeMutablePointer(mutating: p))
+}
+
+func registerStaticBackends() {
+    suji_python_backend_init(nil)
+
+    // PYTHONHOME = <bundle>/python (stdlib 이 python/lib/python3.13), entry =
+    // <bundle>/main.py — build-lib.sh 가 둘을 앱 번들에 스테이징.
+    guard let res = Bundle.main.resourcePath else {
+        NSLog("[suji] python: no resourcePath")
+        return
+    }
+    let home = res + "/python"
+    let entry = res + "/main.py"
+    let started: Bool = home.withCString { h in
+        entry.withCString { e in suji_python_backend_start(h, e) == 0 }
+    }
+    guard started else {
+        NSLog("[suji] python backend start failed (home=\(home))")
+        return
+    }
+
+    // main.py 가 suji.handle 로 등록한 핸들러 이름을 받아 각 채널을 코어에 등록
+    // → 프론트가 suji.invoke("ping") 처럼 데스크탑과 동일하게 호출(채널=핸들러).
+    guard let cstr = suji_python_backend_channels() else { return }
+    defer { suji_python_backend_free(cstr) }
+    let jsonStr = String(cString: cstr)
+    if let data = jsonStr.data(using: .utf8),
+       let names = (try? JSONSerialization.jsonObject(with: data)) as? [String] {
+        for ch in names { sujiReg(ch, pythonHandler, pythonFree) }
+    } else {
+        NSLog("[suji] python: bad channels json: \(jsonStr)")
+    }
+}

--- a/examples/ios/python/build-lib.sh
+++ b/examples/ios/python/build-lib.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Python 단독 iOS 예제 — 코어 + embedded CPython 정적 백엔드 + Python.xcframework
+# + 번들 stdlib + main.py 스테이징.
+# 사용: ./build-lib.sh [sim|device]  (기본 sim — 디바이스 프로비저닝 불필요)
+# 사전: bash scripts/stage-python-ios.sh (Python.xcframework + stdlib 다운로드)
+set -euo pipefail
+
+MODE="${1:-sim}"
+case "$MODE" in
+  sim)    ZIG_T="aarch64-ios-simulator"; SDK_NAME="iphonesimulator"; BK_MODE="ios-sim"; SLICE="ios-arm64_x86_64-simulator"; DYNLOAD="lib-arm64" ;;
+  device) ZIG_T="aarch64-ios";           SDK_NAME="iphoneos";        BK_MODE="ios-device"; SLICE="ios-arm64";             DYNLOAD="lib" ;;
+  *) echo "사용: $0 [sim|device]"; exit 1 ;;
+esac
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+BK="$HERE/../backends"
+VENDOR="$HERE/Vendor"
+PY_APPLE_TAG="${PY_APPLE_TAG:-3.13-b13}"
+PYX="$HOME/.suji/python-ios/$PY_APPLE_TAG/Python.xcframework"
+
+[ -d "$PYX" ] || { echo "Python.xcframework 없음 — 먼저 bash scripts/stage-python-ios.sh" >&2; exit 1; }
+
+rm -rf "$VENDOR"; mkdir -p "$VENDOR"
+
+# 1. 코어 (.a)
+( cd "$REPO" && zig build lib -Dtarget="$ZIG_T" -Doptimize=ReleaseSmall )
+cp "$REPO/zig-out/lib/libsuji_core.a" "$VENDOR/libsuji_core.a"
+
+# 2. Python 백엔드 (.a) — 공용 backends/python/build-lib.sh (xcframework 헤더로 컴파일).
+bash "$BK/python/build-lib.sh" "$BK_MODE" "$VENDOR"
+
+# 3. Python.xcframework — 링크 + 임베드(project.yml dependency).
+cp -R "$PYX" "$VENDOR/Python.xcframework"
+
+# 4. 번들 PYTHONHOME — <bundle>/python/lib/python3.13 = pure-python stdlib +
+#    arch lib-dynload(.so C 확장: _json 등). PYTHONHOME=<resourcePath>/python.
+mkdir -p "$VENDOR/python/lib"
+cp -R "$PYX/lib/python3.13" "$VENDOR/python/lib/python3.13"
+DYNLOAD_SRC="$PYX/$SLICE/$DYNLOAD/python3.13/lib-dynload"
+if [ -d "$DYNLOAD_SRC" ]; then
+  cp -R "$DYNLOAD_SRC" "$VENDOR/python/lib/python3.13/lib-dynload"
+fi
+
+# 5. main.py (엔트리) — <resourcePath>/main.py.
+cp "$BK/python/main.py" "$VENDOR/main.py"
+
+echo "staged ($MODE):"; ls -1 "$VENDOR"
+echo "next: xcodegen generate && xcodebuild -project SujiIOSPython.xcodeproj \\"
+echo "        -scheme SujiIOSPython -sdk $SDK_NAME ARCHS=arm64 build"

--- a/examples/ios/python/project.yml
+++ b/examples/ios/python/project.yml
@@ -1,0 +1,41 @@
+name: SujiIOSPython
+
+options:
+  bundleIdPrefix: dev.suji.examples
+  deploymentTarget:
+    iOS: "15.0"
+
+targets:
+  SujiIOSPython:
+    type: application
+    platform: iOS
+    sources:
+      - path: ../_shared
+        excludes: [Info.plist]
+      - path: Backends.swift
+      - path: web
+      # build-lib.sh 가 스테이징: main.py(엔트리) + python/(번들 PYTHONHOME stdlib).
+      - path: Vendor/main.py
+      - path: Vendor/python
+        type: folder # 폴더 레퍼런스 — 구조 보존 복사 → <resourcePath>/python
+    dependencies:
+      # embedded CPython framework — backend.zig 의 undefined Py* 를 해소 + 앱에 임베드.
+      - framework: Vendor/Python.xcframework
+        embed: true
+        codeSign: true
+    settings:
+      base:
+        DEVELOPMENT_TEAM: ${SUJI_IOS_TEAM_ID}
+        CODE_SIGN_STYLE: Automatic
+        INFOPLIST_FILE: $(SRCROOT)/../_shared/Info.plist
+        SWIFT_OBJC_BRIDGING_HEADER: $(SRCROOT)/../_shared/Suji-Bridging-Header.h
+        HEADER_SEARCH_PATHS:
+          - $(SRCROOT)/../../../include
+        LIBRARY_SEARCH_PATHS:
+          - $(SRCROOT)/Vendor
+        OTHER_LDFLAGS:
+          - -lsuji_core
+          - -lsuji_python_backend
+        LD_RUNPATH_SEARCH_PATHS:
+          - $(inherited)
+          - "@executable_path/Frameworks"

--- a/examples/ios/python/web/e2e.html
+++ b/examples/ios/python/web/e2e.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<!--
+  Python 백엔드 기능 e2e (데모 index.html 과 별개 — 호스트가 e2e 모드일 때만 로드:
+  iOS SUJI_E2E env). 디바이스 안에서 embedded CPython 핸들러(main.py 의 ping/echo)를
+  invoke 로 실 왕복(시뮬=실 libpython + 번들 stdlib → 진짜 e2e)하고 verdict 를
+  e2e:report 채널로 보고. ios-e2e.sh 가 데이터컨테이너 파일로 회수·assert.
+
+  iOS: 브리지(__suji__)는 호스트 WKUserScript 가 documentStart 주입. Android(후속):
+  데모 index.html 인라인 브리지와 동형(window.SujiNative 있을 때만 자체 정의) —
+  다른 변형 e2e.html 과 lockstep.
+-->
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>suji-e2e-pending</title>
+<body style="font:14px -apple-system,system-ui;padding:1rem">
+<pre id="log">running…</pre>
+<script>
+(function () {
+  // Android(후속): 데모 인라인 브리지와 동형(없을 때만 정의). iOS 는 호스트 주입.
+  if (!window.__suji__ && window.SujiNative) {
+    var _id = 0, _pending = {}, _listeners = {};
+    function invoke(channel, payload) {
+      return new Promise(function (res) {
+        var id = ++_id; _pending[id] = res;
+        window.SujiNative.invoke(id, String(channel),
+          JSON.stringify(payload === undefined ? {} : payload));
+      });
+    }
+    function core(json) {
+      return new Promise(function (res) {
+        var id = ++_id; _pending[id] = res;
+        window.SujiNative.invoke(id, "__core__",
+          (typeof json === "string" ? json : JSON.stringify(json)));
+      });
+    }
+    function __resolve__(id, json) {
+      var r = _pending[id]; if (!r) return; delete _pending[id];
+      try { r(json ? JSON.parse(json) : null); } catch (e) { r(json); }
+    }
+    function on(name, cb) { (_listeners[name] = _listeners[name] || []).push(cb); }
+    function __emit__(name, json) {
+      var ls = _listeners[name]; if (!ls) return;
+      var d; try { d = json ? JSON.parse(json) : null; } catch (e) { d = json; }
+      ls.forEach(function (f) { try { f(d); } catch (e) {} });
+    }
+    var api = { invoke: invoke, core: core, on: on,
+                __resolve__: __resolve__, __emit__: __emit__ };
+    window.__suji__ = api; window.suji = api;
+  }
+
+  function invoke(ch, payload) { return window.__suji__.invoke(ch, payload); }
+  var cases = [];
+  function check(name, cond) { cases.push({ name: name, ok: !!cond }); }
+
+  async function pythonSuite() {
+    // ping → embedded CPython 핸들러(main.py) 왕복. 시뮬=실 libpython.
+    var p = await invoke("ping");
+    check("ping runtime=python msg=pong",
+          p && p.runtime === "python" && p.msg === "pong");
+
+    // echo → json.loads/dumps 라운드트립(번들 stdlib 의 json).
+    var e = await invoke("echo", { value: "hello-ios" });
+    check("echo round-trip + cmd",
+          e && e.runtime === "python" && e.value === "hello-ios" &&
+          e.echo && e.echo.cmd === "echo");
+
+    // unicode/이모지 — UTF-8 인코딩 경계.
+    var u = await invoke("echo", { value: "한글-🚀" });
+    check("echo unicode", u && u.value === "한글-🚀");
+
+    // nested object/array — json 직렬화 깊이.
+    var n = await invoke("echo", { value: "x", nested: { a: [1, 2, 3], s: "z" } });
+    check("echo nested",
+          n && n.echo && n.echo.nested && n.echo.nested.a &&
+          n.echo.nested.a.length === 3 && n.echo.nested.s === "z");
+
+    // 20x 안정성(인터프리터 상태 오염/누수 없음).
+    var stressOk = true;
+    for (var k = 0; k < 20; k++) {
+      var sv = "s" + k;
+      var r = await invoke("echo", { value: sv });
+      if (!r || r.value !== sv) { stressOk = false; break; }
+    }
+    check("20x stress", stressOk);
+  }
+
+  async function run() {
+    try {
+      await pythonSuite();
+    } catch (err) { check("suite threw: " + err, false); }
+    var fail = cases.filter(function (c) { return !c.ok; }).length;
+    var verdict = { suite: "python", ok: fail === 0, fail: fail, cases: cases };
+    document.getElementById("log").textContent = JSON.stringify(verdict, null, 1);
+    document.title = fail === 0 ? "suji-e2e-pass" : "suji-e2e-fail";
+    console.log("SUJI_E2E_RESULT " + JSON.stringify(verdict));
+    try { await window.__suji__.invoke("e2e:report", verdict); } catch (e) {}
+  }
+
+  (function wait(n) {
+    if (window.__suji__ && window.__suji__.invoke) { run(); return; }
+    if (n <= 0) {
+      document.title = "suji-e2e-fail";
+      console.log('SUJI_E2E_RESULT {"suite":"python","ok":false,"fail":1,' +
+                  '"cases":[{"name":"bridge unavailable","ok":false}]}');
+      return;
+    }
+    setTimeout(function () { wait(n - 1); }, 100);
+  })(50);
+})();
+</script>
+</body>
+</html>

--- a/examples/ios/python/web/index.html
+++ b/examples/ios/python/web/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Suji iOS · Python</title>
+<body style="font:15px -apple-system,system-ui;padding:1rem">
+<h2>Suji iOS — embedded CPython</h2>
+<button id="ping">ping</button>
+<button id="echo">echo</button>
+<pre id="out">tap a button…</pre>
+<script>
+  // iOS: __suji__ 는 호스트 WKUserScript 가 documentStart 주입.
+  const out = document.getElementById("out");
+  function show(label, v) { out.textContent = label + " → " + JSON.stringify(v, null, 1); }
+  document.getElementById("ping").onclick = async () => {
+    show("ping", await window.__suji__.invoke("ping"));
+  };
+  document.getElementById("echo").onclick = async () => {
+    show("echo", await window.__suji__.invoke("echo", { value: "from-ios", n: 42 }));
+  };
+</script>
+</body>
+</html>

--- a/scripts/stage-python-ios.sh
+++ b/scripts/stage-python-ios.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# iOS embedded CPython staging — BeeWare Python-Apple-support(PEP 730 공식 코드 기반)
+# 의 iOS support tarball 을 ~/.suji/python-ios/<tag> 에 푼다(데스크탑 stage-python.sh
+# 동형, libnode/CEF staging 패턴). examples/ios/backends/python/build-lib.sh 가 이
+# 경로의 Python.xcframework 헤더로 backend.zig 를 컴파일하고, examples/ios/python
+# 호스트가 framework + python-stdlib 를 앱 번들에 임베드한다.
+#
+# 멱등: Python.xcframework 가 이미 있으면 skip.
+#
+# env override:
+#   PY_APPLE_TAG  (default 3.13-b13 — Python-Apple-support 릴리스 태그)
+#
+# 사용: ./scripts/stage-python-ios.sh
+
+set -euo pipefail
+
+PY_APPLE_TAG="${PY_APPLE_TAG:-3.13-b13}"
+DEST="${HOME}/.suji/python-ios/${PY_APPLE_TAG}"
+MARKER="${DEST}/Python.xcframework"
+
+if [ -d "$MARKER" ]; then
+  echo "[stage-python-ios] already staged: $MARKER"
+  exit 0
+fi
+
+# 태그 3.13-b13 → 자산 Python-3.13-iOS-support.b13.tar.gz
+BUILD_SUFFIX="${PY_APPLE_TAG##*-}"          # b13
+PY_MINOR="${PY_APPLE_TAG%%-*}"               # 3.13
+ASSET="Python-${PY_MINOR}-iOS-support.${BUILD_SUFFIX}.tar.gz"
+URL="https://github.com/beeware/Python-Apple-support/releases/download/${PY_APPLE_TAG}/${ASSET}"
+
+echo "[stage-python-ios] downloading ${ASSET}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+curl -fsSL "$URL" -o "$tmp/py.tar.gz"
+
+mkdir -p "$DEST"
+tar -xzf "$tmp/py.tar.gz" -C "$DEST"
+
+if [ ! -d "$MARKER" ]; then
+  echo "[stage-python-ios] FAILED — Python.xcframework not found after extract" >&2
+  exit 1
+fi
+echo "[stage-python-ios] staged: ${DEST}"

--- a/tests/python_test.zig
+++ b/tests/python_test.zig
@@ -72,3 +72,45 @@ test "e2e runner + test 존재 + python 채널" {
     defer a.free(test_ts);
     try expectContains(test_ts, "embedded CPython");
 }
+
+// 모바일(iOS) Python 백엔드 소스 계약 — 실 기능 검증은 tests/mobile-backends/
+// ios-e2e.sh python(시뮬레이터, Xcode 필요라 CI 외 로컬/수동, clipboard 모바일
+// e2e 와 동일 바). 여기선 배선이 빠지지 않게 CEF/Xcode 없이 고정.
+test "iOS Python 백엔드 배선 계약" {
+    const a = std.testing.allocator;
+
+    // staging: Python-Apple-support(PEP 730) iOS xcframework.
+    const stage = try slurp(a, "scripts/stage-python-ios.sh");
+    defer a.free(stage);
+    try expectContains(stage, "Python-Apple-support");
+    try expectContains(stage, "Python.xcframework");
+
+    // backend.zig — 데스크탑 런타임 포팅 + 모바일 C ABI + outbound extern + 교훈.
+    const backend = try slurp(a, "examples/ios/backends/python/src/backend.zig");
+    defer a.free(backend);
+    try expectContains(backend, "export fn suji_python_backend_start");
+    try expectContains(backend, "export fn suji_python_backend_channels");
+    try expectContains(backend, "export fn suji_python_backend_handle_ipc");
+    try expectContains(backend, "extern fn suji_core_invoke"); // outbound 배선
+    try expectContains(backend, "_Py_USE_GCC_BUILTIN_ATOMICS"); // pyatomic 회피
+    try expectContains(backend, "PyObject_CallOneArg"); // non-variadic
+
+    // build-lib: xcframework 헤더로 컴파일(libpython 은 앱 링크 해소).
+    const bbuild = try slurp(a, "examples/ios/backends/python/build-lib.sh");
+    defer a.free(bbuild);
+    try expectContains(bbuild, "Python.xcframework");
+    try expectContains(bbuild, "ios-sim");
+
+    // 호스트 변형: bridging header + Backends.swift(start+channels) + project.yml(embed).
+    const bridge = try slurp(a, "examples/ios/_shared/Suji-Bridging-Header.h");
+    defer a.free(bridge);
+    try expectContains(bridge, "suji_python_backend_start");
+    const swift = try slurp(a, "examples/ios/python/Backends.swift");
+    defer a.free(swift);
+    try expectContains(swift, "suji_python_backend_start");
+    try expectContains(swift, "suji_python_backend_channels");
+    const proj = try slurp(a, "examples/ios/python/project.yml");
+    defer a.free(proj);
+    try expectContains(proj, "Python.xcframework");
+    try expectContains(proj, "embed: true");
+}


### PR DESCRIPTION
데스크탑 Python 백엔드를 **iOS** 로 확장. CPython 3.13 은 PEP 730 으로 공식 iOS 지원 — **인터프리터라 JIT 불요 → Node/V8 의 iOS 불가와 결정적 대조**. `src/platform/python.zig` 런타임을 모바일 정적 백엔드로 포팅(sqlite 모바일이 데스크탑 plugins/sqlite 와 동형인 방식). **실 iOS 시뮬레이터 e2e 5/5 검증.**

## 구현
- **`examples/ios/backends/python/src/backend.zig`** — `@cImport(Python.h)` zig 직접 컴파일, `suji_python_backend_{init,start,channels,handle_ipc,free,destroy}` C ABI. outbound `suji.invoke/send/on` 은 정적 링크된 `suji_core_*` extern 직접 호출(데스크탑 setCore 함수포인터 주입 대신 — static-link 모델). 데스크탑 교훈 그대로: non-variadic `PyObject_CallOneArg`, `_Py_USE_GCC_BUILTIN_ATOMICS`. cmd 추출은 경량 `field()`(zig 형제 동형 — 전체 JSON DOM 파싱 회피).
- **동적 핸들러 배선**: main.py 가 `suji.handle` 로 등록 → `suji_python_backend_channels` 로 이름 목록 → 호스트(Swift)가 각 채널을 `suji_core_register_handler` 로 등록 → 프론트 `suji.invoke("ping")` 데스크탑 동형(채널=핸들러). Python 의 동적 핸들러 모델에 맞춘 의도된 분기(다른 모바일 백엔드는 컴파일타임 고정 채널).
- **iOS 소스**: BeeWare Python-Apple-support(PEP 730) `Python.xcframework` + stdlib staging(`scripts/stage-python-ios.sh`). `examples/ios/python` 변형 — framework 임베드 + stdlib `<bundle>/python`(PYTHONHOME) + main.py + `web/{index,e2e}.html`. project.yml/Backends.swift/build-lib.sh 는 sqlite 변형 패턴.

## 검증
- **`bash tests/mobile-backends/ios-e2e.sh python`** — 실 시뮬레이터에서 `Py_Initialize`(번들 stdlib) → main.py → WKWebView `invoke("ping"/"echo")` → CPython → 번들 `json` 왕복. **5/5**: ping / echo json round-trip / unicode·이모지 / nested / 20x stress.
- `tests/python_test.zig` 소스 계약 가드(CEF/Xcode 없이 CI 상시 — 배선 rot 방지).
- 데스크탑 무회귀(모바일은 별도 `zig build-lib`, 데스크탑 빌드 무영향). `zig fmt` clean.

## /simplify
`handle_ipc` 전체-DOM-파싱 → 경량 `field()` cmd 추출(per-call `std.json` 파싱+arena 제거; 핸들러가 어차피 `json.loads` 재파싱). 재검증 5/5.

## 정직 경계 (후속)
- 검증 천장 **시뮬레이터**(실기기 미검증 — clipboard 모바일 e2e 와 동일 바, Apple Developer 서명 필요).
- **Android Python**(PEP 738) — NDK 크로스컴파일 `libpython.so` + JNI 배선. 이 환경에 Android SDK/NDK/에뮬레이터 부재라 미착수(SDK 있는 머신/CI 후속). iOS backend.zig 런타임 로직 재사용 가능(타깃만 변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)