### PR TITLE
feat(go-sdk): windows 생명주기/상태 메서드 21종 (JS 패리티)

### DIFF
--- a/sdks/suji-go/windows/windows.go
+++ b/sdks/suji-go/windows/windows.go
@@ -327,6 +327,75 @@ func parseWindowID(raw string) (uint32, error) {
 	return *v.WindowID, nil
 }
 
+// ── Electron BrowserWindow 생명주기/상태 (JS @suji/api 패리티) ──
+// 대부분 {"cmd":"X","windowId":N} 동형 → windowOpRequest 로 DRY. 응답은 raw JSON.
+func windowOpRequest(cmd string, windowID uint32) string {
+	return fmt.Sprintf(`{"cmd":"%s","windowId":%d}`, cmd, windowID)
+}
+func setVisibleRequest(windowID uint32, visible bool) string {
+	return fmt.Sprintf(`{"cmd":"set_visible","windowId":%d,"visible":%t}`, windowID, visible)
+}
+func setFullscreenRequest(windowID uint32, flag bool) string {
+	return fmt.Sprintf(`{"cmd":"set_fullscreen","windowId":%d,"flag":%t}`, windowID, flag)
+}
+func setAlwaysOnTopRequest(windowID uint32, onTop bool) string {
+	return fmt.Sprintf(`{"cmd":"set_always_on_top","windowId":%d,"onTop":%t}`, windowID, onTop)
+}
+
+func Minimize(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("minimize", windowID))
+}
+func Maximize(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("maximize", windowID))
+}
+func Unmaximize(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("unmaximize", windowID))
+}
+func Restore(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("restore_window", windowID))
+}
+func Close(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("destroy_window", windowID))
+}
+func Show(windowID uint32) string { return suji.Invoke("__core__", setVisibleRequest(windowID, true)) }
+func Hide(windowID uint32) string { return suji.Invoke("__core__", setVisibleRequest(windowID, false)) }
+func SetFullScreen(windowID uint32, flag bool) string {
+	return suji.Invoke("__core__", setFullscreenRequest(windowID, flag))
+}
+func IsMinimized(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("is_minimized", windowID))
+}
+func IsMaximized(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("is_maximized", windowID))
+}
+func IsFullScreen(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("is_fullscreen", windowID))
+}
+func IsNormal(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("is_normal", windowID))
+}
+func Focus(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("focus", windowID))
+}
+func Blur(windowID uint32) string { return suji.Invoke("__core__", windowOpRequest("blur", windowID)) }
+func IsFocused(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("is_focused", windowID))
+}
+func IsVisible(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("is_visible", windowID))
+}
+func GetBounds(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("get_bounds", windowID))
+}
+func SetAlwaysOnTop(windowID uint32, onTop bool) string {
+	return suji.Invoke("__core__", setAlwaysOnTopRequest(windowID, onTop))
+}
+func IsAlwaysOnTop(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("is_always_on_top", windowID))
+}
+func GetAllWindows() string    { return suji.Invoke("__core__", `{"cmd":"get_all_windows"}`) }
+func GetFocusedWindow() string { return suji.Invoke("__core__", `{"cmd":"get_focused_window"}`) }
+
 // BrowserWindow — windows.*(raw windowID)의 객체지향 facade (Electron
 // `BrowserWindow` 패리티, @suji/api 와 동형). 각 메서드는 <Fn>(w.ID, ...)
 // 위임 — 로직 무중복, windows 변경에 자동 동기화.
@@ -414,3 +483,24 @@ func (w *BrowserWindow) SetViewVisible(viewID uint32, visible bool) string {
 	return SetViewVisible(viewID, visible)
 }
 func (w *BrowserWindow) GetChildViews() string { return GetChildViews(w.ID) }
+
+// Electron BrowserWindow 생명주기/상태 (JS @suji/api 패리티).
+func (w *BrowserWindow) Minimize() string                 { return Minimize(w.ID) }
+func (w *BrowserWindow) Maximize() string                 { return Maximize(w.ID) }
+func (w *BrowserWindow) Unmaximize() string               { return Unmaximize(w.ID) }
+func (w *BrowserWindow) Restore() string                  { return Restore(w.ID) }
+func (w *BrowserWindow) Close() string                    { return Close(w.ID) }
+func (w *BrowserWindow) Show() string                     { return Show(w.ID) }
+func (w *BrowserWindow) Hide() string                     { return Hide(w.ID) }
+func (w *BrowserWindow) SetFullScreen(flag bool) string   { return SetFullScreen(w.ID, flag) }
+func (w *BrowserWindow) IsMinimized() string              { return IsMinimized(w.ID) }
+func (w *BrowserWindow) IsMaximized() string              { return IsMaximized(w.ID) }
+func (w *BrowserWindow) IsFullScreen() string             { return IsFullScreen(w.ID) }
+func (w *BrowserWindow) IsNormal() string                 { return IsNormal(w.ID) }
+func (w *BrowserWindow) Focus() string                    { return Focus(w.ID) }
+func (w *BrowserWindow) Blur() string                     { return Blur(w.ID) }
+func (w *BrowserWindow) IsFocused() string                { return IsFocused(w.ID) }
+func (w *BrowserWindow) IsVisible() string                { return IsVisible(w.ID) }
+func (w *BrowserWindow) GetBounds() string                { return GetBounds(w.ID) }
+func (w *BrowserWindow) SetAlwaysOnTop(onTop bool) string { return SetAlwaysOnTop(w.ID, onTop) }
+func (w *BrowserWindow) IsAlwaysOnTop() string            { return IsAlwaysOnTop(w.ID) }

--- a/sdks/suji-go/windows/windows_test.go
+++ b/sdks/suji-go/windows/windows_test.go
@@ -107,3 +107,28 @@ func TestViewOperationRequests(t *testing.T) {
 		})
 	}
 }
+
+func TestWindowStateRequests(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"minimize", windowOpRequest("minimize", 3), `{"cmd":"minimize","windowId":3}`},
+		{"is_visible", windowOpRequest("is_visible", 7), `{"cmd":"is_visible","windowId":7}`},
+		{"get_bounds", windowOpRequest("get_bounds", 1), `{"cmd":"get_bounds","windowId":1}`},
+		{"restore", windowOpRequest("restore_window", 2), `{"cmd":"restore_window","windowId":2}`},
+		{"close", windowOpRequest("destroy_window", 2), `{"cmd":"destroy_window","windowId":2}`},
+		{"show", setVisibleRequest(2, true), `{"cmd":"set_visible","windowId":2,"visible":true}`},
+		{"hide", setVisibleRequest(2, false), `{"cmd":"set_visible","windowId":2,"visible":false}`},
+		{"set_fullscreen", setFullscreenRequest(4, true), `{"cmd":"set_fullscreen","windowId":4,"flag":true}`},
+		{"set_always_on_top", setAlwaysOnTopRequest(5, true), `{"cmd":"set_always_on_top","windowId":5,"onTop":true}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf("%s request = %q, want %q", c.name, c.got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Go SDK `windows` 패키지가 JS(`@suji/api`)/Node 대비 누락했던 창 생명주기/상태 **21종** 추가. Rust SDK #85 동형 — 백엔드 완성(e2e 검증), raw-JSON passthrough 래퍼만.

- **생명주기**: Minimize/Maximize/Unmaximize/Restore/Close/Show/Hide/SetFullScreen
- **상태 게터**: IsMinimized/IsMaximized/IsFullScreen/IsNormal/IsVisible/IsFocused/IsAlwaysOnTop/GetBounds
- **액션/세터**: Focus/Blur/SetAlwaysOnTop
- **no-windowId**: GetAllWindows/GetFocusedWindow
- `{"cmd":"X","windowId":N}` 동형 15종은 `windowOpRequest` 헬퍼로 DRY, bool 필드는 전용 빌더(`%t`). BrowserWindow 구조체에 동일 인스턴스 메서드.
- getSize/getPosition 제외(raw passthrough, GetBounds 4필드 포함).

검증: `go test ./windows` 통과(TestWindowStateRequests 빌더 JSON 계약 신규) + `gofmt` + `go vet` 클린.

이로써 #4(Rust #85 + Go) 완료 — 4 SDK(JS/Node/Rust/Go) 창 메서드 패리티.

🤖 Generated with [Claude Code](https://claude.com/claude-code)