### PR TITLE
feat(init): multi 스캐폴딩에 lua + python 백엔드 추가

### DIFF
--- a/packages/suji-cli/lib/init.js
+++ b/packages/suji-cli/lib/init.js
@@ -306,6 +306,8 @@ export function sujiJson(name, backend, template, pm) {
         { name: "zig", lang: "zig", entry: "backends/zig" },
         { name: "rust", lang: "rust", entry: "backends/rust" },
         { name: "go", lang: "go", entry: "backends/go" },
+        { name: "lua", lang: "lua", entry: "backends/lua" },
+        { name: "python", lang: "python", entry: "backends/python" },
       ],
       frontend,
     }, null, 2)}\n`;
@@ -354,6 +356,10 @@ export function scaffoldBackend(projectName, backend, name) {
   scaffoldZig("backends/zig");
   scaffoldRust("backends/rust");
   scaffoldGo("backends/go");
+  // lua/python 임베드 런타임은 채널을 router 에 자동 등록하므로(rust/go raw dylib 과
+  // 달리) zig 의 ping/greet 와 충돌하지 않게 네임스페이스 채널 템플릿을 쓴다.
+  W(join("backends/lua", "main.lua"), tpl("multi_lua_main.lua"));
+  W(join("backends/python", "main.py"), tpl("multi_python_main.py"));
 }
 
 export function scaffoldFrontend(projectName, template) {

--- a/packages/suji-cli/templates/multi_lua_main.lua
+++ b/packages/suji-cli/templates/multi_lua_main.lua
@@ -1,0 +1,9 @@
+-- multi-backend: 채널을 백엔드별 네임스페이스로 충돌 회피 (zig 가 ping/greet 소유).
+-- target 없이 suji.invoke("lua-ping") 으로 자동 라우팅된다.
+suji.handle("lua-ping", function()
+  return '{"from":"lua","msg":"pong"}'
+end)
+
+suji.handle("lua-greet", function()
+  return '{"from":"lua","greeting":"Hello from Lua!"}'
+end)

--- a/packages/suji-cli/templates/multi_python_main.py
+++ b/packages/suji-cli/templates/multi_python_main.py
@@ -1,0 +1,17 @@
+import suji
+import json
+
+# multi-backend: 채널을 백엔드별 네임스페이스로 충돌 회피 (zig 가 ping/greet 소유).
+# target 없이 suji.invoke("python-ping") 으로 자동 라우팅된다.
+
+
+def ping(request_json):
+    return json.dumps({"from": "python", "msg": "pong"})
+
+
+def greet(request_json):
+    return json.dumps({"from": "python", "greeting": "Hello from Python!"})
+
+
+suji.handle("python-ping", ping)
+suji.handle("python-greet", greet)

--- a/src/core/init.zig
+++ b/src/core/init.zig
@@ -251,6 +251,19 @@ pub fn run(allocator: std.mem.Allocator, opts: InitOptions) !void {
             var go_dir = try backends_dir.openDir(io, "go", .{});
             defer go_dir.close(io);
             try scaffoldGo(allocator, go_dir, name);
+
+            // lua/python 임베드 런타임은 채널을 router 에 자동 등록하므로(rust/go raw
+            // dylib 과 달리) zig 의 ping/greet 와 충돌하지 않도록 네임스페이스 채널
+            // 템플릿(lua-ping/python-ping)을 쓴다.
+            try backends_dir.createDir(io, "lua", .default_dir);
+            var multi_lua_dir = try backends_dir.openDir(io, "lua", .{});
+            defer multi_lua_dir.close(io);
+            try writeFileContent(multi_lua_dir, "main.lua", @embedFile("../templates/multi_lua_main.lua"));
+
+            try backends_dir.createDir(io, "python", .default_dir);
+            var multi_python_dir = try backends_dir.openDir(io, "python", .{});
+            defer multi_python_dir.close(io);
+            try writeFileContent(multi_python_dir, "main.py", @embedFile("../templates/multi_python_main.py"));
         },
     }
 
@@ -320,7 +333,9 @@ fn writeConfig(allocator: std.mem.Allocator, dir: Dir, name: []const u8, backend
             \\  "backends": [
             \\    {{ "name": "zig", "lang": "zig", "entry": "backends/zig" }},
             \\    {{ "name": "rust", "lang": "rust", "entry": "backends/rust" }},
-            \\    {{ "name": "go", "lang": "go", "entry": "backends/go" }}
+            \\    {{ "name": "go", "lang": "go", "entry": "backends/go" }},
+            \\    {{ "name": "lua", "lang": "lua", "entry": "backends/lua" }},
+            \\    {{ "name": "python", "lang": "python", "entry": "backends/python" }}
             \\  ],
             \\{s}
             \\}}

--- a/src/templates/multi_lua_main.lua
+++ b/src/templates/multi_lua_main.lua
@@ -1,0 +1,9 @@
+-- multi-backend: 채널을 백엔드별 네임스페이스로 충돌 회피 (zig 가 ping/greet 소유).
+-- target 없이 suji.invoke("lua-ping") 으로 자동 라우팅된다.
+suji.handle("lua-ping", function()
+  return '{"from":"lua","msg":"pong"}'
+end)
+
+suji.handle("lua-greet", function()
+  return '{"from":"lua","greeting":"Hello from Lua!"}'
+end)

--- a/src/templates/multi_python_main.py
+++ b/src/templates/multi_python_main.py
@@ -1,0 +1,17 @@
+import suji
+import json
+
+# multi-backend: 채널을 백엔드별 네임스페이스로 충돌 회피 (zig 가 ping/greet 소유).
+# target 없이 suji.invoke("python-ping") 으로 자동 라우팅된다.
+
+
+def ping(request_json):
+    return json.dumps({"from": "python", "msg": "pong"})
+
+
+def greet(request_json):
+    return json.dumps({"from": "python", "greeting": "Hello from Python!"})
+
+
+suji.handle("python-ping", ping)
+suji.handle("python-greet", greet)

--- a/tests/e2e/init-cli.test.ts
+++ b/tests/e2e/init-cli.test.ts
@@ -138,7 +138,13 @@ test("@suji/cli scaffolds multi backend rsbuild project", async () => {
   expect(suji.frontend.dev_command).toBe("pnpm run dev");
   expect(suji.frontend.build_command).toBe("pnpm run build");
   expect(suji.frontend.dist_dir).toBe("frontend/dist");
-  expect(suji.backends.map((b: any) => b.lang)).toEqual(["zig", "rust", "go"]);
+  expect(suji.backends.map((b: any) => b.lang)).toEqual(["zig", "rust", "go", "lua", "python"]);
+  // lua/python 임베드 런타임은 router 자동 등록이라 zig 의 ping/greet 와 충돌하지
+  // 않도록 네임스페이스 채널 템플릿이 스캐폴드돼야 한다(중복 등록 → auto-routing 차단 방지).
+  const luaMain = await readFile(path.join(projectDir, "backends", "lua", "main.lua"), "utf8");
+  expect(luaMain).toContain('suji.handle("lua-ping"');
+  const pyMain = await readFile(path.join(projectDir, "backends", "python", "main.py"), "utf8");
+  expect(pyMain).toContain('suji.handle("python-ping"');
   await expectAgentDocs(projectDir, "(multi)");
   await buildFrontend(projectDir);
 });

--- a/tests/init_test.zig
+++ b/tests/init_test.zig
@@ -99,7 +99,7 @@ test "번들 프론트엔드 템플릿: 계약 + suji-cli 미러 drift 가드" {
     }
 
     // 루트 백엔드 템플릿 미러도 동일 가드 (init.zig @embedFile 무가드였음).
-    inline for (.{ "gitignore", "zig_app.zig", "rust_cargo.toml", "rust_lib.rs", "go_main.go", "node_package.json", "node_main.js", "lua_main.lua", "python_main.py", ".github/workflows/suji.yml" }) |rf| {
+    inline for (.{ "gitignore", "zig_app.zig", "rust_cargo.toml", "rust_lib.rs", "go_main.go", "node_package.json", "node_main.js", "lua_main.lua", "python_main.py", "multi_lua_main.lua", "multi_python_main.py", ".github/workflows/suji.yml" }) |rf| {
         const s = try slurp(a, "src/templates/" ++ rf);
         defer a.free(s);
         const m = try slurp(a, "packages/suji-cli/templates/" ++ rf);


### PR DESCRIPTION
## 무엇
`suji init --backend=multi` 가 기존 `zig+rust+go` 에 더해 **lua + python** 까지 스캐폴드. 네이티브 `suji init` + `@suji/cli`(npx) 양쪽 동형.

## 왜 채널 충돌 회피가 필요한가
- lua/python 임베드 런타임은 `suji.handle` 채널을 **router 에 자동 등록**한다(`registerEmbedRoute`).
- rust/go 는 raw dylib(`backend_handle_ipc` switch)이라 router 미등록 → `target` 으로만 도달(현재 multi 에서 zig 만 `ping`/`greet` 소유).
- 표준 `ping`/`greet` 템플릿을 그대로 lua/python 에 쓰면 zig 와 **중복 등록 → auto-routing 비활성(WARN)** → 스캐폴드된 데모의 `invoke("ping")` 이 깨진다.

→ **네임스페이스 채널 전용 템플릿** 도입(`multi_lua_main.lua`=`lua-ping`/`lua-greet`, `multi_python_main.py`=`python-ping`/`python-greet`). `examples/multi-backend` 의 `lua-ping`/`python-ping` 컨벤션과 동형 → `invoke("lua-ping")` 자동 라우팅 동작(런타임 실증은 multi 예제가 이미 보유).

## 변경
- **신규 템플릿 4개**: `src/templates/` + `packages/suji-cli/templates/` 에 `multi_lua_main.lua` / `multi_python_main.py` (byte-동형 미러, `init_test.zig` 가드).
- **init.zig**: multi case 에 lua/python dir + `@embedFile` 배선, `writeConfig` multi backends 배열에 lua/python.
- **@suji/cli `init.js`**: 동형(multi config backends + scaffoldBackend multi 블록).
- **테스트**: `init_test.zig` 템플릿 미러 목록 + `init-cli.test.ts` multi 테스트(backends=`[zig,rust,go,lua,python]` + 네임스페이스 채널 스캐폴드 검증).

## 검증
- `zig build test` → exit 0 (템플릿 byte-동형 미러 가드 포함)
- `bun init-cli.test.ts -t "multi backend rsbuild"` → 1 pass (backends 5종 + lua-ping/python-ping)
- `bun init-cli.test.ts -t "node, lua, and python"` → 1 pass

## 참고
- node 는 npm install 의존이 무거워 multi 스캐폴드 기본에서 제외(기존과 동일). 필요 시 별도.
- `/simplify` 의 helper 재사용 제안은 multi 템플릿이 표준 템플릿과 동일하다는 오인에 기반(실제로는 충돌 회피 위해 의도적으로 다름) → 기각.

🤖 Generated with [Claude Code](https://claude.com/claude-code)