### PR TITLE
test(mobile): 호스트 하니스에 python 추가 — 모바일 python CI 자동 커버리지

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,5 +296,10 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      # 데스크탑 libpython staging → run.sh 가 모바일 python 백엔드(backend_android.c)를
+      # 호스트로 빌드·링크해 ping/echo 왕복까지 자동 검증(미staging 이면 graceful skip).
+      - name: Stage embedded CPython
+        run: bash scripts/stage-python.sh
+
       - name: Run mobile-backends host harness
         run: bash tests/mobile-backends/run.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,10 +77,15 @@ bash tests/e2e/run-python-e2e.sh        # Python 백엔드 (embedded CPython 3.1
 # 모바일 정적 백엔드 메커니즘 (CEF/iOS 무관, 호스트 검증)
 bash tests/mobile-backends/run.sh       # 코어+Rust(staticlib)+Go(c-archive)+Zig
                                         # +SQLite(build-lib) 정적 링크 →
-                                        # register_handler 왕복 65 케이스.
+                                        # register_handler 왕복 68 케이스.
                                         # zig:http=std.http→localhost 평문+HTTPS,
                                         # sql:*=실 sqlite3 CRUD(모바일 경로,
-                                        # 데스크탑 plugins/sqlite 바이트 동형)
+                                        # 데스크탑 plugins/sqlite 바이트 동형).
+                                        # python=backend_android.c 호스트 빌드+실
+                                        # 데스크탑 libpython 으로 ping/echo 왕복
+                                        # (libpython staged 시 — CI 가 stage-python.sh.
+                                        # 모바일 python 의 유일한 CI 자동 기능 커버리지;
+                                        # 미staging 이면 graceful skip)
 bash tests/mobile-backends/ios-sim-smoke.sh  # iOS 시뮬레이터 변형별 빌드+기동
                                         # 스모크(링크/TLS/심볼충돌 회귀; xcodegen+
                                         # 부팅 시뮬 필요; 기본 zig multi)

--- a/tests/mobile-backends/run.sh
+++ b/tests/mobile-backends/run.sh
@@ -124,10 +124,31 @@ zig build-lib -O ReleaseSmall -fPIC -lc \
   --name suji_zig_backend "$REPO/examples/ios/backends/zig/src/backend.zig"
 rm -f "$OUT/libsuji_zig_backend.a.o"
 
-echo "[5/6] sqlite backend (build-lib + vendored sqlite3.c, host)"
+echo "[5/7] sqlite backend (build-lib + vendored sqlite3.c, host)"
 bash "$REPO/examples/ios/backends/sqlite/build-lib.sh" host "$OUT" >/dev/null
 
-echo "[6/6] link + run"
+# Python(embedded CPython) — 데스크탑 libpython 이 staged 면 모바일 backend_android.c
+# 를 호스트 타깃으로 컴파일·링크해 CI 에서 ping/echo 왕복까지 자동 검증한다.
+# 미staging(로컬 fast path)은 graceful skip → 기존 5-백엔드 하니스 그대로 동작.
+echo "[6/7] python backend (embedded CPython, host — backend_android.c)"
+PY_HOME="$HOME/.suji/python/3.13.13"
+PY_INC="$PY_HOME/include/python3.13"
+case "$(uname -s)" in Darwin) PY_LIBF="$PY_HOME/lib/libpython3.13.dylib" ;; *) PY_LIBF="$PY_HOME/lib/libpython3.13.so" ;; esac
+PY_FLAGS=()
+if [ -f "$PY_LIBF" ] && [ -d "$PY_INC" ]; then
+  # backend_android.c 는 순수 C — real clang 이 bionic/pyatomic 무사(zig translate-c 한정 함정).
+  cc -c "$REPO/examples/ios/backends/python/src/backend_android.c" \
+     -I"$PY_INC" -I"$REPO/include" -fPIC -O2 -o "$OUT/backend_python.o"
+  ar rcs "$OUT/libsuji_python_backend.a" "$OUT/backend_python.o"
+  PY_FLAGS=(-DSUJI_HAVE_PYTHON "$OUT/libsuji_python_backend.a"
+            -L"$PY_HOME/lib" -lpython3.13 -Wl,-rpath,"$PY_HOME/lib")
+  export SUJI_PY_HOME="$PY_HOME" SUJI_PY_MAIN="$REPO/examples/ios/backends/python/main.py"
+  echo "  python staged → ping/echo 왕복 검증 활성"
+else
+  echo "  [SKIP] desktop libpython 미staging — python 케이스 제외 (bash scripts/stage-python.sh)"
+fi
+
+echo "[7/7] link + run"
 EXTRA=()
 case "$(uname -s)" in
   Darwin) EXTRA=(-lresolv -framework CoreFoundation -framework Security) ;;
@@ -137,5 +158,6 @@ esac
 cc "$HERE/verify.c" \
    "$OUT/libsuji_core.a" "$OUT/libsuji_rs_backend.a" "$OUT/libsuji_go_backend.a" \
    "$OUT/libsuji_zig_backend.a" "$OUT/libsuji_sqlite_backend.a" \
+   ${PY_FLAGS[@]+"${PY_FLAGS[@]}"} \
    -I"$REPO/include" "${EXTRA[@]}" -o "$OUT/verify"
 "$OUT/verify"

--- a/tests/mobile-backends/verify.c
+++ b/tests/mobile-backends/verify.c
@@ -39,6 +39,18 @@ extern void suji_zig_backend_set_ca_bundle_path(const char *path);
 extern char *suji_sqlite_backend_handle_ipc(const char *req);
 extern void suji_sqlite_backend_free(char *p);
 extern void suji_sqlite_backend_init(const void *core);
+// Python (embedded CPython) — run.sh 가 데스크탑 libpython 을 staging 했을 때만
+// backend_android.c 를 호스트 타깃으로 빌드·링크하고 -DSUJI_HAVE_PYTHON 을 준다.
+// 미staging 환경(로컬/CI)은 플래그 부재로 python 심볼을 일절 참조하지 않아 기존
+// 5-백엔드 빌드가 그대로 통과. init=no-op, start(home,entry)=Py_Initialize+main.py,
+// channels()=등록 채널 JSON, handle_ipc=cmd 추출→GIL→Python 디스패치.
+#ifdef SUJI_HAVE_PYTHON
+extern void suji_python_backend_init(const void *core);
+extern int suji_python_backend_start(const char *home, const char *entry);
+extern char *suji_python_backend_channels(void);
+extern char *suji_python_backend_handle_ipc(const char *req);
+extern void suji_python_backend_free(char *p);
+#endif
 
 static const char *rust_h(const char *ch, const char *j) {
     char *q = suji_mobile_bridge(ch, j);
@@ -75,6 +87,17 @@ static const char *sqlite_h(const char *ch, const char *j) {
     return r;
 }
 static void sqlite_f(const char *p) { suji_sqlite_backend_free((char *)p); }
+
+#ifdef SUJI_HAVE_PYTHON
+static const char *python_h(const char *ch, const char *j) {
+    char *q = suji_mobile_bridge(ch, j);
+    if (!q) return NULL;
+    char *r = suji_python_backend_handle_ipc(q);
+    free(q);
+    return r;
+}
+static void python_f(const char *p) { suji_python_backend_free((char *)p); }
+#endif
 
 // __core__ 모바일 디스패처 mock. iOS sujiCoreDispatch / Android coreDispatch 와
 // 동일 계약을 C 로 흉내 — register_handler("__core__") 라우팅과 데스크톱
@@ -419,6 +442,40 @@ int main(void) {
         roundtrip("sql:open", "{\"path\":\"rel/path.db\"}", "invalid path",
                   "sqlite relative path rejected (mobile boundary)");
     }
+
+#ifdef SUJI_HAVE_PYTHON
+    // Python 정적 백엔드 — examples/ios/backends/python/src/backend_android.c 를
+    // 호스트 타깃으로 빌드. desktop libpython + staged stdlib 로 main.py(ping/echo)
+    // 핸들러를 실제 Py_Initialize → 등록 → 모바일 경로(register_handler→bridge→
+    // handle_ipc)로 왕복. 데스크탑 python.zig 와 동일 런타임을 모바일 ABI 로 검증.
+    printf("== Python 정적 백엔드 (embedded CPython, 모바일 경로) ==\n");
+    {
+        const char *py_home = getenv("SUJI_PY_HOME");
+        const char *py_main = getenv("SUJI_PY_MAIN");
+        suji_python_backend_init(NULL);
+        if (py_home && py_main && suji_python_backend_start(py_home, py_main) == 0) {
+            char *chans = suji_python_backend_channels();
+            expect("python channels() lists ping", chans ? chans : "", "\"ping\"");
+            if (chans) suji_python_backend_free(chans);
+            if (suji_core_register_handler("ping", python_h, python_f) == 0 &&
+                suji_core_register_handler("echo", python_h, python_f) == 0) {
+                roundtrip("ping", "{}", "\"msg\": \"pong\"",
+                          "python ping (embedded CPython)");
+                // echo 는 json.dumps(ensure_ascii=기본) → 비ASCII 는 \uXXXX 이스케이프
+                // 되므로 호스트 하니스는 ASCII 값으로 검증(유니코드 왕복은 실 sim/emu
+                // e2e 의 e2e.html JS 가 디코드해 검증). cmd 도 함께 에코됨.
+                roundtrip("echo", "{\"value\":\"py-host-rt\"}", "\"value\": \"py-host-rt\"",
+                          "python echo (json round-trip)");
+            } else {
+                printf("  [FAIL] python register_handler\n");
+                fails++; total++;
+            }
+        } else {
+            // staging 실패는 환경 문제 — 빌드/링크는 됐으니 graceful skip(정직).
+            printf("  [SKIP] python start 실패 (SUJI_PY_HOME/SUJI_PY_MAIN staging 확인)\n");
+        }
+    }
+#endif
 
     printf("== Zig http (std.http → localhost 평문) ==\n");
     if (start_http_server() != 0) {

--- a/tests/python_test.zig
+++ b/tests/python_test.zig
@@ -167,3 +167,29 @@ test "Android Python 백엔드 배선 계약" {
     defer a.free(core);
     try expectContains(core, "nativeRegisterPythonBackend");
 }
+
+// CEF-free 호스트 하니스(tests/mobile-backends/run.sh, CI 포함)가 모바일 python
+// 백엔드(backend_android.c)를 호스트 타깃으로 빌드·링크해 ping/echo 왕복까지
+// **CI 자동** 검증한다. iOS/Android e2e 는 sim/emu 필요라 CI 외 → 이 host 경로가
+// 모바일 python 의 유일한 CI 자동 기능 커버리지(sqlite 동급). 미staging 시 graceful skip.
+test "host harness(run.sh): 모바일 python ping/echo CI 자동 검증 배선" {
+    const a = std.testing.allocator;
+
+    const run = try slurp(a, "tests/mobile-backends/run.sh");
+    defer a.free(run);
+    try expectContains(run, "backend_android.c"); // 호스트 타깃 컴파일
+    try expectContains(run, "-DSUJI_HAVE_PYTHON"); // verify.c python 케이스 게이트
+    try expectContains(run, "-lpython3.13"); // desktop libpython 링크
+    try expectContains(run, "SUJI_PY_MAIN"); // main.py 경로 주입
+
+    const verify = try slurp(a, "tests/mobile-backends/verify.c");
+    defer a.free(verify);
+    try expectContains(verify, "SUJI_HAVE_PYTHON"); // 미staging 환경 무참조 가드
+    try expectContains(verify, "suji_python_backend_start");
+    try expectContains(verify, "python ping (embedded CPython)");
+
+    // CI mobile-backends job 이 run.sh 전에 libpython 을 staging.
+    const ci = try slurp(a, ".github/workflows/ci.yml");
+    defer a.free(ci);
+    try expectContains(ci, "Stage embedded CPython");
+}


### PR DESCRIPTION
## 무엇

CEF-free 모바일 호스트 하니스 `tests/mobile-backends/run.sh`(CI 포함)에 **python 백엔드**를 엮어, 모바일 python 의 ping/echo 왕복을 **CI 에서 자동 검증**한다.

## 왜

모바일 python 백엔드(`backend_android.c`)의 기능 테스트는 그동안 실 sim/emu e2e(`ios-e2e.sh`/`android-e2e.sh` — Xcode/NDK/에뮬 필요라 **CI 외**)와 소스 계약 가드만 있었다. sqlite 는 `run.sh`(CI) + e2e 양쪽이라 CI 자동 *기능* 커버리지가 있는데 python 은 없었다. 이 갭을 닫는다.

## 어떻게

- **verify.c**: `#ifdef SUJI_HAVE_PYTHON` 게이트로 python externs/wrapper/테스트 블록 추가(rust/go/zig/sqlite 와 동형 `python_h`/`python_f`). `start(home,entry)`→`channels()`→`register_handler`→roundtrip. 미staging 환경은 플래그 부재로 python 심볼 무참조 → **기존 5-백엔드 빌드 무회귀**.
- **run.sh**: 데스크탑 libpython 이 staged 면 `backend_android.c` 를 호스트 타깃으로 `cc` 컴파일(순수 C — real clang 이 bionic/pyatomic 함정 무사) + libpython 링크 + `SUJI_PY_HOME`/`SUJI_PY_MAIN` 주입. 미staging 이면 graceful skip(bash 3.2 empty-array 안전: `${arr[@]+"${arr[@]}"}`).
- **ci.yml**: `mobile-backends` job 에 `stage-python.sh` 추가(GitHub Actions job 격리 → 자체 staging 필요).
- **python_test.zig**: host 하니스 python 배선 소스 계약 가드(run.sh `-DSUJI_HAVE_PYTHON`/`-lpython3.13`/`SUJI_PY_MAIN`, verify.c, ci.yml `Stage embedded CPython`).
- **CLAUDE.md**: run.sh 설명 65→68 케이스 + python 라인.

## 검증

```
$ bash tests/mobile-backends/run.sh
[6/7] python backend (embedded CPython, host — backend_android.c)
  python staged → ping/echo 왕복 검증 활성
== Python 정적 백엔드 (embedded CPython, 모바일 경로) ==
  [PASS] python channels() lists ping    resp=["ping","echo"]
  [PASS] python ping (embedded CPython)  resp={"runtime": "python", "msg": "pong"}
  [PASS] python echo (json round-trip)   resp={... "value": "py-host-rt"}
ALL PASS  (68/68)
$ zig build test   # exit 0
```

## 정직 경계

- echo 의 유니코드 왕복은 `json.dumps(ensure_ascii=기본)` 가 `\uXXXX` 로 이스케이프하므로 호스트 하니스는 ASCII 값으로 검증(유니코드 왕복은 실 sim/emu e2e 의 `e2e.html` JS 가 디코드해 검증).
- 이 host 경로는 모바일 python 의 **유일한 CI 자동 기능 커버리지**다. 실 디바이스/실 sim·emu 동작은 여전히 `ios-e2e.sh`/`android-e2e.sh`(로컬/수동) 천장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)