### PR TITLE
test(rust-sdk): window 리네임 트랩 cmd 가드 (restore_window/destroy_window)

### DIFF
--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -1226,6 +1226,9 @@ pub mod windows {
             assert_eq!(window_op_request("minimize", 3), r#"{"cmd":"minimize","windowId":3}"#);
             assert_eq!(window_op_request("is_visible", 7), r#"{"cmd":"is_visible","windowId":7}"#);
             assert_eq!(window_op_request("get_bounds", 1), r#"{"cmd":"get_bounds","windowId":1}"#);
+            // 리네임 트랩 cmd 문서/가드 — restore→restore_window, close→destroy_window (Go 테스트 대칭).
+            assert_eq!(window_op_request("restore_window", 2), r#"{"cmd":"restore_window","windowId":2}"#);
+            assert_eq!(window_op_request("destroy_window", 2), r#"{"cmd":"destroy_window","windowId":2}"#);
             assert_eq!(set_visible_request(2, true), r#"{"cmd":"set_visible","windowId":2,"visible":true}"#);
             assert_eq!(set_visible_request(2, false), r#"{"cmd":"set_visible","windowId":2,"visible":false}"#);
             assert_eq!(set_fullscreen_request(4, true), r#"{"cmd":"set_fullscreen","windowId":4,"flag":true}"#);


### PR DESCRIPTION
`/code-review max`(#85/#86) 후속. Go `TestWindowStateRequests` 는 `restore_window`/`destroy_window`(리네임 트랩) cmd 문자열을 assert 하는데 Rust `window_state_request_shapes` 는 누락 → 대칭으로 추가. **리뷰 결과 실 버그 0**, 이건 테스트 커버리지 정합성만 보강.

검증: `cargo test` 42 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)