### PR TITLE
feat(window): BrowserWindow.getBounds()/getSize()/getPosition() (Electron 패리티)

### DIFF
--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -191,6 +191,14 @@ export interface IsNormalResponse extends WindowOpResponse {
     /** minimized/maximized/fullscreen 모두 아닌 일반 상태 */
     normal: boolean;
 }
+export interface BoundsResponse extends WindowOpResponse {
+    cmd: "get_bounds";
+    /** 화면 좌표(top-left 원점) */
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
 export interface ViewOptions {
     /** view를 합성할 host 창 id. live & .window이어야 함 */
     hostId: number;
@@ -293,6 +301,12 @@ export declare const windows: {
     focus(windowId: number): Promise<WindowOpResponse>;
     /** Electron BrowserWindow.isNormal() — minimized/maximized/fullscreen 모두 아님. */
     isNormal(windowId: number): Promise<IsNormalResponse>;
+    /** Electron BrowserWindow.getBounds() — {x,y,width,height} (top-left 원점). */
+    getBounds(windowId: number): Promise<BoundsResponse>;
+    /** Electron BrowserWindow.getSize() — [width, height]. getBounds 에서 파생. */
+    getSize(windowId: number): Promise<[number, number]>;
+    /** Electron BrowserWindow.getPosition() — [x, y]. getBounds 에서 파생. */
+    getPosition(windowId: number): Promise<[number, number]>;
     undo(windowId: number): Promise<WindowOpResponse>;
     redo(windowId: number): Promise<WindowOpResponse>;
     cut(windowId: number): Promise<WindowOpResponse>;
@@ -407,6 +421,9 @@ export declare class BrowserWindow {
     isFullScreen(): Promise<IsFullScreenResponse>;
     focus(): Promise<WindowOpResponse>;
     isNormal(): Promise<IsNormalResponse>;
+    getBounds(): Promise<BoundsResponse>;
+    getSize(): Promise<[number, number]>;
+    getPosition(): Promise<[number, number]>;
     undo(): Promise<WindowOpResponse>;
     redo(): Promise<WindowOpResponse>;
     cut(): Promise<WindowOpResponse>;

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -247,6 +247,20 @@ export const windows = {
     isNormal(windowId) {
         return coreCall({ cmd: "is_normal", windowId });
     },
+    /** Electron BrowserWindow.getBounds() — {x,y,width,height} (top-left 원점). */
+    getBounds(windowId) {
+        return coreCall({ cmd: "get_bounds", windowId });
+    },
+    /** Electron BrowserWindow.getSize() — [width, height]. getBounds 에서 파생. */
+    async getSize(windowId) {
+        const b = await windows.getBounds(windowId);
+        return [b.width, b.height];
+    },
+    /** Electron BrowserWindow.getPosition() — [x, y]. getBounds 에서 파생. */
+    async getPosition(windowId) {
+        const b = await windows.getBounds(windowId);
+        return [b.x, b.y];
+    },
     // Phase 4-E: 편집 — 모두 main frame에 위임. 응답은 ok만.
     undo(windowId) {
         return coreCall({ cmd: "undo", windowId });
@@ -492,6 +506,15 @@ export class BrowserWindow {
     }
     isNormal() {
         return windows.isNormal(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));
+    }
+    getBounds() {
+        return windows.getBounds(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));
+    }
+    getSize() {
+        return windows.getSize(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));
+    }
+    getPosition() {
+        return windows.getPosition(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));
     }
     undo() {
         return windows.undo(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -262,6 +262,14 @@ export interface IsNormalResponse extends WindowOpResponse {
   /** minimized/maximized/fullscreen 모두 아닌 일반 상태 */
   normal: boolean;
 }
+export interface BoundsResponse extends WindowOpResponse {
+  cmd: "get_bounds";
+  /** 화면 좌표(top-left 원점) */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
 
 // ── Phase 17-A: WebContentsView (한 창 multi-content 합성) ──
 // viewId는 windowId와 같은 monotonic 풀에서 발급 — `windows.loadURL(viewId, ...)`,
@@ -495,6 +503,20 @@ export const windows = {
   /** Electron BrowserWindow.isNormal() — minimized/maximized/fullscreen 모두 아님. */
   isNormal(windowId: number): Promise<IsNormalResponse> {
     return coreCall<IsNormalResponse>({ cmd: "is_normal", windowId });
+  },
+  /** Electron BrowserWindow.getBounds() — {x,y,width,height} (top-left 원점). */
+  getBounds(windowId: number): Promise<BoundsResponse> {
+    return coreCall<BoundsResponse>({ cmd: "get_bounds", windowId });
+  },
+  /** Electron BrowserWindow.getSize() — [width, height]. getBounds 에서 파생. */
+  async getSize(windowId: number): Promise<[number, number]> {
+    const b = await windows.getBounds(windowId);
+    return [b.width, b.height];
+  },
+  /** Electron BrowserWindow.getPosition() — [x, y]. getBounds 에서 파생. */
+  async getPosition(windowId: number): Promise<[number, number]> {
+    const b = await windows.getBounds(windowId);
+    return [b.x, b.y];
   },
 
   // Phase 4-E: 편집 — 모두 main frame에 위임. 응답은 ok만.
@@ -773,6 +795,15 @@ export class BrowserWindow {
   }
   isNormal() {
     return windows.isNormal(this.#id);
+  }
+  getBounds() {
+    return windows.getBounds(this.#id);
+  }
+  getSize() {
+    return windows.getSize(this.#id);
+  }
+  getPosition() {
+    return windows.getPosition(this.#id);
   }
   undo() {
     return windows.undo(this.#id);

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -498,6 +498,14 @@ export interface IsNormalResponse extends WindowOpResponse {
   /** minimized/maximized/fullscreen 모두 아닌 일반 상태 */
   normal: boolean;
 }
+export interface BoundsResponse extends WindowOpResponse {
+  cmd: 'get_bounds';
+  /** 화면 좌표(top-left 원점) */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
 
 export interface SetBoundsArgs {
   x?: number;
@@ -712,6 +720,20 @@ export const windows = {
   /** Electron BrowserWindow.isNormal() — minimized/maximized/fullscreen 모두 아님. */
   isNormal(windowId: number): Promise<IsNormalResponse> {
     return invoke<IsNormalResponse>('__core__', { cmd: 'is_normal', windowId });
+  },
+  /** Electron BrowserWindow.getBounds() — {x,y,width,height} (top-left 원점). */
+  getBounds(windowId: number): Promise<BoundsResponse> {
+    return invoke<BoundsResponse>('__core__', { cmd: 'get_bounds', windowId });
+  },
+  /** Electron BrowserWindow.getSize() — [width, height]. getBounds 에서 파생. */
+  async getSize(windowId: number): Promise<[number, number]> {
+    const b = await windows.getBounds(windowId);
+    return [b.width, b.height];
+  },
+  /** Electron BrowserWindow.getPosition() — [x, y]. getBounds 에서 파생. */
+  async getPosition(windowId: number): Promise<[number, number]> {
+    const b = await windows.getBounds(windowId);
+    return [b.x, b.y];
   },
 
   undo(windowId: number): Promise<WindowOpResponse> {
@@ -945,6 +967,15 @@ export class BrowserWindow {
   }
   isNormal() {
     return windows.isNormal(this.#id);
+  }
+  getBounds() {
+    return windows.getBounds(this.#id);
+  }
+  getSize() {
+    return windows.getSize(this.#id);
+  }
+  getPosition() {
+    return windows.getPosition(this.#id);
   }
   undo() {
     return windows.undo(this.#id);

--- a/src/core/window.zig
+++ b/src/core/window.zig
@@ -231,6 +231,7 @@ pub const Native = struct {
         destroy_window: *const fn (ctx: ?*anyopaque, handle: u64) void,
         set_title: *const fn (ctx: ?*anyopaque, handle: u64, title: []const u8) void,
         set_bounds: *const fn (ctx: ?*anyopaque, handle: u64, bounds: Bounds) void,
+        get_bounds: *const fn (ctx: ?*anyopaque, handle: u64) Bounds,
         set_visible: *const fn (ctx: ?*anyopaque, handle: u64, visible: bool) void,
         focus: *const fn (ctx: ?*anyopaque, handle: u64) void,
         // Phase 4-A: webContents 네비/JS
@@ -303,6 +304,9 @@ pub const Native = struct {
     }
     pub fn setBounds(self: Native, handle: u64, bounds: Bounds) void {
         self.vtable.set_bounds(self.ctx, handle, bounds);
+    }
+    pub fn getBounds(self: Native, handle: u64) Bounds {
+        return self.vtable.get_bounds(self.ctx, handle);
     }
     pub fn setVisible(self: Native, handle: u64, visible: bool) void {
         self.vtable.set_visible(self.ctx, handle, visible);
@@ -1233,6 +1237,14 @@ pub const WindowManager = struct {
         defer self.lock.unlock(self.io);
         const win = try self.getLiveLocked(id);
         return self.native.isAudioMuted(win.native_handle);
+    }
+
+    /// Electron BrowserWindow.getBounds() — 창의 현재 화면 좌표/크기(top-left 원점).
+    pub fn getBounds(self: *WindowManager, id: u32) Error!Bounds {
+        self.lock.lockUncancelable(self.io);
+        defer self.lock.unlock(self.io);
+        const win = try self.getLiveLocked(id);
+        return self.native.getBounds(win.native_handle);
     }
 
     pub fn setOpacity(self: *WindowManager, id: u32, opacity: f64) Error!void {

--- a/src/core/window_ipc.zig
+++ b/src/core/window_ipc.zig
@@ -894,6 +894,24 @@ pub fn handleFocus(window_id: u32, response_buf: []u8, wm: *window.WindowManager
     return handleDevToolsOp("focus", &window.WindowManager.focus, window_id, response_buf, wm);
 }
 
+// Electron BrowserWindow.getBounds() — 창 화면 좌표/크기(top-left 원점). getSize/
+// getPosition 은 SDK 가 이 응답에서 파생. 조회 실패 시 ok:false + 0 좌표.
+pub fn handleGetBounds(window_id: u32, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
+    if (response_buf.len < RESPONSE_MIN_LEN) return null;
+    const b = wm.getBounds(window_id) catch {
+        return std.fmt.bufPrint(
+            response_buf,
+            "{{\"from\":\"zig-core\",\"cmd\":\"get_bounds\",\"windowId\":{d},\"ok\":false,\"x\":0,\"y\":0,\"width\":0,\"height\":0}}",
+            .{window_id},
+        ) catch null;
+    };
+    return std.fmt.bufPrint(
+        response_buf,
+        "{{\"from\":\"zig-core\",\"cmd\":\"get_bounds\",\"windowId\":{d},\"ok\":true,\"x\":{d},\"y\":{d},\"width\":{d},\"height\":{d}}}",
+        .{ window_id, b.x, b.y, b.width, b.height },
+    ) catch null;
+}
+
 // Electron BrowserWindow.isNormal() — minimized/maximized/fullscreen 가 모두 아닌
 // 상태. 기존 3 게터에서 파생(네이티브 추가 0). 하나라도 조회 실패 시 ok:false.
 pub fn handleIsNormal(window_id: u32, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1803,6 +1803,7 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         .{ "is_fullscreen", &window_ipc.handleIsFullscreen },
         .{ "focus", &window_ipc.handleFocus },
         .{ "is_normal", &window_ipc.handleIsNormal },
+        .{ "get_bounds", &window_ipc.handleGetBounds },
     }) |entry| {
         if (std.mem.eql(u8, cmd, entry[0])) {
             const wm = window_mod.WindowManager.global orelse return null;

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -324,3 +324,4 @@ pub const applyBackgroundColor = cef_public_api.applyBackgroundColor;
 pub const closeMacWindow = cef_public_api.closeMacWindow;
 pub const setMacWindowTitle = cef_public_api.setMacWindowTitle;
 pub const setMacWindowBounds = cef_public_api.setMacWindowBounds;
+pub const getMacWindowBounds = cef_public_api.getMacWindowBounds;

--- a/src/platform/cef_mac_window.zig
+++ b/src/platform/cef_mac_window.zig
@@ -385,3 +385,26 @@ pub fn setMacWindowBounds(ns_window: *anyopaque, bounds: window_mod.Bounds) void
     const setFrameFn: *const fn (?*anyopaque, ?*anyopaque, NSRect, u8) callconv(.c) void = @ptrCast(&objc.objc_msgSend);
     setFrameFn(ns_window, @ptrCast(setFrameSel), rect, 1);
 }
+
+// setMacWindowBounds 의 역 — NSWindow.frame 을 읽어 top-left 원점 Bounds 로 변환.
+// Cocoa 는 bottom-left 원점이라 y 를 screen.height - frame.y - frame.height 로 뒤집는다
+// (setMacWindowBounds 의 cocoa_y 계산을 역으로).
+pub fn getMacWindowBounds(ns_window: *anyopaque) window_mod.Bounds {
+    const frameFn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) NSRect = @ptrCast(&objc.objc_msgSend);
+    const frame = frameFn(ns_window, @ptrCast(objc.sel_registerName("frame")));
+
+    const top_y: f64 = blk: {
+        const NSScreen = cef.getClass("NSScreen") orelse break :blk frame.y;
+        const mainScreen = cef.msgSend(NSScreen, "mainScreen") orelse break :blk frame.y;
+        const sfFn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) NSRect = @ptrCast(&objc.objc_msgSend);
+        const screen_frame = sfFn(mainScreen, @ptrCast(objc.sel_registerName("frame")));
+        break :blk screen_frame.height - frame.y - frame.height;
+    };
+
+    return .{
+        .x = @intFromFloat(@round(frame.x)),
+        .y = @intFromFloat(@round(top_y)),
+        .width = @intFromFloat(@max(@round(frame.width), 0)),
+        .height = @intFromFloat(@max(@round(frame.height), 0)),
+    };
+}

--- a/src/platform/cef_native_vtable.zig
+++ b/src/platform/cef_native_vtable.zig
@@ -14,6 +14,7 @@ pub const vtable: window_mod.Native.VTable = .{
     .destroy_window = cef_window_runtime.destroyWindow,
     .set_title = cef_window_runtime.setTitle,
     .set_bounds = cef_window_runtime.setBounds,
+    .get_bounds = cef_window_runtime.getBounds,
     .set_visible = cef_window_runtime.setVisible,
     .focus = cef_window_runtime.focus,
     .load_url = cef_web_contents.loadUrl,

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -190,6 +190,7 @@ pub const applyBackgroundColor = cef_mac_window.applyBackgroundColor;
 pub const closeMacWindow = cef_mac_window.closeMacWindow;
 pub const setMacWindowTitle = cef_mac_window.setMacWindowTitle;
 pub const setMacWindowBounds = cef_mac_window.setMacWindowBounds;
+pub const getMacWindowBounds = cef_mac_window.getMacWindowBounds;
 const cef_window_lifecycle = @import("cef_window_lifecycle.zig");
 
 pub const crashReporterEnabled = cef_crash_reporter.crashReporterEnabled;

--- a/src/platform/cef_window_runtime.zig
+++ b/src/platform/cef_window_runtime.zig
@@ -112,3 +112,26 @@ pub fn setBounds(ctx: ?*anyopaque, handle: u64, bounds: window_mod.Bounds) void 
     const ns_window = entry.ns_window orelse return;
     cef.setMacWindowBounds(ns_window, bounds);
 }
+
+pub fn getBounds(ctx: ?*anyopaque, handle: u64) window_mod.Bounds {
+    assertUiThread();
+    const self = fromCtx(ctx);
+    const entry = self.browsers.getPtr(handle) orelse return .{};
+    // CEF Views 창은 get_bounds 가 top-left 원점 cef_rect_t 반환(set_bounds 와 동일
+    // 좌표계) → 변환 불필요. setBounds 와 대칭.
+    if (entry.views_window) |views_window| {
+        if (views_window.base.base.get_bounds) |get_bounds| {
+            const rect = get_bounds(&views_window.base.base);
+            return .{
+                .x = rect.x,
+                .y = rect.y,
+                .width = @intCast(@max(rect.width, 0)),
+                .height = @intCast(@max(rect.height, 0)),
+            };
+        }
+    }
+    if (is_macos) {
+        if (entry.ns_window) |ns_window| return cef.getMacWindowBounds(ns_window);
+    }
+    return .{};
+}

--- a/tests/e2e/window-lifecycle.test.ts
+++ b/tests/e2e/window-lifecycle.test.ts
@@ -355,6 +355,37 @@ describe("Phase 2 — set_title / set_bounds 런타임 변경", () => {
     );
     expect(r2.ok).toBe(false);
   });
+
+  // Electron 패리티: get_bounds (→ SDK getBounds/getSize/getPosition).
+  test("get_bounds: set_bounds 후 roundtrip — 크기 정확, 위치 근사", async () => {
+    const c = await coreCall({ cmd: "create_window", title: "getbounds", url: "about:blank" });
+    await page.evaluate(
+      (req) => (window as any).__suji__.core(JSON.stringify(req)),
+      { cmd: "set_bounds", windowId: c.windowId, x: 90, y: 90, width: 520, height: 380 },
+    );
+    await new Promise((r) => setTimeout(r, 300));
+    const b: any = await page.evaluate(
+      (req) => (window as any).__suji__.core(JSON.stringify(req)),
+      { cmd: "get_bounds", windowId: c.windowId },
+    );
+    expect(b.cmd).toBe("get_bounds");
+    expect(b.ok).toBe(true);
+    // 크기는 정확히 round-trip — 기본값 폴백(.{}=800x600)이면 실패하므로 native 실독 증명.
+    expect(Math.abs(b.width - 520)).toBeLessThanOrEqual(4);
+    expect(Math.abs(b.height - 380)).toBeLessThanOrEqual(4);
+    // 위치는 WM 보정 가능 — 좌표계(top-left) 변환이 대략 맞는지(gross 오류 차단)만.
+    expect(typeof b.x).toBe("number");
+    expect(typeof b.y).toBe("number");
+    expect(Math.abs(b.x - 90)).toBeLessThanOrEqual(50);
+    expect(Math.abs(b.y - 90)).toBeLessThanOrEqual(50);
+  });
+
+  test("get_bounds: 알 수 없는 windowId — ok:false", async () => {
+    const r: any = await page.evaluate(() =>
+      (window as any).__suji__.core(JSON.stringify({ cmd: "get_bounds", windowId: 99999 })),
+    );
+    expect(r.ok).toBe(false);
+  });
 });
 
 // ============================================

--- a/tests/test_native.zig
+++ b/tests/test_native.zig
@@ -124,6 +124,7 @@ pub const TestNative = struct {
         .destroy_window = destroyWindow,
         .set_title = setTitle,
         .set_bounds = setBounds,
+        .get_bounds = getBounds,
         .set_visible = setVisible,
         .focus = focus,
         .load_url = loadUrl,
@@ -220,6 +221,10 @@ pub const TestNative = struct {
         const self = fromCtx(ctx);
         self.set_bounds_calls += 1;
         self.last_bounds = bounds;
+    }
+
+    fn getBounds(ctx: ?*anyopaque, _: u64) window.Bounds {
+        return fromCtx(ctx).last_bounds orelse .{};
     }
 
     fn setVisible(ctx: ?*anyopaque, _: u64, _: bool) void {

--- a/tests/window_manager_test.zig
+++ b/tests/window_manager_test.zig
@@ -247,6 +247,24 @@ test "create stores bounds and title" {
     try std.testing.expectEqual(@as(u32, 1024), win.bounds.width);
 }
 
+test "getBounds returns native-reported bounds (vtable wiring)" {
+    var native = TestNative{};
+    var wm = newManager(&native);
+    defer wm.deinit();
+
+    const id = try wm.create(.{ .title = "B" });
+    // TestNative.getBounds 는 마지막 setBounds 값을 반환 → WM→native vtable 왕복 검증.
+    try wm.setBounds(id, .{ .x = 42, .y = 24, .width = 640, .height = 480 });
+    const b = try wm.getBounds(id);
+    try std.testing.expectEqual(@as(i32, 42), b.x);
+    try std.testing.expectEqual(@as(i32, 24), b.y);
+    try std.testing.expectEqual(@as(u32, 640), b.width);
+    try std.testing.expectEqual(@as(u32, 480), b.height);
+
+    // 미존재 창 → WindowNotFound.
+    try std.testing.expectError(error.WindowNotFound, wm.getBounds(99999));
+}
+
 test "create propagates native failure as NativeCreateFailed" {
     var native = TestNative{ .fail_next_create = true };
     var wm = newManager(&native);


### PR DESCRIPTION
## 무엇
Electron 패리티 [high] 창 메서드 2번째 배치 — 창 화면 좌표/크기 조회. **단일 네이티브 primitive `get_bounds`** 가 3 SDK 메서드(`getBounds`/`getSize`/`getPosition`)를 푼다.

## 네이티브 (setBounds 와 대칭)
- **window.zig**: `Native.VTable.get_bounds` + `Native.getBounds` + `WindowManager.getBounds`(`isAudioMuted`/`getOpacity` 게터 패턴 동형, `getLiveLocked` 잠금).
- **cef_window_runtime.getBounds**: setBounds 대칭 — CEF Views 창은 `get_bounds` 가 top-left `cef_rect_t` 직접 반환(좌표 변환 불요), 아니면 macOS `NSWindow` 폴백.
- **cef_mac_window.getMacWindowBounds**: `setMacWindowBounds` 의 역. `NSWindow.frame` 읽어 cocoa(bottom-left)→top-left y 반전(`screen.height - frame.y - frame.height`).
- export(cef_public_api/cef.zig) + vtable 배선 + `test_native` 스텁(`last_bounds` 반환).

## IPC / SDK
- `window_ipc.handleGetBounds`(ok + x/y/width/height), `main.zig` `get_bounds` 라우팅.
- `@suji/api` + `@suji/node`: `windows.getBounds`(→`BoundsResponse`) + `getSize`(`[w,h]`)/`getPosition`(`[x,y]`) 파생(Electron 배열 시그니처) + `BrowserWindow` 메서드 3종 + 타입. `suji-js/dist` 재빌드(tracked).

## 검증
- `zig build` / `zig build test` → exit 0 (WM getBounds 단위: setBounds→getBounds 왕복 + 미존재 창 `WindowNotFound`)
- `bash tests/e2e/run-window-lifecycle.sh` → **48 pass / 0 fail**
  - set_bounds→get_bounds 왕복: width=520/height=380 **정확**(기본 폴백 800x600 아님 = native 실독 증명), 위치 top-left 변환 근사, 미존재 창 `ok:false`
- `/simplify`: cocoa-y 역변환 정확성 / 6계층 altitude / SDK 미러 전부 클린(변경 없음)

## 참고 (후속)
- Linux/Windows: CEF Views `get_bounds` 경로로 동작(컴파일 검증), 기능 e2e 는 macos 한정(기존 경계).
- 남은 [high]: `isVisible`/`blur`/`isFocused`/`isAlwaysOnTop`(네이티브 vtable 추가), `getAllWindows`/`getFocusedWindow`, Rust/Go SDK 미러.

🤖 Generated with [Claude Code](https://claude.com/claude-code)