### PR TITLE
fix(screen): getDisplayMatching index 정합 가드 (/code-review max --fix)

### DIFF
--- a/src/platform/cef_screen.zig
+++ b/src/platform/cef_screen.zig
@@ -140,7 +140,9 @@ pub fn screenGetDisplayMatching(x: f64, y: f64, w: f64, h: f64) i32 {
     const count_fn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) usize = @ptrCast(&objc.objc_msgSend);
     const count = count_fn(screens, @ptrCast(objc.sel_registerName("count")));
 
-    var displays: [16]screen_model.DisplayBounds = undefined;
+    // 캡은 Windows/Linux(32) 와 동일 — getAllDisplays(버퍼 ~34개 수용)와 같은 수준이라
+    // 현실적 모니터 수에서 잘림 없이 index 정합 유지.
+    var displays: [32]screen_model.DisplayBounds = undefined;
     var len: usize = 0;
     var i: usize = 0;
     while (i < count and len < displays.len) : (i += 1) {

--- a/src/platform/cef_screen_windows.zig
+++ b/src/platform/cef_screen_windows.zig
@@ -112,7 +112,9 @@ const impl = if (builtin.os.tag == .windows) struct {
         const ctx: *BoundsCtx = @ptrFromInt(@as(usize, @intCast(lparam)));
         if (ctx.len >= ctx.list.len) return 0;
         var info: MONITORINFO = .{};
-        if (GetMonitorInfoW(hmon, &info) == 0) return 1; // skip, keep enumerating
+        // getAllDisplays 의 enumProc 는 writeDisplay 실패(GetMonitorInfoW==0) 시 0(중단)
+        // 반환 → 동일하게 중단해야 두 열거가 같은 부분집합/순서 = index 정합.
+        if (GetMonitorInfoW(hmon, &info) == 0) return 0;
         ctx.list[ctx.len] = .{
             .x = info.rcMonitor.left,
             .y = info.rcMonitor.top,


### PR DESCRIPTION
#89 후속 — `/code-review max` 가 잡은 **index 어긋남 2건** 수정.

1. **Windows `boundsEnumProc`**: `GetMonitorInfoW` 실패 시 `return 1`(skip+continue)이라 `getAllDisplays` enumProc(실패 시 `return 0`=중단)와 다른 부분집합을 열거 → 모니터 정보 실패 시 index 어긋남. `return 0` 으로 정렬.
2. **macOS 매칭 캡 `[16]`→`[32]`**: Windows/Linux(32) + getAllDisplays(버퍼 ~34) 와 동일 수준. 16+ 모니터 잘림→불일치 잠복 결함 제거.

**기각**(리뷰 후보 중): macOS/Linux 스킵-정합(null 스크린 미발생 + getAllDisplays 동일 compaction → array position 정합), `best_area=-1`(정상), SDK `?? null`(캡 수정 후 무발생), Rust/Go screen 테스트 부재(기존 컨벤션), 좌표계(pre-existing).

검증: `zig build`/`zig build test` exit 0, system-integration e2e **110 pass**. Windows 경로 컴파일 검증(macOS e2e 범위 밖).

🤖 Generated with [Claude Code](https://claude.com/claude-code)