### PR TITLE
test(init): @suji/cli python 백엔드 스캐폴딩 e2e 추가 (lua 동형 갭)

### DIFF
--- a/tests/e2e/init-cli.test.ts
+++ b/tests/e2e/init-cli.test.ts
@@ -171,7 +171,7 @@ test("@suji/cli supports VoidZero Vite+ runner aliases", async () => {
   await buildFrontend(projectDir);
 });
 
-test("@suji/cli scaffolds node and lua backend entries without root package conflicts", async () => {
+test("@suji/cli scaffolds node, lua, and python backend entries without root package conflicts", async () => {
   const dir = await tempDir();
 
   const nodeInit = await run("node", [
@@ -204,6 +204,19 @@ test("@suji/cli scaffolds node and lua backend entries without root package conf
   const luaSuji = await readJson<any>(path.join(dir, "app-lua", "suji.json"));
   expect(luaSuji.backend).toEqual({ lang: "lua", entry: "backends/lua" });
   expect(await readFile(path.join(dir, "app-lua", "backends", "lua", "main.lua"), "utf8")).toContain("suji.handle");
+
+  const pythonInit = await run("node", [
+    CLI_BIN,
+    "init",
+    "app-python",
+    "--backend=python",
+    "--frontend=vanilla",
+  ], dir);
+  expectClean(pythonInit, "@suji/cli python init");
+
+  const pythonSuji = await readJson<any>(path.join(dir, "app-python", "suji.json"));
+  expect(pythonSuji.backend).toEqual({ lang: "python", entry: "backends/python" });
+  expect(await readFile(path.join(dir, "app-python", "backends", "python", "main.py"), "utf8")).toContain("suji.handle");
 });
 
 const frontendCases = [


### PR DESCRIPTION
## 무엇
`init-cli.test.ts` 에 `--backend=python` 스캐폴딩 e2e 케이스 추가.

## 왜 (전수 확인 결과)
python/lua 의 init 관련 자산을 전수 확인한 결과:

| 항목 | Python | Lua |
|---|---|---|
| 예제앱 (`examples/*-backend`) | ✅ | ✅ |
| 데모 e2e (CI) | ✅ run-python-e2e.sh | ✅ run-lua-e2e.sh |
| 네이티브 init.zig | ✅ scaffoldPython | ✅ scaffoldLua |
| @suji/cli + 템플릿 | ✅ python_main.py | ✅ lua_main.lua |
| init 단위테스트 | ✅ enum+template | ✅ enum+template |
| **init e2e (init-cli.test.ts)** | ❌→✅ (이 PR) | ✅ |

유일한 갭: init e2e 가 lua 스캐폴딩만 라운드트립 검증하고 python 누락 → lua 블록 미러링으로 메움.

## 검증
```
bun test init-cli.test.ts -t "node, lua, and python" → 1 pass / 0 fail
```
suji.json backend=`{lang:"python",entry:"backends/python"}` + main.py `suji.handle` 등록 확인. `e2e.yml run-init-cli.sh` 로 CI 자동.

🤖 Generated with [Claude Code](https://claude.com/claude-code)