### PR TITLE
feat(screen): screen.getDisplayMatching(rect) — 듀얼/멀티모니터 (Electron 패리티)

### DIFF
--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -890,6 +890,17 @@ export interface Display {
     visibleHeight: number;
     scaleFactor: number;
 }
+/**
+ * rect 와 겹침 면적이 최대인 Display 선택 (Electron `screen.getDisplayMatching` 로직).
+ * 겹치는 display 가 없으면 rect 중심에 가장 가까운 display. 빈 배열이면 null.
+ * 순수 함수 — getAllDisplays 결과 + rect 만으로 계산(테스트용 export).
+ */
+export declare function pickDisplayMatching(displays: Display[], rect: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}): Display | null;
 export declare const screen: {
     /** 연결된 모든 모니터의 bounds/scale 정보. macOS NSScreen 기반. */
     getAllDisplays(): Promise<Display[]>;
@@ -905,6 +916,17 @@ export declare const screen: {
     }): Promise<number>;
     /** Primary display 객체 반환 (없으면 null) — getAllDisplays.find(isPrimary) wrapper. */
     getPrimaryDisplay(): Promise<Display | null>;
+    /**
+     * rect(보통 창 bounds)와 가장 많이 겹치는 Display (Electron `screen.getDisplayMatching`).
+     * 듀얼/멀티모니터에서 "이 창이 있는 모니터" 판정 — 겹침 없으면 중심 최근접.
+     * getAllDisplays 에서 파생(getPrimaryDisplay 동형, 순수 로직은 pickDisplayMatching).
+     */
+    getDisplayMatching(rect: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+    }): Promise<Display | null>;
 };
 /** Electron `desktopCapturer.getSources` 소스. ⚠️ thumbnail/appIcon 미포함. */
 export interface DesktopCapturerSource {

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -1153,6 +1153,36 @@ export const webRequest = {
         return this.onBeforeRequest(null, null);
     },
 };
+/**
+ * rect 와 겹침 면적이 최대인 Display 선택 (Electron `screen.getDisplayMatching` 로직).
+ * 겹치는 display 가 없으면 rect 중심에 가장 가까운 display. 빈 배열이면 null.
+ * 순수 함수 — getAllDisplays 결과 + rect 만으로 계산(테스트용 export).
+ */
+export function pickDisplayMatching(displays, rect) {
+    if (displays.length === 0)
+        return null;
+    const overlapArea = (d) => {
+        const iw = Math.min(d.x + d.width, rect.x + rect.width) - Math.max(d.x, rect.x);
+        const ih = Math.min(d.y + d.height, rect.y + rect.height) - Math.max(d.y, rect.y);
+        return iw > 0 && ih > 0 ? iw * ih : 0;
+    };
+    let best = displays[0];
+    let bestArea = overlapArea(displays[0]);
+    for (const d of displays) {
+        const a = overlapArea(d);
+        if (a > bestArea) {
+            best = d;
+            bestArea = a;
+        }
+    }
+    if (bestArea > 0)
+        return best;
+    // 어느 display 와도 겹치지 않음 → rect 중심에 가장 가까운 display.
+    const cx = rect.x + rect.width / 2;
+    const cy = rect.y + rect.height / 2;
+    const dist2 = (d) => (d.x + d.width / 2 - cx) ** 2 + (d.y + d.height / 2 - cy) ** 2;
+    return displays.reduce((b, d) => (dist2(d) < dist2(b) ? d : b), displays[0]);
+}
 export const screen = {
     /** 연결된 모든 모니터의 bounds/scale 정보. macOS NSScreen 기반. */
     async getAllDisplays() {
@@ -1173,6 +1203,14 @@ export const screen = {
     async getPrimaryDisplay() {
         const all = await this.getAllDisplays();
         return all.find((d) => d.isPrimary) ?? all[0] ?? null;
+    },
+    /**
+     * rect(보통 창 bounds)와 가장 많이 겹치는 Display (Electron `screen.getDisplayMatching`).
+     * 듀얼/멀티모니터에서 "이 창이 있는 모니터" 판정 — 겹침 없으면 중심 최근접.
+     * getAllDisplays 에서 파생(getPrimaryDisplay 동형, 순수 로직은 pickDisplayMatching).
+     */
+    async getDisplayMatching(rect) {
+        return pickDisplayMatching(await this.getAllDisplays(), rect);
     },
 };
 export const desktopCapturer = {

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -1840,6 +1840,38 @@ export interface Display {
   scaleFactor: number;
 }
 
+/**
+ * rect 와 겹침 면적이 최대인 Display 선택 (Electron `screen.getDisplayMatching` 로직).
+ * 겹치는 display 가 없으면 rect 중심에 가장 가까운 display. 빈 배열이면 null.
+ * 순수 함수 — getAllDisplays 결과 + rect 만으로 계산(테스트용 export).
+ */
+export function pickDisplayMatching(
+  displays: Display[],
+  rect: { x: number; y: number; width: number; height: number },
+): Display | null {
+  if (displays.length === 0) return null;
+  const overlapArea = (d: Display): number => {
+    const iw = Math.min(d.x + d.width, rect.x + rect.width) - Math.max(d.x, rect.x);
+    const ih = Math.min(d.y + d.height, rect.y + rect.height) - Math.max(d.y, rect.y);
+    return iw > 0 && ih > 0 ? iw * ih : 0;
+  };
+  let best = displays[0];
+  let bestArea = overlapArea(displays[0]);
+  for (const d of displays) {
+    const a = overlapArea(d);
+    if (a > bestArea) {
+      best = d;
+      bestArea = a;
+    }
+  }
+  if (bestArea > 0) return best;
+  // 어느 display 와도 겹치지 않음 → rect 중심에 가장 가까운 display.
+  const cx = rect.x + rect.width / 2;
+  const cy = rect.y + rect.height / 2;
+  const dist2 = (d: Display): number => (d.x + d.width / 2 - cx) ** 2 + (d.y + d.height / 2 - cy) ** 2;
+  return displays.reduce((b, d) => (dist2(d) < dist2(b) ? d : b), displays[0]);
+}
+
 export const screen = {
   /** 연결된 모든 모니터의 bounds/scale 정보. macOS NSScreen 기반. */
   async getAllDisplays(): Promise<Display[]> {
@@ -1863,6 +1895,20 @@ export const screen = {
   async getPrimaryDisplay(): Promise<Display | null> {
     const all = await this.getAllDisplays();
     return all.find((d) => d.isPrimary) ?? all[0] ?? null;
+  },
+
+  /**
+   * rect(보통 창 bounds)와 가장 많이 겹치는 Display (Electron `screen.getDisplayMatching`).
+   * 듀얼/멀티모니터에서 "이 창이 있는 모니터" 판정 — 겹침 없으면 중심 최근접.
+   * getAllDisplays 에서 파생(getPrimaryDisplay 동형, 순수 로직은 pickDisplayMatching).
+   */
+  async getDisplayMatching(rect: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }): Promise<Display | null> {
+    return pickDisplayMatching(await this.getAllDisplays(), rect);
   },
 };
 

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -1605,6 +1605,37 @@ export interface Display {
   scaleFactor: number;
 }
 
+/**
+ * rect 와 겹침 면적이 최대인 Display 선택 (Electron `screen.getDisplayMatching` 로직).
+ * 겹치는 display 가 없으면 rect 중심에 가장 가까운 display. 빈 배열이면 null.
+ * 순수 함수 — getAllDisplays 결과 + rect 만으로 계산(테스트용 export, suji-js 동형).
+ */
+export function pickDisplayMatching(
+  displays: Display[],
+  rect: { x: number; y: number; width: number; height: number },
+): Display | null {
+  if (displays.length === 0) return null;
+  const overlapArea = (d: Display): number => {
+    const iw = Math.min(d.x + d.width, rect.x + rect.width) - Math.max(d.x, rect.x);
+    const ih = Math.min(d.y + d.height, rect.y + rect.height) - Math.max(d.y, rect.y);
+    return iw > 0 && ih > 0 ? iw * ih : 0;
+  };
+  let best = displays[0];
+  let bestArea = overlapArea(displays[0]);
+  for (const d of displays) {
+    const a = overlapArea(d);
+    if (a > bestArea) {
+      best = d;
+      bestArea = a;
+    }
+  }
+  if (bestArea > 0) return best;
+  const cx = rect.x + rect.width / 2;
+  const cy = rect.y + rect.height / 2;
+  const dist2 = (d: Display): number => (d.x + d.width / 2 - cx) ** 2 + (d.y + d.height / 2 - cy) ** 2;
+  return displays.reduce((b, d) => (dist2(d) < dist2(b) ? d : b), displays[0]);
+}
+
 export const screen = {
   /** 연결된 모든 모니터의 bounds/scale 정보. macOS NSScreen 기반. */
   async getAllDisplays(): Promise<Display[]> {
@@ -1628,6 +1659,20 @@ export const screen = {
   async getPrimaryDisplay(): Promise<Display | null> {
     const all = await this.getAllDisplays();
     return all.find((d) => d.isPrimary) ?? all[0] ?? null;
+  },
+
+  /**
+   * rect(보통 창 bounds)와 가장 많이 겹치는 Display (Electron `screen.getDisplayMatching`).
+   * 듀얼/멀티모니터에서 "이 창이 있는 모니터" 판정 — 겹침 없으면 중심 최근접.
+   * getAllDisplays 에서 파생(순수 로직은 pickDisplayMatching).
+   */
+  async getDisplayMatching(rect: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }): Promise<Display | null> {
+    return pickDisplayMatching(await this.getAllDisplays(), rect);
   },
 };
 

--- a/tests/e2e/system-integration.test.ts
+++ b/tests/e2e/system-integration.test.ts
@@ -14,6 +14,7 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import puppeteer, { type Browser, type Page } from "puppeteer-core";
 import { getMainPage } from "./_page";
+import { pickDisplayMatching, type Display } from "../../packages/suji-js/dist/index.js";
 
 let browser: Browser;
 let page: Page;
@@ -1402,12 +1403,55 @@ const sdk = <T = unknown>(path: string, ...args: unknown[]): Promise<T> =>
     { path, args },
   ) as Promise<T>;
 
+// screen.getDisplayMatching 순수 선택 로직(pickDisplayMatching) — 듀얼모니터를
+// 모킹해 page 없이 검증(핵심 로직 가드). 실 디스플레이 라운드트립은 아래 SDK describe.
+describe("screen.getDisplayMatching — pickDisplayMatching (듀얼모니터 순수 로직)", () => {
+  const d = (index: number, isPrimary: boolean, x: number, scaleFactor: number): Display => ({
+    index, isPrimary, x, y: 0, width: 1920, height: 1080,
+    visibleX: x, visibleY: 0, visibleWidth: 1920, visibleHeight: 1040, scaleFactor,
+  });
+  const left = d(0, true, 0, 1); // 0..1920
+  const right = d(1, false, 1920, 2); // 1920..3840
+  const displays = [left, right];
+
+  test("우측 모니터 안의 창 → right", () => {
+    expect(pickDisplayMatching(displays, { x: 2000, y: 100, width: 400, height: 300 })?.index).toBe(1);
+  });
+  test("좌측 모니터 안의 창 → left", () => {
+    expect(pickDisplayMatching(displays, { x: 100, y: 100, width: 400, height: 300 })?.index).toBe(0);
+  });
+  test("경계 걸침(1800~2200) → 겹침 면적 큰 right", () => {
+    // left 겹침 120px, right 겹침 280px → right.
+    expect(pickDisplayMatching(displays, { x: 1800, y: 100, width: 400, height: 300 })?.index).toBe(1);
+  });
+  test("모든 모니터 밖 → 중심 최근접 fallback(right)", () => {
+    expect(pickDisplayMatching(displays, { x: 5000, y: 100, width: 100, height: 100 })?.index).toBe(1);
+  });
+  test("빈 배열 → null", () => {
+    expect(pickDisplayMatching([], { x: 0, y: 0, width: 1, height: 1 })).toBeNull();
+  });
+});
+
 describe("@suji/api SDK — round-trip", () => {
   test("screen.getAllDisplays returns array", async () => {
     const r = await sdk<any[]>("screen.getAllDisplays");
     expect(Array.isArray(r)).toBe(true);
     expect(r.length).toBeGreaterThan(0);
     expect(r[0]).toHaveProperty("scaleFactor");
+  });
+
+  test("screen.getDisplayMatching returns the display containing a rect", async () => {
+    const all = await sdk<any[]>("screen.getAllDisplays");
+    const d0 = all[0];
+    const m = await sdk<any>("screen.getDisplayMatching", {
+      x: d0.x + 10,
+      y: d0.y + 10,
+      width: 100,
+      height: 100,
+    });
+    expect(m).not.toBeNull();
+    expect(m).toHaveProperty("scaleFactor");
+    expect(m.index).toBe(d0.index);
   });
 
   test("desktopCapturer.getSources returns screen sources", async () => {


### PR DESCRIPTION
## 무엇
`rect`(보통 창 bounds)와 **가장 많이 겹치는 `Display`** 반환 — 멀티모니터에서 "이 창이 있는 모니터" 판정. Electron `screen.getDisplayMatching`.

```js
const b = await windows.getBounds(winId);        // #82
const display = await screen.getDisplayMatching(b);
// display.workArea 기준으로 새 창/팝업을 같은 모니터에 배치
```

## 어떻게
- **`getAllDisplays` 에서 파생** (`getPrimaryDisplay` 동형 — native 추가 0). 순수 선택 로직은 `pickDisplayMatching(displays, rect)` 로 분리·export: 겹침 면적 최대 → 무겹침 시 rect 중심 최근접 → 빈 배열 null.
- `@suji/api` + `@suji/node` 에 `screen.getDisplayMatching` + 순수 헬퍼. **full `Display` 반환**(`getDisplayNearestPoint` 의 bare index 보다 유용, Electron 동형).

## 검증
- 양 SDK `tsc` OK
- `bash tests/e2e/run-system-integration.sh` → **115 pass / 0 fail**
  - `pickDisplayMatching` 듀얼모니터 **순수 로직 5케이스**(좌/우/경계 면적/오프스크린 최근접/빈배열) — page 없이 모킹
  - `screen.getDisplayMatching` **실 디스플레이 SDK 라운드트립**(rect→매칭 Display)

## 정직 경계
- Rust/Go SDK 미제공(raw-passthrough 정책, getSize/getPosition 동일) — `getAllDisplays` 원시 데이터로 호출자가 계산.
- CEF native `cef_display_get_matching_bounds` 가 있으나, `getAllDisplays` 파생이 더 단순·이식적(per-platform 코드 0)이라 채택.

🤖 Generated with [Claude Code](https://claude.com/claude-code)