### PR TITLE
fix(power-monitor): Linux 빌드 깨짐 수정 — std.posix.openZ → extern c open

### DIFF
--- a/src/platform/cef_power_monitor.zig
+++ b/src/platform/cef_power_monitor.zig
@@ -60,8 +60,16 @@ const win_power = if (is_windows) struct {
 // macOS: IOKit IOPS (power_monitor.m). 1=배터리 전원.
 extern "c" fn suji_power_monitor_is_on_battery() i32;
 
-// Linux: /sys/class/power_supply/<AC>/online == "0" → AC offline → 배터리. io 불요라
-// std.posix 직접 사용. AC 어댑터 미발견 시 null(데스크탑 등).
+// libc 파일 I/O — zig 0.16 std.posix 엔 open/openZ 가 없음(read 만 존재). io 불요한
+// /sys 단발 읽기라 libc open/read/close 직접 사용(XOpenDisplay 등과 동일 extern 패턴).
+const c_fs = struct {
+    extern "c" fn open(path: [*:0]const u8, flags: c_int) c_int;
+    extern "c" fn read(fd: c_int, buf: [*]u8, count: usize) isize;
+    extern "c" fn close(fd: c_int) c_int;
+};
+
+// Linux: /sys/class/power_supply/<AC>/online == "0" → AC offline → 배터리.
+// AC 어댑터 미발견 시 null(데스크탑 등).
 fn linuxAcOnline() ?bool {
     if (!comptime is_linux) return null;
     const candidates = [_][:0]const u8{
@@ -71,10 +79,11 @@ fn linuxAcOnline() ?bool {
         "/sys/class/power_supply/ADP1/online",
     };
     for (candidates) |path| {
-        const fd = std.posix.openZ(path, .{}, 0) catch continue;
-        defer std.posix.close(fd);
+        const fd = c_fs.open(path.ptr, 0); // O_RDONLY = 0
+        if (fd < 0) continue;
+        defer _ = c_fs.close(fd);
         var buf: [4]u8 = undefined;
-        const n = std.posix.read(fd, &buf) catch continue;
+        const n = c_fs.read(fd, &buf, buf.len);
         if (n >= 1) return buf[0] == '0';
     }
     return null;


### PR DESCRIPTION
## 문제 (P0 — main Linux CI 적색)

#91(`powerMonitorIsOnBattery`)이 `linuxAcOnline`에서 zig 0.16에 **존재하지 않는** `std.posix.openZ`를 사용했다. macOS 빌드는 `comptime is_linux == false`라 그 브랜치를 prune해 통과했지만, **Linux CI 빌드는 의미분석에서 컴파일 실패**:

```
src/platform/cef_power_monitor.zig:74:29: error: root source file struct 'posix' has no member named 'openZ'
        const fd = std.posix.openZ(path, .{}, 0) catch continue;
```

zig 0.16 `std.posix`엔 `open`/`openZ`가 없다(파일 open은 `std.Io` 경유, `read`만 잔존).

## 수정

`/sys/class/power_supply/*/online` 단발 읽기라 io가 불필요 → libc `open`/`read`/`close`를 `extern "c"`로 직접 사용(같은 파일의 `XOpenDisplay`/`CGEventSourceSecondsSinceLastEventType` 등과 동일한 extern 패턴). `O_RDONLY = 0`, `fd < 0` 시 다음 후보로 `continue`.

## 검증

- extern-c open/read/close 패턴을 standalone(un-pruned)으로 컴파일+실행 검증.
- macOS `zig build` 무회귀.
- `grep -rnE "std\.posix\.(openZ|open\b)|std\.net"` src/ → 잔존 0 (다른 PR에서 같은 함정 없음 확인).
- Linux CI가 green 복귀하는지 이 PR에서 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)