### PR TITLE
fix(test): android-e2e.sh e2e.html 체크 pipefail+SIGPIPE false-FAIL

### DIFF
--- a/tests/mobile-backends/android-e2e.sh
+++ b/tests/mobile-backends/android-e2e.sh
@@ -73,7 +73,10 @@ echo "=== assembleDebug ==="
 ( cd "$dir" && ./gradlew --console=plain :app:assembleDebug >/dev/null )
 apk="$(find "$dir/app/build/outputs/apk/debug" -name '*.apk' | head -1)"
 [ -n "$apk" ] || { echo "FAIL: apk 산출물 없음"; exit 1; }
-unzip -l "$apk" | grep -q 'assets/e2e.html' || { echo "FAIL: e2e.html 미번들"; exit 1; }
+# ⚠️ grep -q 는 첫 매치에서 즉시 종료 → 큰 apk(python stdlib 동봉 등)에서 unzip 이
+# SIGPIPE(141)로 죽고 set -o pipefail 이 매치 성공에도 파이프라인을 실패시킨다.
+# grep(no -q)로 전체를 소비해 SIGPIPE 회피.
+unzip -l "$apk" | grep 'assets/e2e.html' >/dev/null || { echo "FAIL: e2e.html 미번들"; exit 1; }
 
 echo "=== install + e2e launch ($PKG) ==="
 "$ADB" -s "$SERIAL" install -r "$apk" >/dev/null


### PR DESCRIPTION
`tests/mobile-backends/android-e2e.sh` 의 apk e2e.html 포함 체크:
```sh
unzip -l "$apk" | grep -q 'assets/e2e.html' || { echo "FAIL: e2e.html 미번들"; exit 1; }
```
`grep -q` 가 첫 매치에서 즉시 종료 → 파이프를 닫음 → `unzip` 이 SIGPIPE(141)로 죽음 → `set -o pipefail` 이 **매치 성공에도** 파이프라인을 실패로 판정 → 설치 전에 false `FAIL: e2e.html 미번들`.

작은 apk(zig/sqlite 등)는 grep 종료 전 unzip 이 listing 을 끝내 무사하지만, embedded CPython stdlib(~8MB zip) 동봉한 **python 변형 apk** 는 항목이 많아 e2e.html 매치 후 unzip 이 계속 출력하다 SIGPIPE → 재현성 있게 false-FAIL.

**수정**: `grep`(no `-q`) + `>/dev/null` 로 전체 입력을 소비(early-exit 제거) → SIGPIPE 회피. 동작 동일.

**실증**: 수정 후 `bash tests/mobile-backends/android-e2e.sh python` 풀 파이프라인(build-lib→assembleDebug→install→launch→logcat) **PASS — 5 cases** (실 arm64-v8a 에뮬레이터).

🤖 Generated with [Claude Code](https://claude.com/claude-code)