### PR TITLE
feat(window): BrowserWindow.getAllWindows() + getFocusedWindow() (Electron 패리티)

### DIFF
--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -211,6 +211,20 @@ export interface IsAlwaysOnTopResponse extends WindowOpResponse {
     cmd: "is_always_on_top";
     alwaysOnTop: boolean;
 }
+export interface GetAllWindowsResponse {
+    from: "zig-core";
+    cmd: "get_all_windows";
+    ok: boolean;
+    /** 살아있는 top-level 창 id (WebContentsView 제외) */
+    windowIds: number[];
+}
+export interface GetFocusedWindowResponse {
+    from: "zig-core";
+    cmd: "get_focused_window";
+    ok: boolean;
+    /** 포커스된 창 id, 없으면 null */
+    windowId: number | null;
+}
 export interface ViewOptions {
     /** view를 합성할 host 창 id. live & .window이어야 함 */
     hostId: number;
@@ -329,6 +343,10 @@ export declare const windows: {
     setAlwaysOnTop(windowId: number, flag: boolean): Promise<WindowOpResponse>;
     /** Electron BrowserWindow.isAlwaysOnTop(). */
     isAlwaysOnTop(windowId: number): Promise<IsAlwaysOnTopResponse>;
+    /** Electron BrowserWindow.getAllWindows() — 살아있는 top-level 창 id (view 제외). */
+    getAllWindows(): Promise<GetAllWindowsResponse>;
+    /** Electron BrowserWindow.getFocusedWindow() — 포커스 창 id 또는 null. */
+    getFocusedWindow(): Promise<GetFocusedWindowResponse>;
     undo(windowId: number): Promise<WindowOpResponse>;
     redo(windowId: number): Promise<WindowOpResponse>;
     cut(windowId: number): Promise<WindowOpResponse>;
@@ -406,6 +424,10 @@ export declare class BrowserWindow {
     static create(opts?: WindowOptions): Promise<BrowserWindow>;
     /** 기존 windowId(예: 메인 창, 이벤트의 windowId)를 인스턴스로 래핑. */
     static fromId(id: number): BrowserWindow;
+    /** Electron BrowserWindow.getAllWindows() — 살아있는 top-level 창 인스턴스 배열. */
+    static getAllWindows(): Promise<BrowserWindow[]>;
+    /** Electron BrowserWindow.getFocusedWindow() — 포커스 창 인스턴스 또는 null. */
+    static getFocusedWindow(): Promise<BrowserWindow | null>;
     setTitle(title: string): Promise<WindowOpResponse>;
     setBounds(bounds: SetBoundsArgs): Promise<WindowOpResponse>;
     loadURL(url: string): Promise<WindowOpResponse>;

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -281,6 +281,14 @@ export const windows = {
     isAlwaysOnTop(windowId) {
         return coreCall({ cmd: "is_always_on_top", windowId });
     },
+    /** Electron BrowserWindow.getAllWindows() — 살아있는 top-level 창 id (view 제외). */
+    getAllWindows() {
+        return coreCall({ cmd: "get_all_windows" });
+    },
+    /** Electron BrowserWindow.getFocusedWindow() — 포커스 창 id 또는 null. */
+    getFocusedWindow() {
+        return coreCall({ cmd: "get_focused_window" });
+    },
     // Phase 4-E: 편집 — 모두 main frame에 위임. 응답은 ok만.
     undo(windowId) {
         return coreCall({ cmd: "undo", windowId });
@@ -414,6 +422,16 @@ export class BrowserWindow {
     /** 기존 windowId(예: 메인 창, 이벤트의 windowId)를 인스턴스로 래핑. */
     static fromId(id) {
         return new BrowserWindow(id);
+    }
+    /** Electron BrowserWindow.getAllWindows() — 살아있는 top-level 창 인스턴스 배열. */
+    static async getAllWindows() {
+        const r = await windows.getAllWindows();
+        return r.windowIds.map((id) => BrowserWindow.fromId(id));
+    }
+    /** Electron BrowserWindow.getFocusedWindow() — 포커스 창 인스턴스 또는 null. */
+    static async getFocusedWindow() {
+        const r = await windows.getFocusedWindow();
+        return r.windowId == null ? null : BrowserWindow.fromId(r.windowId);
     }
     setTitle(title) {
         return windows.setTitle(__classPrivateFieldGet(this, _BrowserWindow_id, "f"), title);

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -282,6 +282,20 @@ export interface IsAlwaysOnTopResponse extends WindowOpResponse {
   cmd: "is_always_on_top";
   alwaysOnTop: boolean;
 }
+export interface GetAllWindowsResponse {
+  from: "zig-core";
+  cmd: "get_all_windows";
+  ok: boolean;
+  /** 살아있는 top-level 창 id (WebContentsView 제외) */
+  windowIds: number[];
+}
+export interface GetFocusedWindowResponse {
+  from: "zig-core";
+  cmd: "get_focused_window";
+  ok: boolean;
+  /** 포커스된 창 id, 없으면 null */
+  windowId: number | null;
+}
 
 // ── Phase 17-A: WebContentsView (한 창 multi-content 합성) ──
 // viewId는 windowId와 같은 monotonic 풀에서 발급 — `windows.loadURL(viewId, ...)`,
@@ -550,6 +564,14 @@ export const windows = {
   isAlwaysOnTop(windowId: number): Promise<IsAlwaysOnTopResponse> {
     return coreCall<IsAlwaysOnTopResponse>({ cmd: "is_always_on_top", windowId });
   },
+  /** Electron BrowserWindow.getAllWindows() — 살아있는 top-level 창 id (view 제외). */
+  getAllWindows(): Promise<GetAllWindowsResponse> {
+    return coreCall<GetAllWindowsResponse>({ cmd: "get_all_windows" });
+  },
+  /** Electron BrowserWindow.getFocusedWindow() — 포커스 창 id 또는 null. */
+  getFocusedWindow(): Promise<GetFocusedWindowResponse> {
+    return coreCall<GetFocusedWindowResponse>({ cmd: "get_focused_window" });
+  },
 
   // Phase 4-E: 편집 — 모두 main frame에 위임. 응답은 ok만.
   undo(windowId: number): Promise<WindowOpResponse> {
@@ -714,6 +736,16 @@ export class BrowserWindow {
   /** 기존 windowId(예: 메인 창, 이벤트의 windowId)를 인스턴스로 래핑. */
   static fromId(id: number): BrowserWindow {
     return new BrowserWindow(id);
+  }
+  /** Electron BrowserWindow.getAllWindows() — 살아있는 top-level 창 인스턴스 배열. */
+  static async getAllWindows(): Promise<BrowserWindow[]> {
+    const r = await windows.getAllWindows();
+    return r.windowIds.map((id) => BrowserWindow.fromId(id));
+  }
+  /** Electron BrowserWindow.getFocusedWindow() — 포커스 창 인스턴스 또는 null. */
+  static async getFocusedWindow(): Promise<BrowserWindow | null> {
+    const r = await windows.getFocusedWindow();
+    return r.windowId == null ? null : BrowserWindow.fromId(r.windowId);
   }
 
   setTitle(title: string) {

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -518,6 +518,20 @@ export interface IsAlwaysOnTopResponse extends WindowOpResponse {
   cmd: 'is_always_on_top';
   alwaysOnTop: boolean;
 }
+export interface GetAllWindowsResponse {
+  from: 'zig-core';
+  cmd: 'get_all_windows';
+  ok: boolean;
+  /** 살아있는 top-level 창 id (WebContentsView 제외) */
+  windowIds: number[];
+}
+export interface GetFocusedWindowResponse {
+  from: 'zig-core';
+  cmd: 'get_focused_window';
+  ok: boolean;
+  /** 포커스된 창 id, 없으면 null */
+  windowId: number | null;
+}
 
 export interface SetBoundsArgs {
   x?: number;
@@ -767,6 +781,14 @@ export const windows = {
   isAlwaysOnTop(windowId: number): Promise<IsAlwaysOnTopResponse> {
     return invoke<IsAlwaysOnTopResponse>('__core__', { cmd: 'is_always_on_top', windowId });
   },
+  /** Electron BrowserWindow.getAllWindows() — 살아있는 top-level 창 id (view 제외). */
+  getAllWindows(): Promise<GetAllWindowsResponse> {
+    return invoke<GetAllWindowsResponse>('__core__', { cmd: 'get_all_windows' });
+  },
+  /** Electron BrowserWindow.getFocusedWindow() — 포커스 창 id 또는 null. */
+  getFocusedWindow(): Promise<GetFocusedWindowResponse> {
+    return invoke<GetFocusedWindowResponse>('__core__', { cmd: 'get_focused_window' });
+  },
 
   undo(windowId: number): Promise<WindowOpResponse> {
     return invoke<WindowOpResponse>('__core__', { cmd: 'undo', windowId });
@@ -862,6 +884,16 @@ export class BrowserWindow {
   /** 기존 windowId(메인 창/이벤트 sender)를 인스턴스로 래핑. */
   static fromId(id: number): BrowserWindow {
     return new BrowserWindow(id);
+  }
+  /** Electron BrowserWindow.getAllWindows() — 살아있는 top-level 창 인스턴스 배열. */
+  static async getAllWindows(): Promise<BrowserWindow[]> {
+    const r = await windows.getAllWindows();
+    return r.windowIds.map((id) => BrowserWindow.fromId(id));
+  }
+  /** Electron BrowserWindow.getFocusedWindow() — 포커스 창 인스턴스 또는 null. */
+  static async getFocusedWindow(): Promise<BrowserWindow | null> {
+    const r = await windows.getFocusedWindow();
+    return r.windowId == null ? null : BrowserWindow.fromId(r.windowId);
   }
 
   loadURL(url: string) {

--- a/src/core/window.zig
+++ b/src/core/window.zig
@@ -1186,6 +1186,37 @@ pub const WindowManager = struct {
         return self.native.isAlwaysOnTop(win.native_handle);
     }
 
+    /// Electron BrowserWindow.getAllWindows() — 살아있는 top-level 창(.window) id 를
+    /// out 에 채우고 개수 반환. .view 와 destroyed 는 제외. out 초과분은 버림.
+    pub fn listWindowIds(self: *WindowManager, out: []u32) usize {
+        self.lock.lockUncancelable(self.io);
+        defer self.lock.unlock(self.io);
+        var n: usize = 0;
+        var it = self.windows.iterator();
+        while (it.next()) |entry| {
+            const win = entry.value_ptr.*;
+            if (win.kind != .window or win.destroyed) continue;
+            if (n >= out.len) break;
+            out[n] = win.id;
+            n += 1;
+        }
+        return n;
+    }
+
+    /// Electron BrowserWindow.getFocusedWindow() — 포커스(key) top-level 창 id, 없으면
+    /// null. native.isFocused 를 직접 질의(개별 WM 게터 재호출 시 잠금 재진입 회피).
+    pub fn getFocusedWindow(self: *WindowManager) ?u32 {
+        self.lock.lockUncancelable(self.io);
+        defer self.lock.unlock(self.io);
+        var it = self.windows.iterator();
+        while (it.next()) |entry| {
+            const win = entry.value_ptr.*;
+            if (win.kind != .window or win.destroyed) continue;
+            if (self.native.isFocused(win.native_handle)) return win.id;
+        }
+        return null;
+    }
+
     // ==================== Phase 4-A: webContents (네비 / JS) ====================
 
     pub fn loadUrl(self: *WindowManager, id: u32, url: []const u8) Error!void {

--- a/src/core/window_ipc.zig
+++ b/src/core/window_ipc.zig
@@ -937,6 +937,40 @@ pub fn handleSetAlwaysOnTop(req: SetAlwaysOnTopReq, response_buf: []u8, wm: *win
     return respondWindowOp(response_buf, "set_always_on_top", req.window_id, ok);
 }
 
+// Electron BrowserWindow.getAllWindows() — 살아있는 top-level 창 id 배열(.view 제외).
+// windowId 입력 없음 → main.zig 가 전용 분기로 호출.
+pub fn handleGetAllWindows(response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
+    if (response_buf.len < RESPONSE_MIN_LEN) return null;
+    var ids: [256]u32 = undefined;
+    const n = wm.listWindowIds(&ids);
+    // handleGetChildViews 와 동일한 std.Io.Writer 배열 빌드 패턴(수동 offset 추적 회피).
+    var w = std.Io.Writer.fixed(response_buf);
+    w.writeAll("{\"from\":\"zig-core\",\"cmd\":\"get_all_windows\",\"ok\":true,\"windowIds\":[") catch return null;
+    for (ids[0..n], 0..) |id, i| {
+        if (i > 0) w.writeByte(',') catch return null;
+        w.print("{d}", .{id}) catch return null;
+    }
+    w.writeAll("]}") catch return null;
+    return w.buffered();
+}
+
+// Electron BrowserWindow.getFocusedWindow() — 포커스 창 id 또는 null. windowId 입력 없음.
+pub fn handleGetFocusedWindow(response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
+    if (response_buf.len < RESPONSE_MIN_LEN) return null;
+    if (wm.getFocusedWindow()) |id| {
+        return std.fmt.bufPrint(
+            response_buf,
+            "{{\"from\":\"zig-core\",\"cmd\":\"get_focused_window\",\"ok\":true,\"windowId\":{d}}}",
+            .{id},
+        ) catch null;
+    }
+    return std.fmt.bufPrint(
+        response_buf,
+        "{{\"from\":\"zig-core\",\"cmd\":\"get_focused_window\",\"ok\":true,\"windowId\":null}}",
+        .{},
+    ) catch null;
+}
+
 // Electron BrowserWindow.isNormal() — minimized/maximized/fullscreen 가 모두 아닌
 // 상태. 기존 3 게터에서 파생(네이티브 추가 0). 하나라도 조회 실패 시 ok:false.
 pub fn handleIsNormal(window_id: u32, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1799,6 +1799,15 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         const on_top = util.extractJsonBool(req_clean, "onTop") orelse false;
         return window_ipc.handleSetAlwaysOnTop(.{ .window_id = win_id, .on_top = on_top }, response_buf, wm);
     }
+    // getAllWindows/getFocusedWindow 는 windowId 입력이 없어 전용 분기.
+    if (std.mem.eql(u8, cmd, "get_all_windows")) {
+        const wm = window_mod.WindowManager.global orelse return null;
+        return window_ipc.handleGetAllWindows(response_buf, wm);
+    }
+    if (std.mem.eql(u8, cmd, "get_focused_window")) {
+        const wm = window_mod.WindowManager.global orelse return null;
+        return window_ipc.handleGetFocusedWindow(response_buf, wm);
+    }
     inline for (.{
         .{ "minimize", &window_ipc.handleMinimize },
         .{ "restore_window", &window_ipc.handleRestoreWindow },

--- a/tests/e2e/window-lifecycle.test.ts
+++ b/tests/e2e/window-lifecycle.test.ts
@@ -436,6 +436,44 @@ describe("BrowserWindow 가시성/포커스/always-on-top (Electron 패리티)",
 });
 
 // ============================================
+// Electron 패리티: getAllWindows / getFocusedWindow
+// ============================================
+describe("BrowserWindow.getAllWindows / getFocusedWindow (Electron 패리티)", () => {
+  const op = (req: object): Promise<any> =>
+    page.evaluate((r) => (window as any).__suji__.core(JSON.stringify(r)), req);
+
+  test("get_all_windows: 생성한 top-level 창 포함", async () => {
+    const a = await coreCall({ cmd: "create_window", title: "all-a", url: "about:blank" });
+    const b = await coreCall({ cmd: "create_window", title: "all-b", url: "about:blank" });
+    const r = await op({ cmd: "get_all_windows" });
+    expect(r.ok).toBe(true);
+    expect(Array.isArray(r.windowIds)).toBe(true);
+    expect(r.windowIds).toContain(a.windowId);
+    expect(r.windowIds).toContain(b.windowId);
+  });
+
+  test("get_all_windows: WebContentsView 는 제외(top-level 만)", async () => {
+    const host = await coreCall({ cmd: "create_window", title: "all-host", url: "about:blank" });
+    const v = await op({
+      cmd: "create_view",
+      hostId: host.windowId,
+      url: "about:blank",
+      bounds: { x: 0, y: 0, width: 100, height: 100 },
+    });
+    expect(typeof v.viewId).toBe("number");
+    const r = await op({ cmd: "get_all_windows" });
+    expect(r.windowIds).toContain(host.windowId);
+    expect(r.windowIds).not.toContain(v.viewId);
+  });
+
+  test("get_focused_window: ok + windowId 는 null 또는 숫자", async () => {
+    const r = await op({ cmd: "get_focused_window" });
+    expect(r.ok).toBe(true);
+    expect(r.windowId === null || typeof r.windowId === "number").toBe(true);
+  });
+});
+
+// ============================================
 // 멀티 윈도우 시나리오 — 동시 작업 + 교차 영향 없음
 // ============================================
 

--- a/tests/window_manager_test.zig
+++ b/tests/window_manager_test.zig
@@ -292,6 +292,42 @@ test "blur/isVisible/isFocused/alwaysOnTop native vtable wiring" {
     try std.testing.expectError(error.WindowNotFound, wm.setAlwaysOnTop(99999, true));
 }
 
+test "listWindowIds / getFocusedWindow — top-level only (view/destroyed 제외)" {
+    var native = TestNative{};
+    var wm = newManager(&native);
+    defer wm.deinit();
+
+    const w1 = try wm.create(.{ .title = "A" });
+    const w2 = try wm.create(.{ .title = "B" });
+    const view = try wm.createView(.{ .host_window_id = w1, .url = "about:blank", .bounds = .{} });
+
+    var ids: [16]u32 = undefined;
+    var n = wm.listWindowIds(&ids);
+    try std.testing.expectEqual(@as(usize, 2), n); // .view 제외
+    var saw_w1 = false;
+    var saw_w2 = false;
+    var saw_view = false;
+    for (ids[0..n]) |id| {
+        if (id == w1) saw_w1 = true;
+        if (id == w2) saw_w2 = true;
+        if (id == view) saw_view = true;
+    }
+    try std.testing.expect(saw_w1 and saw_w2 and !saw_view);
+
+    // getFocusedWindow: stub_focused=false → null.
+    try std.testing.expectEqual(@as(?u32, null), wm.getFocusedWindow());
+    // stub_focused=true → 어떤 top-level 창(view 아님).
+    native.stub_focused = true;
+    const focused = wm.getFocusedWindow().?;
+    try std.testing.expect(focused == w1 or focused == w2);
+
+    // destroy 후 목록에서 제외.
+    try wm.destroy(w2);
+    n = wm.listWindowIds(&ids);
+    try std.testing.expectEqual(@as(usize, 1), n);
+    try std.testing.expectEqual(w1, ids[0]);
+}
+
 test "create propagates native failure as NativeCreateFailed" {
     var native = TestNative{ .fail_next_create = true };
     var wm = newManager(&native);


### PR DESCRIPTION
## 무엇
Electron 패리티 [high] 창 메서드 4번째 배치 — 창 목록/포커스 창 조회. **네이티브 vtable 추가 0**(기존 `isFocused` 재사용).

## WindowManager
- **listWindowIds(out)**: 살아있는 top-level 창(`.window`) id 채움. `.view`(WebContentsView) + `destroyed` 제외(`Window.kind` 디스크리미네이터).
- **getFocusedWindow()**: 잠금 보유 중 `native.isFocused` **직접** 질의(WM 래퍼 재호출 시 `lockUncancelable` 재진입 데드락 회피)로 첫 포커스 top-level 창, 없으면 null.

## IPC / SDK
- `window_ipc.handleGetAllWindows`(`std.Io.Writer` 배열 빌드 — `handleGetChildViews` 패턴 동형) / `handleGetFocusedWindow`(windowId 또는 null). 둘 다 windowId 입력 없어 `main.zig` 전용 분기(inline 테이블 우회).
- `@suji/api` + `@suji/node`: `windows.getAllWindows`/`getFocusedWindow` + `BrowserWindow.getAllWindows()`→`BrowserWindow[]` / `getFocusedWindow()`→`BrowserWindow|null` (static, fromId 매핑) + 응답 타입. suji-js/dist 재빌드.

## 검증
- `zig build` / `zig build test` → exit 0 (WM 단위: 2창+1뷰 → listWindowIds=2(뷰 제외), getFocusedWindow null↔창, destroy 후 제외)
- `bash tests/e2e/run-window-lifecycle.sh` → **55 pass / 0 fail** (get_all_windows 생성창 포함 + **실 런타임 view 제외**, get_focused_window ok + null|number)
- **`/code-review` max(9 angles)**: lock 재진입 / iterator 안전 / destroyed 필터 / 필드명 전부 검증 통과. 버퍼오버플로우(16KB·256 cap)·`== null` 관용구·`.map` 가드는 refuted/허용. **적용 1건**: handleGetAllWindows 를 handleGetChildViews 의 `std.Io.Writer` 패턴으로 통일.

## 참고 (후속)
- getFocusedWindow 는 O(n) 스캔(n=창 수, 보통 1~5) — parity audit 의 focused_window_id 추적은 최적화 옵션(현재 불요).
- 남은: Rust/Go SDK 미러(#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)