### PR TITLE
feat(window): BrowserWindow.focus() + isNormal() (Electron 패리티)

### DIFF
--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -186,6 +186,11 @@ export interface IsFullScreenResponse extends WindowOpResponse {
     cmd: "is_fullscreen";
     fullscreen: boolean;
 }
+export interface IsNormalResponse extends WindowOpResponse {
+    cmd: "is_normal";
+    /** minimized/maximized/fullscreen 모두 아닌 일반 상태 */
+    normal: boolean;
+}
 export interface ViewOptions {
     /** view를 합성할 host 창 id. live & .window이어야 함 */
     hostId: number;
@@ -284,6 +289,10 @@ export declare const windows: {
     isMinimized(windowId: number): Promise<IsMinimizedResponse>;
     isMaximized(windowId: number): Promise<IsMaximizedResponse>;
     isFullScreen(windowId: number): Promise<IsFullScreenResponse>;
+    /** Electron BrowserWindow.focus() — 창을 포그라운드로 키 창으로. */
+    focus(windowId: number): Promise<WindowOpResponse>;
+    /** Electron BrowserWindow.isNormal() — minimized/maximized/fullscreen 모두 아님. */
+    isNormal(windowId: number): Promise<IsNormalResponse>;
     undo(windowId: number): Promise<WindowOpResponse>;
     redo(windowId: number): Promise<WindowOpResponse>;
     cut(windowId: number): Promise<WindowOpResponse>;
@@ -396,6 +405,8 @@ export declare class BrowserWindow {
     isMinimized(): Promise<IsMinimizedResponse>;
     isMaximized(): Promise<IsMaximizedResponse>;
     isFullScreen(): Promise<IsFullScreenResponse>;
+    focus(): Promise<WindowOpResponse>;
+    isNormal(): Promise<IsNormalResponse>;
     undo(): Promise<WindowOpResponse>;
     redo(): Promise<WindowOpResponse>;
     cut(): Promise<WindowOpResponse>;

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -239,6 +239,14 @@ export const windows = {
     isFullScreen(windowId) {
         return coreCall({ cmd: "is_fullscreen", windowId });
     },
+    /** Electron BrowserWindow.focus() — 창을 포그라운드로 키 창으로. */
+    focus(windowId) {
+        return coreCall({ cmd: "focus", windowId });
+    },
+    /** Electron BrowserWindow.isNormal() — minimized/maximized/fullscreen 모두 아님. */
+    isNormal(windowId) {
+        return coreCall({ cmd: "is_normal", windowId });
+    },
     // Phase 4-E: 편집 — 모두 main frame에 위임. 응답은 ok만.
     undo(windowId) {
         return coreCall({ cmd: "undo", windowId });
@@ -478,6 +486,12 @@ export class BrowserWindow {
     }
     isFullScreen() {
         return windows.isFullScreen(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));
+    }
+    focus() {
+        return windows.focus(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));
+    }
+    isNormal() {
+        return windows.isNormal(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));
     }
     undo() {
         return windows.undo(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -257,6 +257,11 @@ export interface IsFullScreenResponse extends WindowOpResponse {
   cmd: "is_fullscreen";
   fullscreen: boolean;
 }
+export interface IsNormalResponse extends WindowOpResponse {
+  cmd: "is_normal";
+  /** minimized/maximized/fullscreen 모두 아닌 일반 상태 */
+  normal: boolean;
+}
 
 // ── Phase 17-A: WebContentsView (한 창 multi-content 합성) ──
 // viewId는 windowId와 같은 monotonic 풀에서 발급 — `windows.loadURL(viewId, ...)`,
@@ -482,6 +487,14 @@ export const windows = {
   },
   isFullScreen(windowId: number): Promise<IsFullScreenResponse> {
     return coreCall<IsFullScreenResponse>({ cmd: "is_fullscreen", windowId });
+  },
+  /** Electron BrowserWindow.focus() — 창을 포그라운드로 키 창으로. */
+  focus(windowId: number): Promise<WindowOpResponse> {
+    return coreCall<WindowOpResponse>({ cmd: "focus", windowId });
+  },
+  /** Electron BrowserWindow.isNormal() — minimized/maximized/fullscreen 모두 아님. */
+  isNormal(windowId: number): Promise<IsNormalResponse> {
+    return coreCall<IsNormalResponse>({ cmd: "is_normal", windowId });
   },
 
   // Phase 4-E: 편집 — 모두 main frame에 위임. 응답은 ok만.
@@ -754,6 +767,12 @@ export class BrowserWindow {
   }
   isFullScreen() {
     return windows.isFullScreen(this.#id);
+  }
+  focus() {
+    return windows.focus(this.#id);
+  }
+  isNormal() {
+    return windows.isNormal(this.#id);
   }
   undo() {
     return windows.undo(this.#id);

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -493,6 +493,11 @@ export interface IsFullScreenResponse extends WindowOpResponse {
   cmd: 'is_fullscreen';
   fullscreen: boolean;
 }
+export interface IsNormalResponse extends WindowOpResponse {
+  cmd: 'is_normal';
+  /** minimized/maximized/fullscreen 모두 아닌 일반 상태 */
+  normal: boolean;
+}
 
 export interface SetBoundsArgs {
   x?: number;
@@ -699,6 +704,14 @@ export const windows = {
   },
   isFullScreen(windowId: number): Promise<IsFullScreenResponse> {
     return invoke<IsFullScreenResponse>('__core__', { cmd: 'is_fullscreen', windowId });
+  },
+  /** Electron BrowserWindow.focus() — 창을 포그라운드로 키 창으로. */
+  focus(windowId: number): Promise<WindowOpResponse> {
+    return invoke<WindowOpResponse>('__core__', { cmd: 'focus', windowId });
+  },
+  /** Electron BrowserWindow.isNormal() — minimized/maximized/fullscreen 모두 아님. */
+  isNormal(windowId: number): Promise<IsNormalResponse> {
+    return invoke<IsNormalResponse>('__core__', { cmd: 'is_normal', windowId });
   },
 
   undo(windowId: number): Promise<WindowOpResponse> {
@@ -926,6 +939,12 @@ export class BrowserWindow {
   }
   isFullScreen() {
     return windows.isFullScreen(this.#id);
+  }
+  focus() {
+    return windows.focus(this.#id);
+  }
+  isNormal() {
+    return windows.isNormal(this.#id);
   }
   undo() {
     return windows.undo(this.#id);

--- a/src/core/window_ipc.zig
+++ b/src/core/window_ipc.zig
@@ -887,3 +887,26 @@ pub fn handleIsMaximized(window_id: u32, response_buf: []u8, wm: *window.WindowM
 pub fn handleIsFullscreen(window_id: u32, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
     return handleStateGet("is_fullscreen", "fullscreen", &window.WindowManager.isFullscreen, window_id, response_buf, wm);
 }
+
+// Electron BrowserWindow.focus() — Native.focus/WindowManager.focus 는 이미 존재
+// (set_visible 동선) → void action 패턴으로 노출만.
+pub fn handleFocus(window_id: u32, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
+    return handleDevToolsOp("focus", &window.WindowManager.focus, window_id, response_buf, wm);
+}
+
+// Electron BrowserWindow.isNormal() — minimized/maximized/fullscreen 가 모두 아닌
+// 상태. 기존 3 게터에서 파생(네이티브 추가 0). 하나라도 조회 실패 시 ok:false.
+pub fn handleIsNormal(window_id: u32, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
+    if (response_buf.len < RESPONSE_MIN_LEN) return null;
+    const normal: ?bool = blk: {
+        const minimized = wm.isMinimized(window_id) catch break :blk null;
+        const maximized = wm.isMaximized(window_id) catch break :blk null;
+        const fullscreen = wm.isFullscreen(window_id) catch break :blk null;
+        break :blk !minimized and !maximized and !fullscreen;
+    };
+    return std.fmt.bufPrint(
+        response_buf,
+        "{{\"from\":\"zig-core\",\"cmd\":\"is_normal\",\"windowId\":{d},\"ok\":{},\"normal\":{}}}",
+        .{ window_id, normal != null, normal orelse false },
+    ) catch null;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1801,6 +1801,8 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         .{ "is_minimized", &window_ipc.handleIsMinimized },
         .{ "is_maximized", &window_ipc.handleIsMaximized },
         .{ "is_fullscreen", &window_ipc.handleIsFullscreen },
+        .{ "focus", &window_ipc.handleFocus },
+        .{ "is_normal", &window_ipc.handleIsNormal },
     }) |entry| {
         if (std.mem.eql(u8, cmd, entry[0])) {
             const wm = window_mod.WindowManager.global orelse return null;

--- a/tests/e2e/window-lifecycle-events.test.ts
+++ b/tests/e2e/window-lifecycle-events.test.ts
@@ -235,6 +235,53 @@ describe("window lifecycle events", () => {
     await new Promise((r) => setTimeout(r, 200));
   });
 
+  // Electron 패리티: BrowserWindow.focus() + isNormal().
+  // focus 는 native focus/WM.focus 기존 동선 노출(ok 스모크). isNormal 은 기존
+  // minimize/maximize 상태 게터에서 파생 — 상태 전이로 행동 검증.
+  test("focus → ok, isNormal: 일반→minimize=false→restore=true→maximize=false", async () => {
+    const created = await core<{ windowId: number }>({
+      cmd: "create_window",
+      title: "lifecycle-focus-isnormal",
+      x: 300, y: 300, width: 400, height: 300,
+    });
+    const id = created.windowId;
+    await new Promise((r) => setTimeout(r, 200));
+
+    const f = await core<{ ok: boolean; windowId: number }>({ cmd: "focus", windowId: id });
+    expect(f.ok).toBe(true);
+    expect(f.windowId).toBe(id);
+
+    const n0 = await core<{ ok: boolean; normal: boolean }>({ cmd: "is_normal", windowId: id });
+    expect(n0.ok).toBe(true);
+    expect(n0.normal).toBe(true);
+
+    // minimize/restore(deminiaturize)/maximize 는 일부 플랫폼에서 비동기 반영 →
+    // is_normal 을 원하는 값까지 폴링(상태 전이 검증, 타이밍 flaky 회피).
+    const waitNormal = async (want: boolean) => {
+      for (let i = 0; i < 25; i++) {
+        if ((await core<{ normal: boolean }>({ cmd: "is_normal", windowId: id })).normal === want) return true;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      return false;
+    };
+
+    await core({ cmd: "minimize", windowId: id });
+    expect(await waitNormal(false)).toBe(true);
+
+    await core({ cmd: "restore_window", windowId: id });
+    expect(await waitNormal(true)).toBe(true);
+
+    await core({ cmd: "maximize", windowId: id });
+    expect(await waitNormal(false)).toBe(true);
+    await core({ cmd: "unmaximize", windowId: id });
+
+    // 알 수 없는 창 → ok:false (게터 invariant).
+    expect((await core<{ ok: boolean }>({ cmd: "is_normal", windowId: 99999 })).ok).toBe(false);
+
+    await core({ cmd: "destroy_window", windowId: id });
+    await new Promise((r) => setTimeout(r, 200));
+  });
+
   test("maximize → window:maximize 이벤트, unmaximize → window:unmaximize", async () => {
     const created = await core<{ windowId: number }>({
       cmd: "create_window",


### PR DESCRIPTION
## 무엇
Electron 패리티 backlog 의 [high] BrowserWindow 메서드 중 **네이티브 추가가 0**인 두 개를 노출.

- **`focus()`** — `Native.focus` + `WindowManager.focus` 는 이미 존재(set_visible 동선). `window_ipc.handleFocus`(void-action 패턴 `handleDevToolsOp`) + `main.zig` 디스패치 테이블 1줄. 신규 네이티브 0.
- **`isNormal()`** — minimized/maximized/fullscreen 가 모두 아닌 상태. 기존 3 게터에서 파생(`handleIsNormal`). 조회 실패 시 ok:false. 단일 bufPrint.

## SDK (4 surface 중 frontend+node)
suji-js(`@suji/api`) + suji-node(`@suji/node`) 양쪽에 `windows.focus`/`windows.isNormal` + `BrowserWindow.focus()`/`isNormal()` + `IsNormalResponse` 타입 추가(기존 `isFullScreen` 패턴 동형). `suji-js/dist` 재빌드(tracked), `suji-node/dist` 는 gitignore(publish 시 빌드).

## 검증
- `zig build` / `zig build test` → exit 0
- `bash tests/e2e/run-window-lifecycle-events.sh` → **14 pass / 0 fail**
  - `focus → ok`, `isNormal`: 일반→minimize=`false`→restore=`true`→maximize=`false`, 미존재 창→`ok:false`
  - restore(deminiaturize) 비동기 반영은 `is_normal` 폴링으로 안정화(flaky 회피)
- `/simplify`: `handleIsNormal` 이중 bufPrint → 단일로 정리(나머지 클린)

## 참고 (후속)
나머지 [high] 창 메서드는 네이티브/뷰필터 작업 필요라 후속 PR: `getBounds`/`getSize`/`getPosition`(CEF Views get_bounds × 3플랫폼), `isVisible`/`blur`/`isFocused`/`isAlwaysOnTop`(네이티브 vtable 추가), `getAllWindows`(view id 필터)/`getFocusedWindow`(focus 추적). Rust/Go SDK 미러도 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)