### PR TITLE
refactor(screen): getDisplayMatching 을 코어 cmd 로 — 6개 언어 전부 지원

### DIFF
--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2184,6 +2184,18 @@ pub mod screen {
             "y": y,
         }).to_string())
     }
+
+    /// rect 와 겹침 면적이 최대인 display index raw JSON. `{"index":N}` (없으면 -1).
+    /// 겹침 없으면 rect 중심 최근접 (Electron `screen.getDisplayMatching`, 듀얼모니터).
+    pub fn get_display_matching(x: f64, y: f64, width: f64, height: f64) -> Option<String> {
+        invoke("__core__", &crate::serde_json::json!({
+            "cmd": "screen_get_display_matching",
+            "x": x,
+            "y": y,
+            "width": width,
+            "height": height,
+        }).to_string())
+    }
 }
 
 /// Electron `desktopCapturer`. 화면/창 소스 열거(썸네일 미포함 — 정직 경계).

--- a/examples/lua-backend/backends/lua/main.lua
+++ b/examples/lua-backend/backends/lua/main.lua
@@ -27,3 +27,16 @@ end)
 suji.on("from-frontend", function(data)
   suji.send("lua-echo", data)
 end)
+
+-- 네이티브 코어 cmd 호출: suji.invoke("__core__", ...) 로 Lua 백엔드도 모든 코어 API
+-- (screen/window/clipboard 등)에 도달함을 실증. 여기선 screen.getDisplayMatching.
+suji.handle("core-display-matching", function(request_json)
+  local req = cjson.decode(request_json)
+  return suji.invoke("__core__", cjson.encode({
+    cmd = "screen_get_display_matching",
+    x = req.x or 0,
+    y = req.y or 0,
+    width = req.width or 0,
+    height = req.height or 0,
+  }))
+end)

--- a/examples/python-backend/backends/python/main.py
+++ b/examples/python-backend/backends/python/main.py
@@ -34,3 +34,19 @@ suji.handle("emit-test", emit_test)
 
 # 이벤트 수신(suji.on): 프론트가 emit 한 "from-frontend" 를 받아 "python-echo" 로 되돌린다.
 suji.on("from-frontend", lambda data: suji.send("python-echo", data))
+
+
+# 네이티브 코어 cmd 호출: suji.invoke("__core__", ...) 로 Python 백엔드도 모든 코어
+# API(screen/window/clipboard 등)에 도달함을 실증. 여기선 screen.getDisplayMatching.
+def core_display_matching(request_json):
+    req = json.loads(request_json)
+    return suji.invoke("__core__", json.dumps({
+        "cmd": "screen_get_display_matching",
+        "x": req.get("x", 0),
+        "y": req.get("y", 0),
+        "width": req.get("width", 0),
+        "height": req.get("height", 0),
+    }))
+
+
+suji.handle("core-display-matching", core_display_matching)

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -890,17 +890,11 @@ export interface Display {
     visibleHeight: number;
     scaleFactor: number;
 }
-/**
- * rect 와 겹침 면적이 최대인 Display 선택 (Electron `screen.getDisplayMatching` 로직).
- * 겹치는 display 가 없으면 rect 중심에 가장 가까운 display. 빈 배열이면 null.
- * 순수 함수 — getAllDisplays 결과 + rect 만으로 계산(테스트용 export).
- */
-export declare function pickDisplayMatching(displays: Display[], rect: {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-}): Display | null;
+export interface DisplayMatchingResponse {
+    cmd: "screen_get_display_matching";
+    /** getAllDisplays 배열 index. 디스플레이 없으면 -1. */
+    index: number;
+}
 export declare const screen: {
     /** 연결된 모든 모니터의 bounds/scale 정보. macOS NSScreen 기반. */
     getAllDisplays(): Promise<Display[]>;
@@ -919,7 +913,8 @@ export declare const screen: {
     /**
      * rect(보통 창 bounds)와 가장 많이 겹치는 Display (Electron `screen.getDisplayMatching`).
      * 듀얼/멀티모니터에서 "이 창이 있는 모니터" 판정 — 겹침 없으면 중심 최근접.
-     * getAllDisplays 에서 파생(getPrimaryDisplay 동형, 순수 로직은 pickDisplayMatching).
+     * 매칭 계산은 코어 cmd `screen_get_display_matching`(전 언어 SDK 공유)이 수행하고,
+     * 여기선 그 index 로 getAllDisplays 에서 Display 를 해석해 반환.
      */
     getDisplayMatching(rect: {
         x: number;

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -1153,36 +1153,6 @@ export const webRequest = {
         return this.onBeforeRequest(null, null);
     },
 };
-/**
- * rect 와 겹침 면적이 최대인 Display 선택 (Electron `screen.getDisplayMatching` 로직).
- * 겹치는 display 가 없으면 rect 중심에 가장 가까운 display. 빈 배열이면 null.
- * 순수 함수 — getAllDisplays 결과 + rect 만으로 계산(테스트용 export).
- */
-export function pickDisplayMatching(displays, rect) {
-    if (displays.length === 0)
-        return null;
-    const overlapArea = (d) => {
-        const iw = Math.min(d.x + d.width, rect.x + rect.width) - Math.max(d.x, rect.x);
-        const ih = Math.min(d.y + d.height, rect.y + rect.height) - Math.max(d.y, rect.y);
-        return iw > 0 && ih > 0 ? iw * ih : 0;
-    };
-    let best = displays[0];
-    let bestArea = overlapArea(displays[0]);
-    for (const d of displays) {
-        const a = overlapArea(d);
-        if (a > bestArea) {
-            best = d;
-            bestArea = a;
-        }
-    }
-    if (bestArea > 0)
-        return best;
-    // 어느 display 와도 겹치지 않음 → rect 중심에 가장 가까운 display.
-    const cx = rect.x + rect.width / 2;
-    const cy = rect.y + rect.height / 2;
-    const dist2 = (d) => (d.x + d.width / 2 - cx) ** 2 + (d.y + d.height / 2 - cy) ** 2;
-    return displays.reduce((b, d) => (dist2(d) < dist2(b) ? d : b), displays[0]);
-}
 export const screen = {
     /** 연결된 모든 모니터의 bounds/scale 정보. macOS NSScreen 기반. */
     async getAllDisplays() {
@@ -1207,10 +1177,14 @@ export const screen = {
     /**
      * rect(보통 창 bounds)와 가장 많이 겹치는 Display (Electron `screen.getDisplayMatching`).
      * 듀얼/멀티모니터에서 "이 창이 있는 모니터" 판정 — 겹침 없으면 중심 최근접.
-     * getAllDisplays 에서 파생(getPrimaryDisplay 동형, 순수 로직은 pickDisplayMatching).
+     * 매칭 계산은 코어 cmd `screen_get_display_matching`(전 언어 SDK 공유)이 수행하고,
+     * 여기선 그 index 로 getAllDisplays 에서 Display 를 해석해 반환.
      */
     async getDisplayMatching(rect) {
-        return pickDisplayMatching(await this.getAllDisplays(), rect);
+        const r = await coreCall({ cmd: "screen_get_display_matching", ...rect });
+        if (r.index < 0)
+            return null;
+        return (await this.getAllDisplays())[r.index] ?? null;
     },
 };
 export const desktopCapturer = {

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -1840,36 +1840,10 @@ export interface Display {
   scaleFactor: number;
 }
 
-/**
- * rect 와 겹침 면적이 최대인 Display 선택 (Electron `screen.getDisplayMatching` 로직).
- * 겹치는 display 가 없으면 rect 중심에 가장 가까운 display. 빈 배열이면 null.
- * 순수 함수 — getAllDisplays 결과 + rect 만으로 계산(테스트용 export).
- */
-export function pickDisplayMatching(
-  displays: Display[],
-  rect: { x: number; y: number; width: number; height: number },
-): Display | null {
-  if (displays.length === 0) return null;
-  const overlapArea = (d: Display): number => {
-    const iw = Math.min(d.x + d.width, rect.x + rect.width) - Math.max(d.x, rect.x);
-    const ih = Math.min(d.y + d.height, rect.y + rect.height) - Math.max(d.y, rect.y);
-    return iw > 0 && ih > 0 ? iw * ih : 0;
-  };
-  let best = displays[0];
-  let bestArea = overlapArea(displays[0]);
-  for (const d of displays) {
-    const a = overlapArea(d);
-    if (a > bestArea) {
-      best = d;
-      bestArea = a;
-    }
-  }
-  if (bestArea > 0) return best;
-  // 어느 display 와도 겹치지 않음 → rect 중심에 가장 가까운 display.
-  const cx = rect.x + rect.width / 2;
-  const cy = rect.y + rect.height / 2;
-  const dist2 = (d: Display): number => (d.x + d.width / 2 - cx) ** 2 + (d.y + d.height / 2 - cy) ** 2;
-  return displays.reduce((b, d) => (dist2(d) < dist2(b) ? d : b), displays[0]);
+export interface DisplayMatchingResponse {
+  cmd: "screen_get_display_matching";
+  /** getAllDisplays 배열 index. 디스플레이 없으면 -1. */
+  index: number;
 }
 
 export const screen = {
@@ -1900,7 +1874,8 @@ export const screen = {
   /**
    * rect(보통 창 bounds)와 가장 많이 겹치는 Display (Electron `screen.getDisplayMatching`).
    * 듀얼/멀티모니터에서 "이 창이 있는 모니터" 판정 — 겹침 없으면 중심 최근접.
-   * getAllDisplays 에서 파생(getPrimaryDisplay 동형, 순수 로직은 pickDisplayMatching).
+   * 매칭 계산은 코어 cmd `screen_get_display_matching`(전 언어 SDK 공유)이 수행하고,
+   * 여기선 그 index 로 getAllDisplays 에서 Display 를 해석해 반환.
    */
   async getDisplayMatching(rect: {
     x: number;
@@ -1908,7 +1883,9 @@ export const screen = {
     width: number;
     height: number;
   }): Promise<Display | null> {
-    return pickDisplayMatching(await this.getAllDisplays(), rect);
+    const r = await coreCall<DisplayMatchingResponse>({ cmd: "screen_get_display_matching", ...rect });
+    if (r.index < 0) return null;
+    return (await this.getAllDisplays())[r.index] ?? null;
   },
 };
 

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -1605,35 +1605,10 @@ export interface Display {
   scaleFactor: number;
 }
 
-/**
- * rect 와 겹침 면적이 최대인 Display 선택 (Electron `screen.getDisplayMatching` 로직).
- * 겹치는 display 가 없으면 rect 중심에 가장 가까운 display. 빈 배열이면 null.
- * 순수 함수 — getAllDisplays 결과 + rect 만으로 계산(테스트용 export, suji-js 동형).
- */
-export function pickDisplayMatching(
-  displays: Display[],
-  rect: { x: number; y: number; width: number; height: number },
-): Display | null {
-  if (displays.length === 0) return null;
-  const overlapArea = (d: Display): number => {
-    const iw = Math.min(d.x + d.width, rect.x + rect.width) - Math.max(d.x, rect.x);
-    const ih = Math.min(d.y + d.height, rect.y + rect.height) - Math.max(d.y, rect.y);
-    return iw > 0 && ih > 0 ? iw * ih : 0;
-  };
-  let best = displays[0];
-  let bestArea = overlapArea(displays[0]);
-  for (const d of displays) {
-    const a = overlapArea(d);
-    if (a > bestArea) {
-      best = d;
-      bestArea = a;
-    }
-  }
-  if (bestArea > 0) return best;
-  const cx = rect.x + rect.width / 2;
-  const cy = rect.y + rect.height / 2;
-  const dist2 = (d: Display): number => (d.x + d.width / 2 - cx) ** 2 + (d.y + d.height / 2 - cy) ** 2;
-  return displays.reduce((b, d) => (dist2(d) < dist2(b) ? d : b), displays[0]);
+export interface DisplayMatchingResponse {
+  cmd: 'screen_get_display_matching';
+  /** getAllDisplays 배열 index. 디스플레이 없으면 -1. */
+  index: number;
 }
 
 export const screen = {
@@ -1664,7 +1639,7 @@ export const screen = {
   /**
    * rect(보통 창 bounds)와 가장 많이 겹치는 Display (Electron `screen.getDisplayMatching`).
    * 듀얼/멀티모니터에서 "이 창이 있는 모니터" 판정 — 겹침 없으면 중심 최근접.
-   * getAllDisplays 에서 파생(순수 로직은 pickDisplayMatching).
+   * 매칭 계산은 코어 cmd `screen_get_display_matching`(전 언어 SDK 공유)이 수행.
    */
   async getDisplayMatching(rect: {
     x: number;
@@ -1672,7 +1647,9 @@ export const screen = {
     width: number;
     height: number;
   }): Promise<Display | null> {
-    return pickDisplayMatching(await this.getAllDisplays(), rect);
+    const r = await invoke<DisplayMatchingResponse>('__core__', { cmd: 'screen_get_display_matching', ...rect });
+    if (r.index < 0) return null;
+    return (await this.getAllDisplays())[r.index] ?? null;
   },
 };
 

--- a/sdks/suji-go/screen/screen.go
+++ b/sdks/suji-go/screen/screen.go
@@ -24,3 +24,12 @@ func GetCursorScreenPoint() string {
 func GetDisplayNearestPoint(x, y float64) string {
 	return suji.Invoke("__core__", fmt.Sprintf(`{"cmd":"screen_get_display_nearest_point","x":%g,"y":%g}`, x, y))
 }
+
+// GetDisplayMatching returns the display index whose bounds overlap rect most (-1 if none).
+// 겹침 없으면 rect 중심 최근접. raw JSON: `{"index":N}`. (Electron screen.getDisplayMatching, 듀얼모니터)
+func GetDisplayMatching(x, y, width, height float64) string {
+	return suji.Invoke("__core__", fmt.Sprintf(
+		`{"cmd":"screen_get_display_matching","x":%g,"y":%g,"width":%g,"height":%g}`,
+		x, y, width, height,
+	))
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -2095,6 +2095,19 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
             .{idx},
         ) catch null;
     }
+    // Electron screen.getDisplayMatching — rect 와 겹침 최대 display index(없으면 중심 최근접).
+    if (std.mem.eql(u8, cmd, "screen_get_display_matching")) {
+        const x = util.extractJsonFloat(req_clean, "x") orelse 0;
+        const y = util.extractJsonFloat(req_clean, "y") orelse 0;
+        const w = util.extractJsonFloat(req_clean, "width") orelse 0;
+        const h = util.extractJsonFloat(req_clean, "height") orelse 0;
+        const idx = cef.screenGetDisplayMatching(x, y, w, h);
+        return std.fmt.bufPrint(
+            response_buf,
+            "{{\"from\":\"zig-core\",\"cmd\":\"screen_get_display_matching\",\"index\":{d}}}",
+            .{idx},
+        ) catch null;
+    }
 
     // app.getPath — Electron 표준 키 7개. config.app.name이 userData 경로에 들어감.
     if (std.mem.eql(u8, cmd, "app_get_path")) {

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -69,6 +69,7 @@ pub const shellOpenPath = cef_public_api.shellOpenPath;
 pub const shellTrashItem = cef_public_api.shellTrashItem;
 pub const screenGetAllDisplays = cef_public_api.screenGetAllDisplays;
 pub const screenGetDisplayNearestPoint = cef_public_api.screenGetDisplayNearestPoint;
+pub const screenGetDisplayMatching = cef_public_api.screenGetDisplayMatching;
 pub const desktopCapturerGetSources = cef_public_api.desktopCapturerGetSources;
 pub const desktopCapturerCaptureThumbnail = cef_public_api.desktopCapturerCaptureThumbnail;
 pub const nativeThemeIsDark = cef_public_api.nativeThemeIsDark;

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -236,6 +236,7 @@ pub const shellTrashItem = cef_shell.shellTrashItem;
 pub const screenGetAllDisplays = cef_screen.screenGetAllDisplays;
 pub const screenGetCursorPoint = cef_screen.screenGetCursorPoint;
 pub const screenGetDisplayNearestPoint = cef_screen.screenGetDisplayNearestPoint;
+pub const screenGetDisplayMatching = cef_screen.screenGetDisplayMatching;
 
 pub const desktopCapturerGetSources = cef_desktop_capturer.desktopCapturerGetSources;
 pub const desktopCapturerCaptureThumbnail = cef_desktop_capturer.desktopCapturerCaptureThumbnail;

--- a/src/platform/cef_screen.zig
+++ b/src/platform/cef_screen.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const linux_screen = @import("cef_screen_linux.zig");
 const windows_screen = @import("cef_screen_windows.zig");
+const screen_model = @import("screen_model.zig");
 const cef = @import("cef.zig");
 
 const is_macos = builtin.os.tag == .macos;
@@ -125,4 +126,35 @@ pub fn screenGetDisplayNearestPoint(x: f64, y: f64) i32 {
         }
     }
     return -1;
+}
+
+/// rect 와 겹침 면적이 최대인 display index (Electron `screen.getDisplayMatching`).
+/// 겹침 없으면 중심 최근접. 전 플랫폼 공유 screen_model.matchingDisplayIndex 사용 —
+/// 각 플랫폼은 DisplayBounds 열거만(getAllDisplays 와 동일 좌표/순서 → index 일치).
+pub fn screenGetDisplayMatching(x: f64, y: f64, w: f64, h: f64) i32 {
+    if (comptime builtin.os.tag == .windows) return windows_screen.displayMatching(x, y, w, h);
+    if (comptime is_linux) return linux_screen.displayMatching(x, y, w, h);
+    if (!comptime is_macos) return -1;
+    const NSScreen = getClass("NSScreen") orelse return -1;
+    const screens = msgSend(NSScreen, "screens") orelse return -1;
+    const count_fn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) usize = @ptrCast(&objc.objc_msgSend);
+    const count = count_fn(screens, @ptrCast(objc.sel_registerName("count")));
+
+    var displays: [16]screen_model.DisplayBounds = undefined;
+    var len: usize = 0;
+    var i: usize = 0;
+    while (i < count and len < displays.len) : (i += 1) {
+        const obj_fn: *const fn (?*anyopaque, ?*anyopaque, usize) callconv(.c) ?*anyopaque = @ptrCast(&objc.objc_msgSend);
+        const screen = obj_fn(screens, @ptrCast(objc.sel_registerName("objectAtIndex:")), i) orelse continue;
+        const rect_fn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) NSRect = @ptrCast(&objc.objc_msgSend);
+        const frame = rect_fn(screen, @ptrCast(objc.sel_registerName("frame")));
+        displays[len] = .{
+            .x = @intFromFloat(frame.x),
+            .y = @intFromFloat(frame.y),
+            .width = @intFromFloat(frame.width),
+            .height = @intFromFloat(frame.height),
+        };
+        len += 1;
+    }
+    return screen_model.matchingDisplayIndex(displays[0..len], x, y, w, h);
 }

--- a/src/platform/cef_screen_linux.zig
+++ b/src/platform/cef_screen_linux.zig
@@ -106,6 +106,25 @@ const impl = if (builtin.os.tag == .linux) struct {
         }
         return screen_model.containedDisplayIndex(displays[0..len], x, y);
     }
+
+    pub fn displayMatching(x: f64, y: f64, w: f64, h: f64) i32 {
+        const display = XOpenDisplay(null) orelse return -1;
+        defer _ = XCloseDisplay(display);
+
+        const count = XScreenCount(display);
+        if (count <= 0) return -1;
+
+        var displays: [32]screen_model.DisplayBounds = undefined;
+        var len: usize = 0;
+        var idx: c_int = 0;
+        while (idx < count and len < displays.len) : (idx += 1) {
+            if (displayBounds(display, idx)) |b| {
+                displays[len] = b;
+                len += 1;
+            }
+        }
+        return screen_model.matchingDisplayIndex(displays[0..len], x, y, w, h);
+    }
 } else struct {
     pub fn getAllDisplays(out_buf: []u8) []const u8 {
         const empty = "[]";
@@ -121,8 +140,13 @@ const impl = if (builtin.os.tag == .linux) struct {
     pub fn displayNearestPoint(_: f64, _: f64) i32 {
         return -1;
     }
+
+    pub fn displayMatching(_: f64, _: f64, _: f64, _: f64) i32 {
+        return -1;
+    }
 };
 
 pub const getAllDisplays = impl.getAllDisplays;
 pub const cursorPoint = impl.cursorPoint;
 pub const displayNearestPoint = impl.displayNearestPoint;
+pub const displayMatching = impl.displayMatching;

--- a/src/platform/cef_screen_windows.zig
+++ b/src/platform/cef_screen_windows.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const screen_model = @import("screen_model.zig");
 
 const impl = if (builtin.os.tag == .windows) struct {
     const RECT = extern struct { left: i32, top: i32, right: i32, bottom: i32 };
@@ -102,6 +103,34 @@ const impl = if (builtin.os.tag == .windows) struct {
         _ = EnumDisplayMonitors(null, null, &find_cb, @intCast(@intFromPtr(&ctx)));
         return ctx.index;
     }
+
+    const BoundsCtx = struct {
+        list: *[32]screen_model.DisplayBounds,
+        len: usize = 0,
+    };
+    fn boundsEnumProc(hmon: ?*anyopaque, _: ?*anyopaque, _: *RECT, lparam: isize) callconv(.winapi) i32 {
+        const ctx: *BoundsCtx = @ptrFromInt(@as(usize, @intCast(lparam)));
+        if (ctx.len >= ctx.list.len) return 0;
+        var info: MONITORINFO = .{};
+        if (GetMonitorInfoW(hmon, &info) == 0) return 1; // skip, keep enumerating
+        ctx.list[ctx.len] = .{
+            .x = info.rcMonitor.left,
+            .y = info.rcMonitor.top,
+            .width = info.rcMonitor.right - info.rcMonitor.left,
+            .height = info.rcMonitor.bottom - info.rcMonitor.top,
+        };
+        ctx.len += 1;
+        return 1;
+    }
+
+    // getAllDisplays 와 동일한 EnumDisplayMonitors 순서로 DisplayBounds 열거 →
+    // 공유 screen_model.matchingDisplayIndex (index 가 getAllDisplays 와 일치).
+    pub fn displayMatching(x: f64, y: f64, w: f64, h: f64) i32 {
+        var list: [32]screen_model.DisplayBounds = undefined;
+        var ctx: BoundsCtx = .{ .list = &list };
+        _ = EnumDisplayMonitors(null, null, &boundsEnumProc, @intCast(@intFromPtr(&ctx)));
+        return screen_model.matchingDisplayIndex(list[0..ctx.len], x, y, w, h);
+    }
 } else struct {
     pub fn getAllDisplays(out_buf: []u8) []const u8 {
         const empty = "[]";
@@ -117,8 +146,13 @@ const impl = if (builtin.os.tag == .windows) struct {
     pub fn displayNearestPoint(_: f64, _: f64) i32 {
         return -1;
     }
+
+    pub fn displayMatching(_: f64, _: f64, _: f64, _: f64) i32 {
+        return -1;
+    }
 };
 
 pub const getAllDisplays = impl.getAllDisplays;
 pub const cursorPoint = impl.cursorPoint;
 pub const displayNearestPoint = impl.displayNearestPoint;
+pub const displayMatching = impl.displayMatching;

--- a/src/platform/screen_model.zig
+++ b/src/platform/screen_model.zig
@@ -22,6 +22,54 @@ pub fn containedDisplayIndex(displays: []const DisplayBounds, x: f64, y: f64) i3
     return -1;
 }
 
+/// rect 와 display 의 교집합 면적(px²). 겹치지 않으면 0.
+pub fn intersectionArea(d: DisplayBounds, rx: f64, ry: f64, rw: f64, rh: f64) f64 {
+    const dl: f64 = @floatFromInt(d.x);
+    const dt: f64 = @floatFromInt(d.y);
+    const dr = dl + @as(f64, @floatFromInt(d.width));
+    const db = dt + @as(f64, @floatFromInt(d.height));
+    const iw = @min(dr, rx + rw) - @max(dl, rx);
+    const ih = @min(db, ry + rh) - @max(dt, ry);
+    if (iw <= 0 or ih <= 0) return 0;
+    return iw * ih;
+}
+
+fn centerDist2(d: DisplayBounds, cx: f64, cy: f64) f64 {
+    const dcx = @as(f64, @floatFromInt(d.x)) + @as(f64, @floatFromInt(d.width)) / 2;
+    const dcy = @as(f64, @floatFromInt(d.y)) + @as(f64, @floatFromInt(d.height)) / 2;
+    return (dcx - cx) * (dcx - cx) + (dcy - cy) * (dcy - cy);
+}
+
+/// Electron `screen.getDisplayMatching` — rect 와 겹침 면적이 최대인 display index.
+/// 겹치는 display 가 없으면 rect 중심에 가장 가까운 display. 빈 목록이면 -1.
+/// 전 플랫폼(macOS/Windows/Linux) 공유 — 각 플랫폼은 DisplayBounds 열거만 담당.
+pub fn matchingDisplayIndex(displays: []const DisplayBounds, rx: f64, ry: f64, rw: f64, rh: f64) i32 {
+    if (displays.len == 0) return -1;
+    var best: i32 = 0;
+    var best_area: f64 = -1;
+    for (displays, 0..) |d, idx| {
+        const a = intersectionArea(d, rx, ry, rw, rh);
+        if (a > best_area) {
+            best_area = a;
+            best = @intCast(idx);
+        }
+    }
+    if (best_area > 0) return best;
+    // 겹침 없음 → rect 중심 최근접.
+    const cx = rx + rw / 2;
+    const cy = ry + rh / 2;
+    var nearest: i32 = 0;
+    var nearest_d2: f64 = centerDist2(displays[0], cx, cy);
+    for (displays, 0..) |d, idx| {
+        const d2 = centerDist2(d, cx, cy);
+        if (d2 < nearest_d2) {
+            nearest_d2 = d2;
+            nearest = @intCast(idx);
+        }
+    }
+    return nearest;
+}
+
 test "containsPoint uses right/bottom exclusive display bounds" {
     const display: DisplayBounds = .{ .x = 0, .y = 0, .width = 100, .height = 80 };
     try std.testing.expect(containsPoint(display, 0, 0));
@@ -54,4 +102,28 @@ test "containedDisplayIndex returns -1 outside all displays" {
     try std.testing.expectEqual(@as(i32, -1), containedDisplayIndex(&displays, -1, 0));
     try std.testing.expectEqual(@as(i32, -1), containedDisplayIndex(&displays, 0, -1));
     try std.testing.expectEqual(@as(i32, -1), containedDisplayIndex(&displays, 100, 0));
+}
+
+test "matchingDisplayIndex picks max-overlap, falls back to center-nearest" {
+    // 듀얼모니터: 좌 0..1920, 우 1920..3840.
+    const dual = [_]DisplayBounds{
+        .{ .x = 0, .y = 0, .width = 1920, .height = 1080 },
+        .{ .x = 1920, .y = 0, .width = 1920, .height = 1080 },
+    };
+    // 우측 안의 창 → 1.
+    try std.testing.expectEqual(@as(i32, 1), matchingDisplayIndex(&dual, 2000, 100, 400, 300));
+    // 좌측 안의 창 → 0.
+    try std.testing.expectEqual(@as(i32, 0), matchingDisplayIndex(&dual, 100, 100, 400, 300));
+    // 경계 1800..2200: left 겹침 120px, right 280px → 1.
+    try std.testing.expectEqual(@as(i32, 1), matchingDisplayIndex(&dual, 1800, 100, 400, 300));
+    // 모든 모니터 밖(중심 5050) → right(중심 2880)이 left(960)보다 가까움 → 1.
+    try std.testing.expectEqual(@as(i32, 1), matchingDisplayIndex(&dual, 5000, 100, 100, 100));
+    // 빈 목록 → -1.
+    try std.testing.expectEqual(@as(i32, -1), matchingDisplayIndex(&.{}, 0, 0, 1, 1));
+}
+
+test "intersectionArea zero when edges touch (exclusive overlap)" {
+    const d: DisplayBounds = .{ .x = 0, .y = 0, .width = 100, .height = 100 };
+    try std.testing.expectEqual(@as(f64, 0), intersectionArea(d, 100, 0, 50, 50)); // 우측 경계 접촉
+    try std.testing.expectEqual(@as(f64, 2500), intersectionArea(d, 50, 50, 50, 50)); // 우하단 1/4
 }

--- a/tests/e2e/lua-invoke.test.ts
+++ b/tests/e2e/lua-invoke.test.ts
@@ -42,6 +42,14 @@ describe("Lua backend invoke (vendored Lua 5.4 + cjson)", () => {
     expect(r.msg).toBe("pong");
   });
 
+  test("backend → __core__ 도달: suji.invoke('__core__', screen_get_display_matching)", async () => {
+    // Lua 백엔드가 suji.invoke("__core__", ...) 로 네이티브 코어 cmd 를 호출 →
+    // 모든 언어 백엔드가 코어 API 에 도달함을 실증(타입드 래퍼 없이 raw invoke).
+    const r: any = await invoke("core-display-matching", { x: 10, y: 10, width: 100, height: 100 });
+    expect(r.cmd).toBe("screen_get_display_matching");
+    expect(typeof r.index).toBe("number");
+  });
+
   test("echo: cjson decode/encode roundtrip", async () => {
     const r: any = await invoke("echo", { message: "hello from frontend", value: 42 });
     expect(r.runtime).toBe("lua");

--- a/tests/e2e/python-invoke.test.ts
+++ b/tests/e2e/python-invoke.test.ts
@@ -42,6 +42,14 @@ describe("Python backend invoke (embedded CPython 3.13 + GIL)", () => {
     expect(r.msg).toBe("pong");
   });
 
+  test("backend → __core__ 도달: suji.invoke('__core__', screen_get_display_matching)", async () => {
+    // Python 백엔드가 suji.invoke("__core__", ...) 로 네이티브 코어 cmd 를 호출 →
+    // 모든 언어 백엔드가 코어 API 에 도달함을 실증(타입드 래퍼 없이 raw invoke).
+    const r: any = await invoke("core-display-matching", { x: 10, y: 10, width: 100, height: 100 });
+    expect(r.cmd).toBe("screen_get_display_matching");
+    expect(typeof r.index).toBe("number");
+  });
+
   test("echo: json decode/encode roundtrip", async () => {
     const r: any = await invoke("echo", { message: "hello from frontend", value: 42 });
     expect(r.runtime).toBe("python");

--- a/tests/e2e/system-integration.test.ts
+++ b/tests/e2e/system-integration.test.ts
@@ -14,7 +14,6 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import puppeteer, { type Browser, type Page } from "puppeteer-core";
 import { getMainPage } from "./_page";
-import { pickDisplayMatching, type Display } from "../../packages/suji-js/dist/index.js";
 
 let browser: Browser;
 let page: Page;
@@ -1403,34 +1402,8 @@ const sdk = <T = unknown>(path: string, ...args: unknown[]): Promise<T> =>
     { path, args },
   ) as Promise<T>;
 
-// screen.getDisplayMatching 순수 선택 로직(pickDisplayMatching) — 듀얼모니터를
-// 모킹해 page 없이 검증(핵심 로직 가드). 실 디스플레이 라운드트립은 아래 SDK describe.
-describe("screen.getDisplayMatching — pickDisplayMatching (듀얼모니터 순수 로직)", () => {
-  const d = (index: number, isPrimary: boolean, x: number, scaleFactor: number): Display => ({
-    index, isPrimary, x, y: 0, width: 1920, height: 1080,
-    visibleX: x, visibleY: 0, visibleWidth: 1920, visibleHeight: 1040, scaleFactor,
-  });
-  const left = d(0, true, 0, 1); // 0..1920
-  const right = d(1, false, 1920, 2); // 1920..3840
-  const displays = [left, right];
-
-  test("우측 모니터 안의 창 → right", () => {
-    expect(pickDisplayMatching(displays, { x: 2000, y: 100, width: 400, height: 300 })?.index).toBe(1);
-  });
-  test("좌측 모니터 안의 창 → left", () => {
-    expect(pickDisplayMatching(displays, { x: 100, y: 100, width: 400, height: 300 })?.index).toBe(0);
-  });
-  test("경계 걸침(1800~2200) → 겹침 면적 큰 right", () => {
-    // left 겹침 120px, right 겹침 280px → right.
-    expect(pickDisplayMatching(displays, { x: 1800, y: 100, width: 400, height: 300 })?.index).toBe(1);
-  });
-  test("모든 모니터 밖 → 중심 최근접 fallback(right)", () => {
-    expect(pickDisplayMatching(displays, { x: 5000, y: 100, width: 100, height: 100 })?.index).toBe(1);
-  });
-  test("빈 배열 → null", () => {
-    expect(pickDisplayMatching([], { x: 0, y: 0, width: 1, height: 1 })).toBeNull();
-  });
-});
+// 매칭 선택 로직(겹침 면적/중심 최근접)은 코어 screen_model.matchingDisplayIndex
+// 의 zig 단위테스트가 듀얼모니터 케이스를 커버. 여기선 실 디스플레이 SDK 라운드트립만.
 
 describe("@suji/api SDK — round-trip", () => {
   test("screen.getAllDisplays returns array", async () => {


### PR DESCRIPTION
## 무엇 / 왜
#88 은 `getDisplayMatching` 을 JS/Node SDK 파생으로만 구현 → **Rust/Go/Python/Lua 에서 못 썼다**. 코어 cmd `screen_get_display_matching` 으로 전환해 `__core__` 경유로 **모든 언어 백엔드가 호출** 가능하게 함(coreInvoke `special_dispatch` 라우팅 검증). `getDisplayNearestPoint`(백엔드 cmd)와 altitude 일치 + SDK 알고리즘 중복 제거.

## 코어 (전 플랫폼 공유 단일 출처)
- **`screen_model.matchingDisplayIndex(displays, rect)`**: 겹침 면적 최대 → 무겹침 시 중심 최근접 → 빈 목록 `-1`. **순수 함수 + zig 단위테스트**(듀얼모니터 5케이스 + `intersectionArea` 경계). macOS/Windows/Linux 는 `DisplayBounds` 열거만 담당하고 이 공유 로직 호출(`getAllDisplays` 와 동일 좌표/순서 → index 일치).
- `cef_screen.screenGetDisplayMatching`(mac NSScreen) + `cef_screen_windows`(EnumDisplayMonitors) + `cef_screen_linux`(XRR) + `main.zig` 라우팅.

## SDK (4 타입드 + 2 raw)
- **JS/Node**: `screen.getDisplayMatching` → cmd index → `getAllDisplays()[index]` (full `Display` 반환). 기존 `pickDisplayMatching`(SDK 파생) 제거.
- **Rust** `suji::screen::get_display_matching` / **Go** `screen.GetDisplayMatching`: raw JSON(`get_display_nearest_point` 동형).
- **Python/Lua**: `suji.invoke("__core__", ...)` raw(네이티브 래퍼 없는 컨벤션) — 예제 백엔드에 `core-display-matching` 핸들러.

## 검증 (6개 언어)
- `zig build` / `zig build test` exit 0 (`screen_model` 단위)
- **system-integration e2e 110 pass** (JS/Node → cmd 라운드트립)
- **`run-lua-e2e.sh` 7 pass / `run-python-e2e.sh` 7 pass** (Lua/Python → `__core__` → `screen_get_display_matching` `{index}` 도달 실증)
- `cargo build` / `go build`(+`gofmt`) OK

## 참고
- 좌표계: macOS `getAllDisplays`/매칭은 NSScreen frame(bottom-up) 일관. `getBounds`(top-left)↔display 좌표 cross-API 정합은 별도 기존 경계(이 PR 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)