### PR TITLE
feat(session): setProxy — Electron session.setProxy (Chromium proxy preference)

### DIFF
--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2495,6 +2495,20 @@ pub mod session {
         invoke("__core__", r#"{"cmd":"session_flush_store"}"#)
     }
 
+    /// Electron `session.setProxy(config)` — Chromium "proxy" preference 설정.
+    /// mode "" → "direct"(프록시 해제). proxy_rules: "host:port". raw: `{"success":bool}`.
+    pub fn set_proxy(mode: &str, proxy_rules: &str, proxy_bypass_rules: &str, pac_script: &str) -> Option<String> {
+        let req = json!({
+            "cmd": "session_set_proxy",
+            "mode": mode,
+            "proxyRules": proxy_rules,
+            "proxyBypassRules": proxy_bypass_rules,
+            "pacScript": pac_script,
+        })
+        .to_string();
+        invoke("__core__", &req)
+    }
+
     /// IndexedDB/localStorage/cache 삭제 (Electron `session.clearStorageData`).
     /// origin "" → 전역 HTTP 캐시만(웹 플랫폼상 origin 없이 storage 일괄
     /// 삭제 불가). storage_types None → "all".

--- a/examples/lua-backend/backends/lua/main.lua
+++ b/examples/lua-backend/backends/lua/main.lua
@@ -46,3 +46,9 @@ end)
 suji.handle("core-single-instance", function(_)
   return suji.invoke("__core__", cjson.encode({ cmd = "app_has_single_instance_lock" }))
 end)
+
+-- session.setProxy 도 __core__ 로 도달. 백엔드(lua 워커 스레드)에서 호출하면 UI
+-- 스레드로 post 되는 경로 검증(크래시 없이 success). mode=direct(부작용 없음).
+suji.handle("core-set-proxy", function(_)
+  return suji.invoke("__core__", cjson.encode({ cmd = "session_set_proxy", mode = "direct" }))
+end)

--- a/examples/python-backend/backends/python/main.py
+++ b/examples/python-backend/backends/python/main.py
@@ -59,3 +59,12 @@ def core_single_instance(_request_json):
 
 
 suji.handle("core-single-instance", core_single_instance)
+
+
+# session.setProxy 도 __core__ 로 도달. 백엔드(python 워커 스레드)에서 호출하면 UI
+# 스레드로 post 되는 경로 검증(크래시 없이 success). mode=direct(부작용 없음).
+def core_set_proxy(_request_json):
+    return suji.invoke("__core__", json.dumps({"cmd": "session_set_proxy", "mode": "direct"}))
+
+
+suji.handle("core-set-proxy", core_set_proxy)

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -809,6 +809,17 @@ export declare const session: {
     /** disk store flush (Electron `session.cookies.flushStore`). */
     flushStore(): Promise<boolean>;
     /**
+     * Electron `session.setProxy(config)` — Chromium "proxy" preference 설정.
+     * mode 미지정/`"direct"` → 프록시 해제. `proxyRules`: `"host:port"` 또는
+     * `"http=foo:80;https=bar:80"`. 이후 요청에 적용. fire-and-forget(설정 성공 bool).
+     */
+    setProxy(config: {
+        mode?: "direct" | "auto_detect" | "pac_script" | "fixed_servers" | "system";
+        proxyRules?: string;
+        proxyBypassRules?: string;
+        pacScript?: string;
+    }): Promise<boolean>;
+    /**
      * IndexedDB/localStorage/cache 삭제 (Electron `session.clearStorageData`).
      * origin 미지정 → 전역 HTTP 캐시만(웹 플랫폼상 origin 없이 storage 일괄
      * 삭제 불가 — 호출부가 자기 앱 origin 전달 시 그 origin storage 삭제).

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -960,6 +960,21 @@ export const session = {
         return r.success === true;
     },
     /**
+     * Electron `session.setProxy(config)` — Chromium "proxy" preference 설정.
+     * mode 미지정/`"direct"` → 프록시 해제. `proxyRules`: `"host:port"` 또는
+     * `"http=foo:80;https=bar:80"`. 이후 요청에 적용. fire-and-forget(설정 성공 bool).
+     */
+    async setProxy(config) {
+        const r = await coreCall({
+            cmd: "session_set_proxy",
+            mode: config.mode ?? "",
+            proxyRules: config.proxyRules ?? "",
+            proxyBypassRules: config.proxyBypassRules ?? "",
+            pacScript: config.pacScript ?? "",
+        });
+        return r.success === true;
+    },
+    /**
      * IndexedDB/localStorage/cache 삭제 (Electron `session.clearStorageData`).
      * origin 미지정 → 전역 HTTP 캐시만(웹 플랫폼상 origin 없이 storage 일괄
      * 삭제 불가 — 호출부가 자기 앱 origin 전달 시 그 origin storage 삭제).

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -1569,6 +1569,27 @@ export const session = {
   },
 
   /**
+   * Electron `session.setProxy(config)` — Chromium "proxy" preference 설정.
+   * mode 미지정/`"direct"` → 프록시 해제. `proxyRules`: `"host:port"` 또는
+   * `"http=foo:80;https=bar:80"`. 이후 요청에 적용. fire-and-forget(설정 성공 bool).
+   */
+  async setProxy(config: {
+    mode?: "direct" | "auto_detect" | "pac_script" | "fixed_servers" | "system";
+    proxyRules?: string;
+    proxyBypassRules?: string;
+    pacScript?: string;
+  }): Promise<boolean> {
+    const r = await coreCall<{ success: boolean }>({
+      cmd: "session_set_proxy",
+      mode: config.mode ?? "",
+      proxyRules: config.proxyRules ?? "",
+      proxyBypassRules: config.proxyBypassRules ?? "",
+      pacScript: config.pacScript ?? "",
+    });
+    return r.success === true;
+  },
+
+  /**
    * IndexedDB/localStorage/cache 삭제 (Electron `session.clearStorageData`).
    * origin 미지정 → 전역 HTTP 캐시만(웹 플랫폼상 origin 없이 storage 일괄
    * 삭제 불가 — 호출부가 자기 앱 origin 전달 시 그 origin storage 삭제).

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -2034,6 +2034,26 @@ export const session = {
   },
 
   /**
+   * Electron `session.setProxy(config)` — Chromium "proxy" preference 설정.
+   * mode 미지정/`"direct"` → 프록시 해제. `proxyRules`: `"host:port"`. 이후 요청에 적용.
+   */
+  async setProxy(config: {
+    mode?: 'direct' | 'auto_detect' | 'pac_script' | 'fixed_servers' | 'system';
+    proxyRules?: string;
+    proxyBypassRules?: string;
+    pacScript?: string;
+  }): Promise<boolean> {
+    const r = await invoke<{ success: boolean }>('__core__', {
+      cmd: 'session_set_proxy',
+      mode: config.mode ?? '',
+      proxyRules: config.proxyRules ?? '',
+      proxyBypassRules: config.proxyBypassRules ?? '',
+      pacScript: config.pacScript ?? '',
+    });
+    return r.success === true;
+  },
+
+  /**
    * IndexedDB/localStorage/cache 삭제 (Electron `session.clearStorageData`).
    * origin 미지정 → 전역 HTTP 캐시만(웹 플랫폼상 origin 없이 storage 일괄
    * 삭제 불가). storageTypes 기본 "all" (CDP 콤마구분).

--- a/sdks/suji-go/session/session.go
+++ b/sdks/suji-go/session/session.go
@@ -18,6 +18,16 @@ func FlushStore() string {
 	return suji.Invoke("__core__", `{"cmd":"session_flush_store"}`)
 }
 
+// SetProxy sets the network proxy (Electron `session.setProxy`). mode "" → "direct"
+// (프록시 해제). proxyRules: "host:port". Response: `{"success":bool}`.
+func SetProxy(mode, proxyRules, proxyBypassRules, pacScript string) string {
+	req, _ := json.Marshal(map[string]any{
+		"cmd": "session_set_proxy", "mode": mode, "proxyRules": proxyRules,
+		"proxyBypassRules": proxyBypassRules, "pacScript": pacScript,
+	})
+	return suji.Invoke("__core__", string(req))
+}
+
 // ClearStorageData removes IndexedDB/localStorage/cache (Electron
 // `session.clearStorageData`). origin "" → 전역 HTTP 캐시만(웹 플랫폼상
 // origin 없이 storage 일괄 삭제 불가). storageTypes "" → "all".

--- a/src/main.zig
+++ b/src/main.zig
@@ -2446,6 +2446,20 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         const ok = cef.sessionFlushStore();
         return std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"session_flush_store\",\"success\":{}}}", .{ok}) catch null;
     }
+    // Electron session.setProxy — Chromium "proxy" pref 설정(mode/proxyRules/
+    // proxyBypassRules/pacScript). 빈 mode → "direct"(프록시 해제).
+    if (std.mem.eql(u8, cmd, "session_set_proxy")) {
+        var mode_buf: [64]u8 = undefined;
+        var rules_buf: [2048]u8 = undefined;
+        var bypass_buf: [2048]u8 = undefined;
+        var pac_buf: [2048]u8 = undefined;
+        const mode_n = util.unescapeJsonStr(util.extractJsonString(req_clean, "mode") orelse "", &mode_buf) orelse 0;
+        const rules_n = util.unescapeJsonStr(util.extractJsonString(req_clean, "proxyRules") orelse "", &rules_buf) orelse 0;
+        const bypass_n = util.unescapeJsonStr(util.extractJsonString(req_clean, "proxyBypassRules") orelse "", &bypass_buf) orelse 0;
+        const pac_n = util.unescapeJsonStr(util.extractJsonString(req_clean, "pacScript") orelse "", &pac_buf) orelse 0;
+        const ok = cef.sessionSetProxy(mode_buf[0..mode_n], rules_buf[0..rules_n], bypass_buf[0..bypass_n], pac_buf[0..pac_n]);
+        return std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"session_set_proxy\",\"success\":{}}}", .{ok}) catch null;
+    }
     if (std.mem.eql(u8, cmd, "session_clear_storage_data")) {
         var origin_buf: [2048]u8 = undefined;
         var types_buf: [256]u8 = undefined;

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -107,6 +107,7 @@ pub const sessionClearStorageData = cef_public_api.sessionClearStorageData;
 pub const sessionSetCookie = cef_public_api.sessionSetCookie;
 pub const sessionRemoveCookies = cef_public_api.sessionRemoveCookies;
 pub const sessionGetCookies = cef_public_api.sessionGetCookies;
+pub const sessionSetProxy = cef_public_api.sessionSetProxy;
 pub const ApplicationMenuItem = cef_public_api.ApplicationMenuItem;
 pub const MenuEmitHandler = cef_public_api.MenuEmitHandler;
 pub const setMenuEmitHandler = cef_public_api.setMenuEmitHandler;

--- a/src/platform/cef_c.zig
+++ b/src/platform/cef_c.zig
@@ -39,6 +39,9 @@ pub const c = @cImport({
     @cInclude("include/capi/cef_resource_handler_capi.h");
     @cInclude("include/capi/cef_task_capi.h");
     @cInclude("include/capi/cef_cookie_capi.h");
+    @cInclude("include/capi/cef_preference_capi.h");
+    @cInclude("include/capi/cef_request_context_capi.h");
+    @cInclude("include/capi/cef_values_capi.h");
     @cInclude("include/capi/cef_crash_util_capi.h");
     @cInclude("include/capi/cef_print_handler_capi.h");
     @cInclude("include/capi/views/cef_browser_view_capi.h");

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -38,6 +38,7 @@ const cef_screen = @import("cef_screen.zig");
 const cef_scheme = @import("cef_scheme.zig");
 const cef_security_scoped_bookmark = @import("cef_security_scoped_bookmark.zig");
 const cef_session_cookies = @import("cef_session_cookies.zig");
+const cef_session_proxy = @import("cef_session_proxy.zig");
 const cef_shell = @import("cef_shell.zig");
 const cef_single_instance = @import("cef_single_instance.zig");
 const cef_tray = @import("cef_tray.zig");
@@ -288,6 +289,7 @@ pub const sessionClearStorageData = cef_session_cookies.sessionClearStorageData;
 pub const sessionSetCookie = cef_session_cookies.sessionSetCookie;
 pub const sessionRemoveCookies = cef_session_cookies.sessionRemoveCookies;
 pub const sessionGetCookies = cef_session_cookies.sessionGetCookies;
+pub const sessionSetProxy = cef_session_proxy.sessionSetProxy;
 
 pub const ApplicationMenuItem = cef_menu.ApplicationMenuItem;
 pub const MenuEmitHandler = cef_menu.MenuEmitHandler;

--- a/src/platform/cef_session_proxy.zig
+++ b/src/platform/cef_session_proxy.zig
@@ -1,0 +1,159 @@
+//! session.setProxy — CEF preference manager "proxy" preference 설정.
+//!
+//! Electron `session.setProxy(config)` 대응. Chromium "proxy" pref(ProxyConfig
+//! Dictionary) 포맷으로 매핑: {mode, server(=proxyRules), bypass_list(=
+//! proxyBypassRules), pac_url(=pacScript)}.
+//!
+//! "proxy" 는 **request context** preference(네트워크 관장)이므로 전역 preference
+//! manager 가 아니라 `cef_request_context_get_global_context`(브라우저 기본 컨텍스트)
+//! 에 설정해야 실 요청에 적용된다. request_context 는 preference manager 를 상속
+//! (`.base` = cef_preference_manager_t).
+//!
+//! set_preference 는 **UI 스레드 필수**. 프론트(@suji/api renderer) invoke 는 UI
+//! 스레드라 직접 호출하고, 백엔드(Node/Rust/Go/Python/Lua) SDK 는 워커 스레드라
+//! UI 스레드로 task post(Electron 도 setProxy 는 main 프로세스=백엔드가 자연 호출자
+//! 이므로 백엔드 경로가 핵심). 둘 다 동일 setProxyOnUi 로 수렴.
+
+const std = @import("std");
+const cef = @import("cef.zig");
+
+const c = cef.c;
+const asPtr = cef.asPtr;
+const setCefString = cef.setCefString;
+
+const c_allocator = std.heap.c_allocator;
+
+// setCefString 이 cef_string_utf8_to_utf16 로 할당한 버퍼를 dtor 로 해제(leak 방지).
+fn clearCefStr(s: *c.cef_string_t) void {
+    if (s.dtor) |d| d(s.str);
+    s.* = .{};
+}
+
+fn dictSetStr(dict: *c.cef_dictionary_value_t, key: []const u8, val: []const u8) void {
+    const set_string = dict.set_string orelse return;
+    var k: c.cef_string_t = .{};
+    var v: c.cef_string_t = .{};
+    setCefString(&k, key);
+    setCefString(&v, val);
+    _ = set_string(dict, &k, &v); // dict 가 키/값 복사
+    clearCefStr(&k);
+    clearCefStr(&v);
+}
+
+// 실제 proxy pref 설정 — **UI 스레드에서만** 호출(직접 또는 task execute 경유).
+fn setProxyOnUi(mode: []const u8, proxy_rules: []const u8, bypass: []const u8, pac_url: []const u8) bool {
+    std.debug.assert(c.cef_currently_on(c.TID_UI) == 1);
+
+    // request context = 네트워크/proxy 관장. 전역 컨텍스트의 preference manager(.base)에 설정.
+    const ctx = asPtr(c.cef_request_context_t, c.cef_request_context_get_global_context()) orelse return false;
+    defer if (ctx.base.base.release) |rel| {
+        _ = rel(&ctx.base.base);
+    };
+    const mgr: *c.cef_preference_manager_t = &ctx.base;
+    const set_pref = mgr.set_preference orelse return false;
+
+    // ⚠️ CEF *C API* 컨벤션(C++ doc 과 다름 — 주의): set 메서드(set_dictionary/
+    // set_preference)에 cef_xxx_t* 를 넘기면 CToCpp::Wrap 이 우리 ref 를 consume 한다.
+    // C++ 헤더 doc 은 "keeps a reference / ownership unchanged"(AddRef)라 적혀 있지만,
+    // 그건 C++ 객체 의미론이고 C API 의 Wrap 은 C 측 ref 를 가져간다. 따라서 create
+    // 로 받은 dict/value 를 set 후 release 하면 double-free → **0xefefefef UAF 크래시**.
+    // (실측: release 시 e2e 가 SIGBUS 0xef 로 죽었고, release 제거 후 통과. doc 만 보고
+    //  release 를 "추가"하면 크래시 재발하니 절대 금지.) ctx 만 get_*global* 반환 ref 라 release.
+    const dict = asPtr(c.cef_dictionary_value_t, c.cef_dictionary_value_create()) orelse return false;
+    dictSetStr(dict, "mode", if (mode.len > 0) mode else "direct");
+    if (proxy_rules.len > 0) dictSetStr(dict, "server", proxy_rules);
+    if (bypass.len > 0) dictSetStr(dict, "bypass_list", bypass);
+    if (pac_url.len > 0) dictSetStr(dict, "pac_url", pac_url);
+
+    const value = asPtr(c.cef_value_t, c.cef_value_create()) orelse return false;
+    const set_dict = value.set_dictionary orelse return false;
+    _ = set_dict(value, dict); // dict ref 인수됨 — 이후 dict 접근 금지
+
+    var name: c.cef_string_t = .{};
+    setCefString(&name, "proxy");
+    defer clearCefStr(&name);
+    var err: c.cef_string_t = .{};
+    defer clearCefStr(&err);
+    const ok = set_pref(mgr, &name, value, &err); // value ref 인수됨
+    return ok != 0;
+}
+
+// ---- off-UI-thread(백엔드 워커) → UI 스레드 post 용 task ----
+// cef_initial_load 의 task 패턴 동형(task 가 첫 필드 → base/self == task 주소).
+const SetProxyTask = struct {
+    task: c.cef_task_t = undefined,
+    allocator: std.mem.Allocator,
+    ref_count: std.atomic.Value(u32) = .init(1),
+    mode: [64]u8 = undefined,
+    mode_len: usize = 0,
+    rules: [2048]u8 = undefined,
+    rules_len: usize = 0,
+    bypass: [2048]u8 = undefined,
+    bypass_len: usize = 0,
+    pac: [2048]u8 = undefined,
+    pac_len: usize = 0,
+};
+
+fn taskFromBase(base: ?*c.cef_base_ref_counted_t) ?*SetProxyTask {
+    return @ptrCast(@alignCast(base orelse return null));
+}
+fn taskFromSelf(self: ?*c._cef_task_t) ?*SetProxyTask {
+    return @ptrCast(@alignCast(self orelse return null));
+}
+fn taskAddRef(base: ?*c.cef_base_ref_counted_t) callconv(.c) void {
+    const t = taskFromBase(base) orelse return;
+    _ = t.ref_count.fetchAdd(1, .acq_rel);
+}
+fn taskRelease(base: ?*c.cef_base_ref_counted_t) callconv(.c) i32 {
+    const t = taskFromBase(base) orelse return 0;
+    if (t.ref_count.fetchSub(1, .acq_rel) != 1) return 0;
+    t.allocator.destroy(t);
+    return 1;
+}
+fn taskHasOneRef(base: ?*c.cef_base_ref_counted_t) callconv(.c) i32 {
+    const t = taskFromBase(base) orelse return 0;
+    return if (t.ref_count.load(.acquire) == 1) 1 else 0;
+}
+fn taskHasAtLeastOneRef(base: ?*c.cef_base_ref_counted_t) callconv(.c) i32 {
+    const t = taskFromBase(base) orelse return 0;
+    return if (t.ref_count.load(.acquire) >= 1) 1 else 0;
+}
+fn taskExecute(self: ?*c._cef_task_t) callconv(.c) void {
+    const t = taskFromSelf(self) orelse return;
+    _ = setProxyOnUi(t.mode[0..t.mode_len], t.rules[0..t.rules_len], t.bypass[0..t.bypass_len], t.pac[0..t.pac_len]);
+}
+
+/// Electron `session.setProxy`. mode 빈 문자열 → "direct"(프록시 해제). UI 스레드면
+/// 즉시 적용 후 결과 반환, 백엔드 워커 스레드면 UI 스레드로 post(fire-and-forget,
+/// post 성공 시 true).
+pub fn sessionSetProxy(mode: []const u8, proxy_rules: []const u8, bypass: []const u8, pac_url: []const u8) bool {
+    if (c.cef_currently_on(c.TID_UI) == 1) {
+        return setProxyOnUi(mode, proxy_rules, bypass, pac_url);
+    }
+    // 백엔드 워커 스레드 — 문자열을 task 에 복사해 UI 스레드로 post.
+    if (mode.len > 64 or proxy_rules.len > 2048 or bypass.len > 2048 or pac_url.len > 2048) return false;
+    const t = c_allocator.create(SetProxyTask) catch return false;
+    t.* = .{
+        .allocator = c_allocator,
+        .mode_len = mode.len,
+        .rules_len = proxy_rules.len,
+        .bypass_len = bypass.len,
+        .pac_len = pac_url.len,
+    };
+    @memcpy(t.mode[0..mode.len], mode);
+    @memcpy(t.rules[0..proxy_rules.len], proxy_rules);
+    @memcpy(t.bypass[0..bypass.len], bypass);
+    @memcpy(t.pac[0..pac_url.len], pac_url);
+    @memset(std.mem.asBytes(&t.task), 0);
+    t.task.base.size = @sizeOf(c.cef_task_t);
+    t.task.base.add_ref = &taskAddRef;
+    t.task.base.release = &taskRelease;
+    t.task.base.has_one_ref = &taskHasOneRef;
+    t.task.base.has_at_least_one_ref = &taskHasAtLeastOneRef;
+    t.task.execute = &taskExecute;
+    if (c.cef_post_task(c.TID_UI, &t.task) != 1) {
+        _ = taskRelease(&t.task.base); // post 실패 → 우리 ref 해제(free)
+        return false;
+    }
+    return true; // posted — UI 스레드에서 곧 적용
+}

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -818,6 +818,7 @@ fn readCefSource() ![]u8 {
         "src/platform/cef_power_save_blocker.zig",
         "src/platform/cef_desktop_capturer.zig",
         "src/platform/cef_session_cookies.zig",
+        "src/platform/cef_session_proxy.zig",
         "src/platform/cef_security_scoped_bookmark.zig",
         "src/platform/cef_request_user_attention.zig",
         "src/platform/cef_menu.zig",
@@ -1954,9 +1955,11 @@ test "app.exit + session.clearCookies/flushStore IPC" {
         "\"session_clear_cookies\"",
         "\"session_flush_store\"",
         "\"session_clear_storage_data\"",
+        "\"session_set_proxy\"",
         "cef.sessionClearCookies",
         "cef.sessionFlushStore",
         "cef.sessionClearStorageData",
+        "cef.sessionSetProxy",
     }) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, main_src, needle) != null);
     }
@@ -1967,9 +1970,11 @@ test "app.exit + session.clearCookies/flushStore IPC" {
         "pub fn sessionClearCookies",
         "pub fn sessionFlushStore",
         "pub fn sessionClearStorageData",
+        "pub fn sessionSetProxy",
         "Storage.clearDataForOrigin",
         "Network.clearBrowserCache",
         "cef_cookie_manager_get_global_manager",
+        "cef_request_context_get_global_context",
     }) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, cef_src, needle) != null);
     }

--- a/tests/e2e/lua-invoke.test.ts
+++ b/tests/e2e/lua-invoke.test.ts
@@ -57,6 +57,13 @@ describe("Lua backend invoke (vendored Lua 5.4 + cjson)", () => {
     expect(typeof r.locked).toBe("boolean");
   });
 
+  test("backend → __core__ 도달: session.setProxy (워커 스레드 → UI post)", async () => {
+    // Lua 워커 스레드에서 호출 → UI 스레드로 post 되어 크래시 없이 success.
+    const r: any = await invoke("core-set-proxy", {});
+    expect(r.cmd).toBe("session_set_proxy");
+    expect(r.success).toBe(true);
+  });
+
   test("echo: cjson decode/encode roundtrip", async () => {
     const r: any = await invoke("echo", { message: "hello from frontend", value: 42 });
     expect(r.runtime).toBe("lua");

--- a/tests/e2e/python-invoke.test.ts
+++ b/tests/e2e/python-invoke.test.ts
@@ -57,6 +57,13 @@ describe("Python backend invoke (embedded CPython 3.13 + GIL)", () => {
     expect(typeof r.locked).toBe("boolean");
   });
 
+  test("backend → __core__ 도달: session.setProxy (워커 스레드 → UI post)", async () => {
+    // Python 워커 스레드에서 호출 → UI 스레드로 post 되어 크래시 없이 success.
+    const r: any = await invoke("core-set-proxy", {});
+    expect(r.cmd).toBe("session_set_proxy");
+    expect(r.success).toBe(true);
+  });
+
   test("echo: json decode/encode roundtrip", async () => {
     const r: any = await invoke("echo", { message: "hello from frontend", value: 42 });
     expect(r.runtime).toBe("python");

--- a/tests/e2e/system-integration.test.ts
+++ b/tests/e2e/system-integration.test.ts
@@ -1686,3 +1686,58 @@ describe("app.requestSingleInstanceLock", () => {
     expect(evt.argv).toContain("/tmp/x.txt");
   });
 });
+
+// session.setProxy — 프록시 설정이 렌더러 네트워크 요청에 실효하는지 실측.
+// dead proxy + "<-loopback>"(루프백도 프록시 경유)로 fetch 실패 → direct 복귀로 성공.
+describe("session.setProxy", () => {
+  const setProxy = (cfg: Record<string, string>) =>
+    core({ cmd: "session_set_proxy", mode: "", proxyRules: "", proxyBypassRules: "", pacScript: "", ...cfg });
+
+  test("프록시 설정이 렌더러 요청에 실효 (프록시 경유 .invalid 해석 → 성공, direct → 실패)", async () => {
+    // 로컬 http 서버를 프록시로 사용 — 프록시는 target host 를 자체 해석하므로
+    // .invalid 호스트는 direct 면 DNS 실패, 프록시 경유면 이 서버가 200 응답.
+    const proxy = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain", "access-control-allow-origin": "*" });
+      res.end("via-proxy");
+    });
+    const target = "http://suji-proxy-probe.invalid/"; // 프록시 경유로만 도달
+    try {
+      await new Promise<void>((resolve) => proxy.listen(0, "127.0.0.1", resolve));
+      const addr = proxy.address();
+      if (typeof addr !== "object" || addr === null) throw new Error("no proxy address");
+      const proxyHostPort = `127.0.0.1:${addr.port}`;
+
+      const fetchOk = (): Promise<boolean> =>
+        page.evaluate(async (u: string) => {
+          try {
+            const r = await fetch(u, { cache: "no-store" });
+            return r.ok;
+          } catch {
+            return false;
+          }
+        }, target);
+      const poll = async (want: boolean): Promise<boolean> => {
+        for (let i = 0; i < 20; i++) {
+          if ((await fetchOk()) === want) return true;
+          await new Promise((r) => setTimeout(r, 100));
+        }
+        return false;
+      };
+
+      // direct: .invalid 는 DNS 실패 → fetch 실패
+      await setProxy({ mode: "direct" });
+      expect(await poll(false)).toBe(true);
+
+      // 프록시 경유: .invalid 요청이 127.0.0.1:PORT 프록시로 가서 200 → fetch 성공
+      expect((await setProxy({ mode: "fixed_servers", proxyRules: proxyHostPort }) as any).success).toBe(true);
+      expect(await poll(true)).toBe(true);
+    } finally {
+      await setProxy({ mode: "direct" }).catch(() => {}); // 다른 테스트 보호(프록시 해제)
+      proxy.close();
+    }
+  }, 30000);
+
+  test("SDK round-trip: session.setProxy 가 boolean 반환", async () => {
+    expect(await sdk<boolean>("session.setProxy", { mode: "direct" })).toBe(true);
+  });
+});


### PR DESCRIPTION
## 개요

Electron `session.setProxy(config)` 패리티 — 런타임 프록시 설정. electron-parity-audit `[high]` 항목(재동기화로 드러난 진짜 잔존 5개 중 하나).

## 메커니즘

- **"proxy" 는 request context preference**(네트워크 관장) → 전역 preference manager 가 아니라 `cef_request_context_get_global_context()`(브라우저 기본 컨텍스트)의 `set_preference` 로 설정. (Electron 의 session = request context.)
- config 매핑: `mode` / `proxyRules`→server / `proxyBypassRules`→bypass_list / `pacScript`→pac_url. `mode:""` → `"direct"`(해제).
- **UI 스레드 처리**: `set_preference` 는 UI 스레드 필수. 프론트(@suji/api renderer) invoke 는 UI 스레드라 직접 호출, **백엔드(워커 스레드)는 `cef_post_task` 로 UI 스레드에 post**(Electron 도 setProxy 는 main 프로세스=백엔드가 자연 호출자). `cef_initial_load` task 패턴 동형.

## 전 6개 언어

JS `@suji/api` `session.setProxy(config)` / Node `@suji/node` 동형 / Rust `session::set_proxy` / Go `session.SetProxy` / Python·Lua raw `invoke("__core__")`.

## 검증

- **e2e system-integration (117)**: 로컬 http 서버를 프록시로, `.invalid` 호스트 fetch — direct 면 DNS 실패, 프록시 경유면 200 성공(프록시 실효 **positive** 검증, 프론트 UI-스레드 경로) + SDK round-trip.
- **e2e lua/python (각 9)**: 백엔드 워커 스레드 → `__core__` → UI 스레드 post 경로 크래시 없이 `success`(off-UI-thread 처리 검증).
- 소스 계약 가드(cef_ipc_test): `session_set_proxy` + `cef.sessionSetProxy` + `cef_request_context_get_global_context`.

## 리뷰에서 잡은 것 (`/simplify` + `/code-review max`)

- **UAF (e2e SIGBUS 0xef)**: CEF C API 의 set 메서드가 전달 ref 를 consume → create dict/value release 시 double-free. release 제거로 수정(주석에 실측 근거 + "doc 보고 release 추가 금지" 명시).
- **off-UI-thread 크래시**: 백엔드(워커 스레드)에서 호출 시 `set_preference` UI-스레드 assert abort → `cef_post_task` 로 UI 스레드 post 하도록 수정(lua/python e2e 로 검증).
- "proxy" 가 전역 preference manager 가 아니라 request context pref 임을 e2e 실효 검증으로 발견·수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)