### PR TITLE
docs: setSSLConfig / cookies.changed — CEF 본질적 제약으로 보류 명시

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -914,6 +914,16 @@ net-control 이라 데이터 유출 sink 아님 → 범위 제외. 모바일은 
   콜백 수명 관리(issue #16 가 leak 이던 표면)를 재도입하므로 비용 대비 가치 낮아
   미수정. **서로 다른 종류**(print↔capture)의 같은-path 교차충돌은 `kind`
   디스크리미네이터로 해소됨(PR #54 review #3). UAF/슬롯 고갈/타임아웃은 모두 수정.
+- **`session.setSSLConfig` / `session.cookies` `'changed'` 이벤트 — CEF 본질적 제약으로
+  지원 우선 보류**: Electron 은 Chromium network service 에 직접 접근하지만 suji 는 CEF
+  (Chromium 의 부분집합만 노출) 위라, 두 기능이 의존하는 Chromium-deep 인터페이스가
+  CEF 에 없다. (1) **setSSLConfig**: Electron 은 `network::mojom::SSLConfig` 로 런타임
+  TLS 버전/cipher 제어 — CEF 엔 런타임 SSL 설정 API 부재(시작-시 `--ssl-version-min`
+  플래그 정도만). (2) **cookies 'changed'**: Electron 은 `CookieManager.AddCookieChange
+  Listener`(변경 옵저버) 래핑 — CEF `cef_cookie_manager_t` 는 set/delete/visit/flush 만,
+  변경 옵저버 부재(폴링 흉내만 가능). 깔끔한 런타임 동등 불가라 **보류**(CEF 가 해당
+  인터페이스를 노출하면 재개). 같은 패턴: cross-origin `protocol.handle` 보류,
+  isolated-world contextBridge 부재. 상세: docs/electron-parity-audit.md `[보류]` 항목.
 
 ## 구현 노트
 

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -56,9 +56,9 @@
 
 ### session
 
-- **[high]** `session.cookies.changed event` — Add session:cookies-changed event emission on cookie modifications. Implementation: (1) Register a CEF cookie visitor/observer with CEF's cookie manager via cef_cookie_manager_t callbacks (if CEF expo
+- 🔒 **[high · 보류 — CEF 본질적 제약]** `session.cookies.changed event` — Electron 은 Chromium network service 의 `CookieManager.AddCookieChangeListener`(CookieStore 변경 옵저버)를 래핑해 지원하지만, CEF 의 `cef_cookie_manager_t` 는 set/delete/visit/flush 만 노출하고 **변경 옵저버 API 가 없다**(CEF 는 Chromium 의 부분집합만 surface). 폴링(주기적 스냅샷 비교)으로만 흉내 가능 → 부정확/비효율이라 **지원 우선 보류**. CEF 가 cookie-change 콜백을 노출하면 재개. (원안) Add session:cookies-changed event emission on cookie modifications via cef_cookie_manager_t callbacks (if CEF expo
 - ~~**[high]** `session.setProxy(config)`~~ ✅ (#99) — Add session.setProxy(config) to all SDKs. Define ProxyConfig interface (proxyRules, pacScript, etc.). Backend: implement session_set_proxy Zig command in cef.zig, wired to CEF proxy API. Pattern: sync
-- **[high]** `session.setSSLConfig(config)` — Add session.setSSLConfig(config) implementation: (1) Extend Zig session handler in src/main.zig to accept "session_set_ssl_config" command with minVersion/maxVersion/disabledCipherSuites parameters. (
+- 🔒 **[high · 보류 — CEF 본질적 제약]** `session.setSSLConfig(config)` — Electron 은 Chromium network service 의 `network::mojom::SSLConfig` 를 직접 설정해 minVersion/maxVersion/cipher 를 런타임 제어하지만, CEF 엔 **런타임 SSL 설정 API 가 없다**(TLS 최소버전 등은 시작-시 `--ssl-version-min` 명령행 플래그 정도만; 세션별 런타임 pref 부재). 깔끔한 런타임 동등 구현 불가 → **지원 우선 보류**. CEF 가 SSLConfig 인터페이스를 노출하면 재개. (원안) Add session.setSSLConfig(config) via "session_set_ssl_config" command with minVersion/maxVersion/disabledCipherSuites parameters. (
 - **[high]** `session.setPermissionRequestHandler` — Implement permission handler in Zig, CEF, and all SDKs
 
 ### shell


### PR DESCRIPTION
남은 [high] 중 `session.setSSLConfig`·`session.cookies 'changed'` 는 CEF 아키텍처 제약(Chromium 부분집합만 노출)으로 Electron 동등 구현 불가 → **지원 우선 보류**를 문서에 명시.

- audit: `🔒 [보류 — CEF 본질적 제약]` 마커 + 사유(Electron=raw Chromium network service 직접 접근 vs suji=CEF).
- CLAUDE.md 알려진 이슈: 동일 패턴(protocol.handle 보류 등) 추가.

진짜 남은 [high]는 `setPermissionRequestHandler`(CEF `cef_permission_handler_t` 정식 지원) 하나 — 별도 진행. 코드 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)