### PR TITLE
feat(window): BrowserWindow.destroy() — 강제 파괴 (window:close 스킵)

### DIFF
--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -801,6 +801,10 @@ pub mod windows {
     pub fn close(window_id: u32) -> Option<String> {
         invoke("__core__", &window_op_request("destroy_window", window_id))
     }
+    /// 강제 파괴 (Electron `BrowserWindow.destroy`) — `window:close`(취소 hook) 스킵, `window:closed` 만.
+    pub fn destroy(window_id: u32) -> Option<String> {
+        invoke("__core__", &window_op_request("destroy_window_force", window_id))
+    }
     pub fn show(window_id: u32) -> Option<String> {
         invoke("__core__", &set_visible_request(window_id, true))
     }
@@ -1156,6 +1160,10 @@ pub mod windows {
         pub fn close(&self) -> Option<String> {
             close(self.id)
         }
+        /// 강제 파괴 (Electron `BrowserWindow.destroy`) — `window:close` 스킵, `window:closed` 만.
+        pub fn destroy(&self) -> Option<String> {
+            destroy(self.id)
+        }
         pub fn show(&self) -> Option<String> {
             show(self.id)
         }
@@ -1249,6 +1257,7 @@ pub mod windows {
             // 리네임 트랩 cmd 문서/가드 — restore→restore_window, close→destroy_window (Go 테스트 대칭).
             assert_eq!(window_op_request("restore_window", 2), r#"{"cmd":"restore_window","windowId":2}"#);
             assert_eq!(window_op_request("destroy_window", 2), r#"{"cmd":"destroy_window","windowId":2}"#);
+            assert_eq!(window_op_request("destroy_window_force", 2), r#"{"cmd":"destroy_window_force","windowId":2}"#);
             assert_eq!(set_visible_request(2, true), r#"{"cmd":"set_visible","windowId":2,"visible":true}"#);
             assert_eq!(set_visible_request(2, false), r#"{"cmd":"set_visible","windowId":2,"visible":false}"#);
             assert_eq!(set_fullscreen_request(4, true), r#"{"cmd":"set_fullscreen","windowId":4,"flag":true}"#);

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -319,6 +319,9 @@ export declare const windows: {
     show(windowId: number): Promise<WindowOpResponse>;
     hide(windowId: number): Promise<WindowOpResponse>;
     close(windowId: number): Promise<WindowOpResponse>;
+    /** 강제 파괴 (Electron `BrowserWindow.destroy`). close 와 달리 `window:close`
+     *  (취소 hook)를 스킵하고 `window:closed` 만 발화 — listener 가 막을 수 없음. */
+    destroy(windowId: number): Promise<WindowOpResponse>;
     setFullScreen(windowId: number, flag: boolean): Promise<WindowOpResponse>;
     isMinimized(windowId: number): Promise<IsMinimizedResponse>;
     isMaximized(windowId: number): Promise<IsMaximizedResponse>;
@@ -465,6 +468,8 @@ export declare class BrowserWindow {
     show(): Promise<WindowOpResponse>;
     hide(): Promise<WindowOpResponse>;
     close(): Promise<WindowOpResponse>;
+    /** 강제 파괴 (Electron `BrowserWindow.destroy`) — `window:close` 스킵, `window:closed` 만. */
+    destroy(): Promise<WindowOpResponse>;
     setFullScreen(flag: boolean): Promise<WindowOpResponse>;
     isMinimized(): Promise<IsMinimizedResponse>;
     isMaximized(): Promise<IsMaximizedResponse>;

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -227,6 +227,11 @@ export const windows = {
     close(windowId) {
         return coreCall({ cmd: "destroy_window", windowId });
     },
+    /** 강제 파괴 (Electron `BrowserWindow.destroy`). close 와 달리 `window:close`
+     *  (취소 hook)를 스킵하고 `window:closed` 만 발화 — listener 가 막을 수 없음. */
+    destroy(windowId) {
+        return coreCall({ cmd: "destroy_window_force", windowId });
+    },
     setFullScreen(windowId, flag) {
         return coreCall({ cmd: "set_fullscreen", windowId, flag });
     },
@@ -539,6 +544,10 @@ export class BrowserWindow {
     }
     close() {
         return windows.close(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));
+    }
+    /** 강제 파괴 (Electron `BrowserWindow.destroy`) — `window:close` 스킵, `window:closed` 만. */
+    destroy() {
+        return windows.destroy(__classPrivateFieldGet(this, _BrowserWindow_id, "f"));
     }
     setFullScreen(flag) {
         return windows.setFullScreen(__classPrivateFieldGet(this, _BrowserWindow_id, "f"), flag);

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -510,6 +510,11 @@ export const windows = {
   close(windowId: number): Promise<WindowOpResponse> {
     return coreCall<WindowOpResponse>({ cmd: "destroy_window", windowId });
   },
+  /** 강제 파괴 (Electron `BrowserWindow.destroy`). close 와 달리 `window:close`
+   *  (취소 hook)를 스킵하고 `window:closed` 만 발화 — listener 가 막을 수 없음. */
+  destroy(windowId: number): Promise<WindowOpResponse> {
+    return coreCall<WindowOpResponse>({ cmd: "destroy_window_force", windowId });
+  },
   setFullScreen(windowId: number, flag: boolean): Promise<WindowOpResponse> {
     return coreCall<WindowOpResponse>({ cmd: "set_fullscreen", windowId, flag });
   },
@@ -854,6 +859,10 @@ export class BrowserWindow {
   }
   close() {
     return windows.close(this.#id);
+  }
+  /** 강제 파괴 (Electron `BrowserWindow.destroy`) — `window:close` 스킵, `window:closed` 만. */
+  destroy() {
+    return windows.destroy(this.#id);
   }
   setFullScreen(flag: boolean) {
     return windows.setFullScreen(this.#id, flag);

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -727,6 +727,10 @@ export const windows = {
   close(windowId: number): Promise<WindowOpResponse> {
     return invoke<WindowOpResponse>('__core__', { cmd: 'destroy_window', windowId });
   },
+  /** 강제 파괴 (Electron `BrowserWindow.destroy`). `window:close`(취소 hook) 스킵, `window:closed` 만. */
+  destroy(windowId: number): Promise<WindowOpResponse> {
+    return invoke<WindowOpResponse>('__core__', { cmd: 'destroy_window_force', windowId });
+  },
   setFullScreen(windowId: number, flag: boolean): Promise<WindowOpResponse> {
     return invoke<WindowOpResponse>('__core__', { cmd: 'set_fullscreen', windowId, flag });
   },
@@ -1026,6 +1030,10 @@ export class BrowserWindow {
   }
   close() {
     return windows.close(this.#id);
+  }
+  /** 강제 파괴 (Electron `BrowserWindow.destroy`) — `window:close` 스킵, `window:closed` 만. */
+  destroy() {
+    return windows.destroy(this.#id);
   }
   setFullScreen(flag: boolean) {
     return windows.setFullScreen(this.#id, flag);

--- a/sdks/suji-go/windows/windows.go
+++ b/sdks/suji-go/windows/windows.go
@@ -357,6 +357,12 @@ func Restore(windowID uint32) string {
 func Close(windowID uint32) string {
 	return suji.Invoke("__core__", windowOpRequest("destroy_window", windowID))
 }
+
+// Destroy force-destroys a window (Electron `BrowserWindow.destroy`). Unlike Close,
+// it skips the `window:close` (cancelable hook) and emits only `window:closed`.
+func Destroy(windowID uint32) string {
+	return suji.Invoke("__core__", windowOpRequest("destroy_window_force", windowID))
+}
 func Show(windowID uint32) string { return suji.Invoke("__core__", setVisibleRequest(windowID, true)) }
 func Hide(windowID uint32) string { return suji.Invoke("__core__", setVisibleRequest(windowID, false)) }
 func SetFullScreen(windowID uint32, flag bool) string {
@@ -503,6 +509,7 @@ func (w *BrowserWindow) Maximize() string                        { return Maximi
 func (w *BrowserWindow) Unmaximize() string                      { return Unmaximize(w.ID) }
 func (w *BrowserWindow) Restore() string                         { return Restore(w.ID) }
 func (w *BrowserWindow) Close() string                           { return Close(w.ID) }
+func (w *BrowserWindow) Destroy() string                         { return Destroy(w.ID) }
 func (w *BrowserWindow) Show() string                            { return Show(w.ID) }
 func (w *BrowserWindow) Hide() string                            { return Hide(w.ID) }
 func (w *BrowserWindow) SetFullScreen(flag bool) string          { return SetFullScreen(w.ID, flag) }

--- a/sdks/suji-go/windows/windows_test.go
+++ b/sdks/suji-go/windows/windows_test.go
@@ -119,6 +119,7 @@ func TestWindowStateRequests(t *testing.T) {
 		{"get_bounds", windowOpRequest("get_bounds", 1), `{"cmd":"get_bounds","windowId":1}`},
 		{"restore", windowOpRequest("restore_window", 2), `{"cmd":"restore_window","windowId":2}`},
 		{"close", windowOpRequest("destroy_window", 2), `{"cmd":"destroy_window","windowId":2}`},
+		{"destroy", windowOpRequest("destroy_window_force", 2), `{"cmd":"destroy_window_force","windowId":2}`},
 		{"show", setVisibleRequest(2, true), `{"cmd":"set_visible","windowId":2,"visible":true}`},
 		{"hide", setVisibleRequest(2, false), `{"cmd":"set_visible","windowId":2,"visible":false}`},
 		{"set_fullscreen", setFullscreenRequest(4, true), `{"cmd":"set_fullscreen","windowId":4,"flag":true}`},

--- a/src/core/window.zig
+++ b/src/core/window.zig
@@ -891,9 +891,14 @@ pub const WindowManager = struct {
         }
     }
 
-    /// 창 파괴 (강제). `window:closed` 이벤트는 `close()` 경로에서만 발화. 단 host destroy로
-    /// 자동 정리되는 child view는 view-destroyed 이벤트 발화 (Electron WebContentsView 호환).
-    pub fn destroy(self: *WindowManager, id: u32) Error!void {
+    /// 파괴 + 단방향 이벤트 공용 (destroy/destroyWithClosedEvent/close Phase 3~4 공유).
+    /// lock 안에서 destroyLocked, lock 밖에서 view-destroyed + (emit_closed 면) window:closed
+    /// + all-closed. 유효성/취소(window:close) 단계는 caller 책임. name 은 destroy 전 캡처.
+    fn destroyAndEmitClosed(self: *WindowManager, id: u32, emit_closed: bool) Error!void {
+        const name_snapshot: ?[]const u8 = if (emit_closed)
+            (if (self.windows.get(id)) |w| w.name else null)
+        else
+            null;
         var live_after: usize = undefined;
         var destroyed_views: std.ArrayListUnmanaged(DestroyedView) = .empty;
         {
@@ -904,7 +909,33 @@ pub const WindowManager = struct {
             live_after = self.liveCountLocked();
         }
         self.emitViewDestroyedAndDeinit(&destroyed_views);
+        if (emit_closed) {
+            if (self.sink) |s| {
+                var buf: [PAYLOAD_BUF_SIZE]u8 = undefined;
+                const payload = buildIdPayload(&buf, id, name_snapshot);
+                s.emit(events.closed, payload);
+            }
+        }
         self.maybeEmitAllClosed(true, live_after);
+    }
+
+    /// 창 파괴 (강제, silent). `window:closed` 미발화(close()/destroyWithClosedEvent() 경로
+    /// 에서만 발화). 단 host destroy로 자동 정리되는 child view는 view-destroyed 발화.
+    pub fn destroy(self: *WindowManager, id: u32) Error!void {
+        return self.destroyAndEmitClosed(id, false);
+    }
+
+    /// Electron BrowserWindow.destroy() — 강제 파괴 + `window:closed`(단방향) 발화.
+    /// close() 와 달리 `window:close`(취소 가능 hook)는 **스킵**(force-close, listener
+    /// 가 막을 수 없음). .window 전용(view 는 destroyView) — close() 와 동일 가드. 미존재/
+    /// view id 는 error.
+    pub fn destroyWithClosedEvent(self: *WindowManager, id: u32) Error!void {
+        {
+            self.lock.lockUncancelable(self.io);
+            defer self.lock.unlock(self.io);
+            _ = try self.getLiveWindowLocked(id); // .window 전용 (Electron destroy = BrowserWindow)
+        }
+        return self.destroyAndEmitClosed(id, true);
     }
 
     /// 정책적 close. `window:close`(취소 가능) 발화 → preventDefault 아니면 파괴 +
@@ -918,7 +949,8 @@ pub const WindowManager = struct {
             _ = try self.getLiveWindowLocked(id);
         }
 
-        // Phase 2: 취소 가능 이벤트 (lock 밖). name은 destroy 전에 캡처해서 close/closed 동일 사용.
+        // Phase 2: 취소 가능 이벤트 (lock 밖). name은 destroy 전에 캡처(window:close 용 —
+        // window:closed 는 헬퍼가 재캡처, name 불변이라 동일 값).
         const name_snapshot: ?[]const u8 = if (self.windows.get(id)) |w| w.name else null;
         if (self.sink) |s| {
             var buf: [PAYLOAD_BUF_SIZE]u8 = undefined;
@@ -928,26 +960,9 @@ pub const WindowManager = struct {
             if (ev.default_prevented) return false;
         }
 
-        // Phase 3: 실제 파괴 (lock, listener 도중 destroy됐는지 재확인)
-        var live_after: usize = undefined;
-        var destroyed_views: std.ArrayListUnmanaged(DestroyedView) = .empty;
-        {
-            self.lock.lockUncancelable(self.io);
-            defer self.lock.unlock(self.io);
-            const win = try self.getLiveLocked(id);
-            self.destroyLocked(win, &destroyed_views);
-            live_after = self.liveCountLocked();
-        }
-
-        // Phase 4: 단방향 이벤트 (lock 밖) — view-destroyed 먼저 (자식 → 부모 순서),
-        // 그 다음 host의 closed.
-        self.emitViewDestroyedAndDeinit(&destroyed_views);
-        if (self.sink) |s| {
-            var buf: [PAYLOAD_BUF_SIZE]u8 = undefined;
-            const payload = buildIdPayload(&buf, id, name_snapshot);
-            s.emit(events.closed, payload);
-        }
-        self.maybeEmitAllClosed(true, live_after);
+        // Phase 3~4: 실제 파괴 + 단방향 이벤트 (공용 헬퍼 — listener 도중 destroy됐는지
+        // getLiveLocked 로 재확인, view-destroyed → closed → all-closed).
+        try self.destroyAndEmitClosed(id, true);
         return true;
     }
 

--- a/src/core/window_ipc.zig
+++ b/src/core/window_ipc.zig
@@ -739,6 +739,18 @@ pub fn handleDestroyWindow(window_id: u32, response_buf: []u8, wm: *window.Windo
     ) catch null;
 }
 
+/// 강제 destroy (Electron BrowserWindow.destroy) — `window:close`(취소 hook) 스킵,
+/// `window:closed` 만 발화. 미존재 windowId 는 success=false.
+pub fn handleForceDestroyWindow(window_id: u32, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
+    if (response_buf.len < RESPONSE_MIN_LEN) return null;
+    const ok = if (wm.destroyWithClosedEvent(window_id)) |_| true else |_| false;
+    return std.fmt.bufPrint(
+        response_buf,
+        "{{\"from\":\"zig-core\",\"cmd\":\"destroy_window_force\",\"windowId\":{d},\"success\":{}}}",
+        .{ window_id, ok },
+    ) catch null;
+}
+
 pub const AddChildViewReq = struct {
     host_id: u32,
     view_id: u32,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1516,6 +1516,11 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         const win_id: u32 = util.nonNegU32(util.extractJsonInt(req_clean, "windowId") orelse return null);
         return window_ipc.handleDestroyWindow(win_id, response_buf, wm);
     }
+    if (std.mem.eql(u8, cmd, "destroy_window_force")) {
+        const wm = window_mod.WindowManager.global orelse return null;
+        const win_id: u32 = util.nonNegU32(util.extractJsonInt(req_clean, "windowId") orelse return null);
+        return window_ipc.handleForceDestroyWindow(win_id, response_buf, wm);
+    }
     if (std.mem.eql(u8, cmd, "set_title")) {
         const wm = window_mod.WindowManager.global orelse return null;
         const win_id: u32 = @intCast(util.extractJsonInt(req_clean, "windowId") orelse return null);

--- a/tests/e2e/window-lifecycle-events.test.ts
+++ b/tests/e2e/window-lifecycle-events.test.ts
@@ -201,6 +201,32 @@ describe("window lifecycle events", () => {
     }
   });
 
+  test("destroy()(force) → window:closed 발화, window:close(취소 hook)는 스킵", async () => {
+    const a = (await core<{ windowId: number }>({
+      cmd: "create_window", title: "destroy-force-a", x: 510, y: 510, width: 300, height: 200,
+    })).windowId;
+    const closeCol = collect<{ windowId: number }>("window:close", 1500);
+    const closedCol = collect<{ windowId: number }>("window:closed", 1500);
+    await core({ cmd: "destroy_window_force", windowId: a });
+    const closeEvts = await closeCol;
+    const closedEvts = await closedCol;
+    // Electron destroy(): window:closed 발화, window:close(취소 hook)는 미발화.
+    expect(closedEvts.some((e) => e.windowId === a)).toBe(true);
+    expect(closeEvts.some((e) => e.windowId === a)).toBe(false);
+  });
+
+  test("close() 대조 → window:close + window:closed 둘 다 발화 (destroy 와 차이)", async () => {
+    // harness 가 window:close 를 실제 감지함을 확인 → 위 destroy 의 '스킵' 단언이 유의미.
+    const b = (await core<{ windowId: number }>({
+      cmd: "create_window", title: "close-ctrl-b", x: 520, y: 520, width: 300, height: 200,
+    })).windowId;
+    const closeCol = collect<{ windowId: number }>("window:close", 1500);
+    const closedCol = collect<{ windowId: number }>("window:closed", 1500);
+    await core({ cmd: "destroy_window", windowId: b });
+    expect((await closeCol).some((e) => e.windowId === b)).toBe(true);
+    expect((await closedCol).some((e) => e.windowId === b)).toBe(true);
+  });
+
   // ==================== Phase 5: minimize/maximize/fullscreen ====================
   // 새 창을 만들고 IPC로 NSWindow를 조작 → NSWindowDelegate가 이벤트 발화.
   // CI runner는 dock 동작이 비결정적이라 toBeGreaterThan(0)만 검증 (정확한 횟수 X).

--- a/tests/window_manager_test.zig
+++ b/tests/window_manager_test.zig
@@ -1055,6 +1055,31 @@ test "destroy does not emit window:close or window:closed (silent destruction)" 
     try std.testing.expectEqual(@as(usize, 0), countEvents(&sink, window.events.closed));
 }
 
+test "destroyWithClosedEvent emits window:closed but skips window:close (force, Electron destroy)" {
+    var native = TestNative{};
+    var sink = TestSink{};
+    defer sink.deinit();
+    var wm = newManager(&native);
+    defer wm.deinit();
+    wm.setEventSink(sink.asSink());
+
+    const id = try wm.create(.{});
+    sink.events.clearRetainingCapacity();
+
+    try wm.destroyWithClosedEvent(id);
+    // Electron destroy(): 취소 hook(window:close) 스킵, window:closed 만 발화.
+    try std.testing.expectEqual(@as(usize, 0), countEvents(&sink, window.events.close));
+    try std.testing.expectEqual(@as(usize, 1), countEvents(&sink, window.events.closed));
+    try std.testing.expect(wm.get(id).?.destroyed);
+}
+
+test "destroyWithClosedEvent on unknown id returns WindowNotFound" {
+    var native = TestNative{};
+    var wm = newManager(&native);
+    defer wm.deinit();
+    try std.testing.expectError(window.Error.WindowNotFound, wm.destroyWithClosedEvent(999));
+}
+
 // ============================================
 // 동시성 — 같은 name으로 N 스레드 create → singleton 유지
 // ============================================


### PR DESCRIPTION
## 개요

Electron `BrowserWindow.destroy()` 패리티 — **강제 파괴**. `close()` 와 달리 취소 가능 hook(`window:close`)을 스킵하고 `window:closed` 만 발화(listener 가 막을 수 없음). electron-parity-audit `[high]` (재동기화로 드러난 진짜 잔존 4개 중 하나).

| | close() | destroy() |
|---|---|---|
| `window:close` (취소 hook) | 발화 (preventDefault 가능) | **스킵** |
| `window:closed` | 발화 | 발화 |

## 구현

- **window.zig**: `WM.destroyWithClosedEvent` (force + `window:closed`, window-only 가드). 공용 헬퍼 `destroyAndEmitClosed(id, emit_closed)` 추출 — `destroy()`(silent) / `destroyWithClosedEvent()` / `close()` Phase 3-4 가 공유(3중복 제거). 기존 `destroyLocked` 재사용 → **native vtable 추가 0**(test_native 무영향).
- **window_ipc / main.zig**: cmd `destroy_window_force`(close 는 기존 `destroy_window` 유지).
- **SDK (전 6개 언어)**: `windows.destroy` + `BrowserWindow.destroy` (suji-js/node) · `windows::destroy` + `BrowserWindow::destroy` (rust) · `windows.Destroy` + `BrowserWindow.Destroy` (go) · Python/Lua raw `invoke("__core__", destroy_window_force)`.

## 검증

- **WM 유닛 테스트**: `destroyWithClosedEvent` → `window:closed` 발화 + `window:close` 스킵 / unknown id → `WindowNotFound`. 기존 close(cancelable/preventDefault/retry)·destroy(silent) 테스트 보존(헬퍼 리팩터 behavior-identical).
- **e2e window-lifecycle-events (16 pass)**: destroy(force)=closed only, close() 대조=close+closed(harness 가 `window:close` 감지함을 확인 → '스킵' 단언 유의미).
- Rust/Go 리네임 가드(`destroy_window_force`) + zig/Rust/Go 테스트 통과.

## 리뷰 (`/simplify` + `/code-review max`)

- `/simplify`: destroy/destroyWithClosedEvent/close Phase3-4 3중복 → `destroyAndEmitClosed` 헬퍼로 통합(close() behavior-identical 검증).
- `/code-review max`: close() 리팩터 line-by-line 등가 확인. 수정 — Go `BrowserWindow.Destroy()` 파사드 누락 보완, `destroyWithClosedEvent` window-only 가드(close 와 동일, view id 거부).

🤖 Generated with [Claude Code](https://claude.com/claude-code)