### PR TITLE
docs(app): single-instance / second-instance API 문서화 (#94~96)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,9 @@ suji::export_handlers!(ping);
 // suji::request_user_attention(true) / suji::cancel_user_attention_request(id)
 // suji::quit()                 — 앱 종료 (Electron app.quit())
 // suji::exit()                 — 앱 강제 종료 (Electron app.exit, code 무시)
+// suji::request_single_instance_lock() / has_single_instance_lock() / release_single_instance_lock()
+//   — 단일 인스턴스 락 (raw Option<String>; {"locked":bool}/{"success":bool}). second-instance
+//     argv 는 suji::on("app:second-instance", ...) 로 수신
 // suji::session::{clear_cookies(), flush_store()}  — CEF cookie_manager fire-and-forget
 // suji::platform()             — "macos" | "linux" | "windows"
 // suji::typescript::SujiHandlers::new()
@@ -348,6 +351,10 @@ var _ = suji.Bind(&App{})
 // attention.RequestUser(true) / attention.CancelUserRequest(id)
 // import "github.com/ohah/suji-go/webrequest"
 // webrequest.SetBlockedUrls([]string{"https://*.ad/*"})
+// import "github.com/ohah/suji-go/app"
+// app.RequestSingleInstanceLock() / HasSingleInstanceLock() / ReleaseSingleInstanceLock()
+//   — 단일 인스턴스 락 (raw {"locked":bool}/{"success":bool}). second-instance argv 는
+//     suji.On("app:second-instance", ...) 로 수신
 // suji.Quit()                   — 앱 종료
 // suji.Platform()               — "macos" | "linux" | "windows"
 // suji.NewTSHandlers().Handler("greet", GreetReq{}, GreetRes{}).Export()
@@ -443,6 +450,13 @@ suji.platform                                                // "macos" | "linux
 // const bm = await app.createSecurityScopedBookmark(path)                 — App Sandbox 영속 파일 접근
 // const acc = await app.startAccessingSecurityScopedResource(bm)          → {id,path,stale}
 // await app.stopAccessingSecurityScopedResource(acc.id)                   (NSURL bookmark; 비-sandbox=일반)
+// const ok = await app.requestSingleInstanceLock()                        — Electron 단일 인스턴스 락
+//   primary 면 true, 다른 인스턴스가 이미 보유 중이면 false(보통 앱 quit). 멱등.
+//   (macOS/Linux <userData> flock, Windows named mutex)
+// await app.hasSingleInstanceLock() / app.releaseSingleInstanceLock()
+//   → 두 번째 인스턴스는 자기 argv 를 primary 로 전달 →
+//     suji.on('app:second-instance', ({argv}) => myWindow.focus())       (Electron second-instance;
+//     argv 전달 IPC: macOS/Linux Unix 소켓, Windows named pipe)
 // await webRequest.setBlockedUrls(["https://*.ad/*"])                     (CEF ResourceRequestHandler)
 //   → suji.on('webRequest:completed', ({url, statusCode, ...}) => ...)
 // await webRequest.onBeforeRequest({urls:["https://*.tracker/*"]}, (details, cb) => cb({cancel:true}))
@@ -532,6 +546,9 @@ suji.send('my-event', JSON.stringify({ msg: 'hello' }))
 // await app.getPath("userData") — Electron app.getPath
 // await app.exit()                                                       — 앱 강제 종료 (code 무시)
 // const reqId = await app.requestUserAttention(true) / cancelUserAttentionRequest(reqId)
+// await app.requestSingleInstanceLock() / hasSingleInstanceLock() / releaseSingleInstanceLock()
+//   — Electron 단일 인스턴스 락 (primary=true, 중복=false). second-instance argv 는
+//     suji.on('app:second-instance', ({argv}) => ...) 로 수신 (전 6개 언어 동일 채널)
 // await webRequest.setBlockedUrls(["https://*.ad/*"])
 // await session.clearCookies() / session.flushStore()                    — CEF cookie_manager
 

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -36,7 +36,7 @@
 
 ### app
 
-- **[high]** `app.releaseSingleInstanceLock()` — Implement three companion methods alongside existing app.* APIs: (1) app.requestSingleInstanceLock() → IPC handler in /src/main.zig + JS/Node SDK wrappers, (2) app.releaseSingleInstanceLock() → same p
+- ~~**[high]** `app.releaseSingleInstanceLock()`~~ ✅ (#94/#95/#96) — Implement three companion methods alongside existing app.* APIs: (1) app.requestSingleInstanceLock() → IPC handler in /src/main.zig + JS/Node SDK wrappers, (2) app.releaseSingleInstanceLock() → same p
 
 ### nativeTheme
 
@@ -93,8 +93,8 @@
 
 - **[medium]** `app.before-quit event` — Add app:before-quit event hook to Suji quit() path. Modify the quit flow in Zig core to emit a 'app:before-quit' event before termination begins, allowing handlers to call an event.preventDefault() eq
 - **[medium]** `app.removeAsDefaultProtocolClient(protocol: string, path?: string, args?: string[]) : boolean` — Add app.setAsDefaultProtocolClient(protocol: string, path?: string, args?: string[]): Promise<boolean> and app.removeAsDefaultProtocolClient(protocol: string, path?: string, args?: string[]): Promise<
-- **[medium]** `app.requestSingleInstanceLock()` — Add app.requestSingleInstanceLock(additionalData?) method across all SDKs. Zig: implement with temp file lock or NSFileManager (macOS). JS/Node: expose as async method returning boolean. Rust/Go: wrap
-- **[medium]** `hasSingleInstanceLock() method` — Implement three methods in the app object across both suji-js and suji-node SDKs: (1) app.requestSingleInstanceLock() → Promise<boolean> indicating lock acquisition success, (2) app.hasSingleInstanceL
+- ~~**[medium]** `app.requestSingleInstanceLock()`~~ ✅ (#94) — Add app.requestSingleInstanceLock(additionalData?) method across all SDKs. Zig: implement with temp file lock or NSFileManager (macOS). JS/Node: expose as async method returning boolean. Rust/Go: wrap
+- ~~**[medium]** `hasSingleInstanceLock() method`~~ ✅ (#94) — Implement three methods in the app object across both suji-js and suji-node SDKs: (1) app.requestSingleInstanceLock() → Promise<boolean> indicating lock acquisition success, (2) app.hasSingleInstanceL
 
 ### clipboard
 
@@ -214,7 +214,7 @@
 - **[low]** `certificate-error event` — Expose app:certificate-error event on TLS cert verification failure. (1) Hook CEF's certificate verification callback in cef.zig (if not already wired). (2) Fire app:certificate-error IPC event with p
 - **[low]** `select-client-certificate event` — To add select-client-certificate parity: (1) Design an app-level event listener API in Suji's core (e.g., core emitting 'app:select-client-certificate' events). (2) Hook CEF's cef_request_handler_t.on
 - **[low]** `app.on('login') — HTTP basic auth event` — Wire cef_auth_callback_t into request handler (src/platform/cef.zig line 4739-4780). Register on_auth callback, emit app:login or webRequest:auth-required event following webRequest:before-request pat
-- **[low]** `second-instance event + requestSingleInstanceLock` — Add requestSingleInstanceLock() to @suji/node app module and @suji/api app module (macOS only, via lock file in app data dir or NSRunningApplication scan). Fire 'app:second-instance' event when second
+- ~~**[low]** `second-instance event + requestSingleInstanceLock`~~ ✅ (#95/#96) — Add requestSingleInstanceLock() to @suji/node app module and @suji/api app module (macOS only, via lock file in app data dir or NSRunningApplication scan). Fire 'app:second-instance' event when second
 - **[low]** `app.relaunch(options?) method` — Add app.relaunch(options?: {args?: string[], execPath?: string}) method to Suji:  1. **Frontend (@suji/api)**: Add method to app object in packages/suji-js/src/index.ts (around line 1751-1870). Signat
 - **[low]** `app.isActive()` — Add app.isActive() method: (1) Zig handler in src/main.zig: new case "app_is_active" → `NSApplication.sharedApplication.isActive` (macOS) / false (other platforms), returns {success:true, active:bool}
 - **[low]** `app.isHidden()` — Add app.isHidden() (macOS only, return false on other platforms) to all SDKs. Implementation: (1) Zig core handler app_is_hidden → NSApplication.isHidden query; (2) expose via __core__ IPC cmd; (3) ad

--- a/documents/events.mdx
+++ b/documents/events.mdx
@@ -46,6 +46,29 @@ fn onAllClosed(_: suji.Event) void {
 
 macOS는 창이 모두 닫혀도 앱은 dock에 유지 (Electron과 동일). 나머지 플랫폼은 종료.
 
+### app 단일 인스턴스 (second-instance)
+
+| 채널 | payload | 발화 시점 |
+|---|---|---|
+| `app:second-instance` | `{argv: string[]}` | 두 번째 인스턴스가 실행돼 argv 를 primary 로 전달했을 때 |
+
+`app.requestSingleInstanceLock()`(Electron 동등)으로 primary 를 정하고, 두 번째
+인스턴스는 자기 argv 를 primary 로 보낸 뒤 종료 → primary 가 `app:second-instance`
+로 수신. 락은 macOS/Linux flock + Windows named mutex, argv 전달 IPC 는
+macOS/Linux Unix 소켓 + Windows named pipe. 전 6개 언어 동일 채널로 수신.
+
+```js
+const gotLock = await app.requestSingleInstanceLock();
+if (!gotLock) {
+  await app.exit();           // 두 번째 인스턴스는 종료(argv 는 이미 primary 로 전달됨)
+} else {
+  suji.on('app:second-instance', ({ argv }) => {
+    myWindow.focus();         // 기존 창을 앞으로
+    // argv 로 열려던 파일/딥링크 처리
+  });
+}
+```
+
 ## Electron API 대응표
 
 | Electron | Suji |
@@ -59,6 +82,8 @@ macOS는 창이 모두 닫혀도 앱은 dock에 유지 (Electron과 동일). 나
 | `win.webContents.send(ch, data)` | `suji.send(ch, data, {to: winId})` / Zig `suji.sendTo(id, ch, data)` |
 | `BrowserWindow.getAllWindows()` | (roadmap) `suji.windows.all()` |
 | `app.quit()` | `suji.quit()` |
+| `app.requestSingleInstanceLock()` | `app.requestSingleInstanceLock()` (mac/Linux flock, Win mutex) |
+| `app.on('second-instance', (e, argv) => {})` | `suji.on('app:second-instance', ({argv}) => {})` |
 | `process.platform` | `suji.platform` — **"macos"** (not "darwin") |
 | `MessageChannelMain` | **미지원 (V1)** |
 | `remote` 모듈 | **미지원** (Electron도 deprecated) |


### PR DESCRIPTION
## 개요

기능 PR(#94 락, #95 Unix 소켓 second-instance, #96 Windows named pipe)에서 누락한 **사용자 문서**를 보강. 코드 변경 없음(문서 전용).

## 변경

- **CLAUDE.md** — frontend `@suji/api`, Node `@suji/node`, Rust, Go app 섹션에 `requestSingleInstanceLock`/`hasSingleInstanceLock`/`releaseSingleInstanceLock` + `app:second-instance` 이벤트 추가.
- **documents/events.mdx** — "app 단일 인스턴스 (second-instance)" 이벤트 섹션(`app:second-instance` `{argv}` payload + 사용 예) + Electron 대응표 행 2개(`requestSingleInstanceLock`, `second-instance`).
- **docs/electron-parity-audit.md** — single-instance 백로그 4항목 done 마킹(`~~..~~ ✅`).

## 검증

문서 전용 — 빌드/런타임 영향 없음. CLAUDE.md API 항목은 실제 머지된 SDK 표면(#94~96)과 일치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)