### PR TITLE
feat(menu): MenuItem id + visible fields (Menu batch Phase A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -570,6 +570,9 @@ suji.send('my-event', JSON.stringify({ msg: 'hello' }))
 // await notification.requestPermission() / show({title,body,silent}) / close(notificationId)
 //                              — suji.on('notification:click', ({notificationId}) => ...)
 // await menu.setApplicationMenu([{label:"Tools",submenu:[{label:"Run",click:"run"}]}])
+//   MenuItem 옵션: enabled, checked(checkbox), id(getMenuItemById 식별자 — UI 효과 없음),
+//   visible(false=항목 숨김; macOS NSMenuItem.setHidden / GTK set_visible 실효, Win no-op).
+//   전 6개 언어(JS/Node optional, Rust enum 필드, Go *bool omitempty, lua/python raw).
 // await menu.resetApplicationMenu()
 // await menu.popup([{label:"Run",click:"run"}], {x:10,y:10}) — suji.on('menu:click', ({click}) => ...)
 // import { screen, powerSaveBlocker, safeStorage, app, webRequest, session, crashReporter, autoUpdater } from '@suji/node'

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2162,23 +2162,31 @@ pub mod menu {
     use crate::{invoke, serde_json};
 
     /// Application menu item — top-level entries should be Submenu.
+    /// `id`(getMenuItemById 식별자, UI 효과 없음) / `visible`(false=숨김; Electron MenuItem).
+    /// 미사용 시 `id: ""`, `visible: true` 전달.
     pub enum MenuItem<'a> {
         Item {
             label: &'a str,
             click: &'a str,
             enabled: bool,
+            id: &'a str,
+            visible: bool,
         },
         Checkbox {
             label: &'a str,
             click: &'a str,
             checked: bool,
             enabled: bool,
+            id: &'a str,
+            visible: bool,
         },
         Separator,
         Submenu {
             label: &'a str,
             enabled: bool,
             submenu: Vec<MenuItem<'a>>,
+            id: &'a str,
+            visible: bool,
         },
     }
 
@@ -2188,34 +2196,46 @@ pub mod menu {
                 label,
                 click,
                 enabled,
+                id,
+                visible,
             } => serde_json::json!({
                 "type": "item",
                 "label": label,
                 "click": click,
                 "enabled": enabled,
+                "id": id,
+                "visible": visible,
             }),
             MenuItem::Checkbox {
                 label,
                 click,
                 checked,
                 enabled,
+                id,
+                visible,
             } => serde_json::json!({
                 "type": "checkbox",
                 "label": label,
                 "click": click,
                 "checked": checked,
                 "enabled": enabled,
+                "id": id,
+                "visible": visible,
             }),
             MenuItem::Separator => serde_json::json!({"type": "separator"}),
             MenuItem::Submenu {
                 label,
                 enabled,
                 submenu,
+                id,
+                visible,
             } => serde_json::json!({
                 "type": "submenu",
                 "label": label,
                 "enabled": enabled,
                 "submenu": submenu.iter().map(item_to_json).collect::<Vec<_>>(),
+                "id": id,
+                "visible": visible,
             }),
         }
     }
@@ -3051,23 +3071,32 @@ mod tests {
                     label: "Run",
                     click: "run",
                     enabled: true,
+                    id: "run-item",
+                    visible: false,
                 },
                 crate::menu::MenuItem::Checkbox {
                     label: "Flag",
                     click: "flag",
                     checked: true,
                     enabled: false,
+                    id: "",
+                    visible: true,
                 },
                 crate::menu::MenuItem::Separator,
             ],
+            id: "",
+            visible: true,
         }]);
         let v: serde_json::Value = serde_json::from_str(&req).unwrap();
         assert_eq!(v["cmd"], "menu_set_application_menu");
         assert_eq!(v["items"][0]["type"], "submenu");
         assert_eq!(v["items"][0]["label"], "Tools");
         assert_eq!(v["items"][0]["submenu"][0]["click"], "run");
+        assert_eq!(v["items"][0]["submenu"][0]["id"], "run-item");
+        assert_eq!(v["items"][0]["submenu"][0]["visible"], false);
         assert_eq!(v["items"][0]["submenu"][1]["checked"], true);
         assert_eq!(v["items"][0]["submenu"][1]["enabled"], false);
+        assert_eq!(v["items"][0]["submenu"][1]["visible"], true);
         assert_eq!(v["items"][0]["submenu"][2]["type"], "separator");
     }
 
@@ -3080,7 +3109,11 @@ mod tests {
                 label: "Run \\ now",
                 click: "run\nnow",
                 enabled: true,
+                id: "",
+                visible: true,
             }],
+            id: "",
+            visible: true,
         }]);
         let v: serde_json::Value = serde_json::from_str(&req).unwrap();
         assert_eq!(v["items"][0]["label"], "도구 \"Tools\"");

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -125,8 +125,8 @@
 - **[medium]** `MenuItem.role property` — Add optional `role?: string` field to MenuCommandItem interface in packages/suji-js/src/index.ts (line 934-939) and packages/suji-node/src/index.ts (line 1093-1098). Extend cef.ApplicationMenuItem.ite
 - **[medium]** `MenuItem.accelerator property` — Add optional `accelerator?: string` field to MenuCommandItem and MenuCheckboxItem types in packages/suji-js/src/index.ts and packages/suji-node/src/index.ts. Parse accelerator in src/platform/cef.zig 
 - **[medium]** `MenuItem.icon property` — Add optional `icon?: string` field to MenuCommandItem, MenuCheckboxItem, and MenuSubmenuItem interfaces in packages/suji-js/src/index.ts. Update Zig ApplicationMenuItem union in src/platform/cef.zig t
-- **[medium]** `MenuItem.visible property` — Add optional visible?: boolean (default true) field to MenuCommandItem, MenuCheckboxItem, and MenuSubmenuItem interfaces in packages/suji-js/src/index.ts. Update JSON parsing in src/main.zig's parseAp
-- **[medium]** `MenuItem constructor options completeness` — Add support for high-value MenuItem fields in phases: (1) Phase A (trivial): `id` (string identifier, no UI side-effect), `visible` (boolean flag, reuse enabled logic pattern). (2) Phase B (moderate):
+- ~~**[medium]** `MenuItem.visible property`~~ ✅ (Menu PR-1) — visible?:boolean(기본 true) 전 SDK 필드 + main.zig parseApplicationMenuItem 파싱 + 네이티브(macOS NSMenuItem.setHidden: / GTK set_no_show_all+set_visible 실효, Win no-op). ApplicationMenuItem(item/checkbox/submenu)에 적용.
+- **[medium]** `MenuItem constructor options completeness` — **Phase A(id, visible) 완료** (Menu PR-1 — id/visible 전 6개 언어 필드 + 파싱 + 네이티브). 잔여 Phase B(role/accelerator/icon)는 Menu PR-2. Add support for high-value MenuItem fields in phases: (1) Phase A (trivial): `id` (string identifier, no UI side-effect), `visible` (boolean flag, reuse enabled logic pattern). (2) Phase B (moderate):
 
 ### nativeImage
 

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -743,6 +743,10 @@ export interface MenuCommandItem {
     label: string;
     click: string;
     enabled?: boolean;
+    /** Electron MenuItem.id — getMenuItemById 식별자(UI 효과 없음). */
+    id?: string;
+    /** Electron MenuItem.visible — false 면 항목 숨김(기본 true). macOS 실효, Win/Linux best-effort. */
+    visible?: boolean;
 }
 export interface MenuCheckboxItem {
     type: "checkbox";
@@ -750,12 +754,16 @@ export interface MenuCheckboxItem {
     click: string;
     checked?: boolean;
     enabled?: boolean;
+    id?: string;
+    visible?: boolean;
 }
 export interface MenuSubmenuItem {
     type?: "submenu";
     label: string;
     enabled?: boolean;
     submenu: MenuItem[];
+    id?: string;
+    visible?: boolean;
 }
 export type MenuItem = MenuCommandItem | MenuCheckboxItem | MenuSeparator | MenuSubmenuItem;
 export declare const menu: {

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -1439,6 +1439,10 @@ export interface MenuCommandItem {
   label: string;
   click: string;
   enabled?: boolean;
+  /** Electron MenuItem.id — getMenuItemById 식별자(UI 효과 없음). */
+  id?: string;
+  /** Electron MenuItem.visible — false 면 항목 숨김(기본 true). macOS 실효, Win/Linux best-effort. */
+  visible?: boolean;
 }
 
 export interface MenuCheckboxItem {
@@ -1447,6 +1451,8 @@ export interface MenuCheckboxItem {
   click: string;
   checked?: boolean;
   enabled?: boolean;
+  id?: string;
+  visible?: boolean;
 }
 
 export interface MenuSubmenuItem {
@@ -1454,6 +1460,8 @@ export interface MenuSubmenuItem {
   label: string;
   enabled?: boolean;
   submenu: MenuItem[];
+  id?: string;
+  visible?: boolean;
 }
 
 export type MenuItem = MenuCommandItem | MenuCheckboxItem | MenuSeparator | MenuSubmenuItem;

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -1713,6 +1713,10 @@ export interface MenuCommandItem {
   label: string;
   click: string;
   enabled?: boolean;
+  /** Electron MenuItem.id — getMenuItemById 식별자(UI 효과 없음). */
+  id?: string;
+  /** Electron MenuItem.visible — false 면 항목 숨김(기본 true). */
+  visible?: boolean;
 }
 export interface MenuCheckboxItem {
   type: 'checkbox';
@@ -1720,12 +1724,16 @@ export interface MenuCheckboxItem {
   click: string;
   checked?: boolean;
   enabled?: boolean;
+  id?: string;
+  visible?: boolean;
 }
 export interface MenuSubmenuItem {
   type?: 'submenu';
   label: string;
   enabled?: boolean;
   submenu: MenuItem[];
+  id?: string;
+  visible?: boolean;
 }
 export type MenuItem = MenuCommandItem | MenuCheckboxItem | MenuSeparator | MenuSubmenuItem;
 

--- a/sdks/suji-go/menu/menu.go
+++ b/sdks/suji-go/menu/menu.go
@@ -16,6 +16,11 @@ type MenuItem struct {
 	Enabled *bool      `json:"enabled,omitempty"`
 	Checked bool       `json:"checked,omitempty"`
 	Submenu []MenuItem `json:"submenu,omitempty"`
+	// ID — Electron MenuItem.id (getMenuItemById 식별자; UI 효과 없음).
+	ID string `json:"id,omitempty"`
+	// Visible — Electron MenuItem.visible. nil=기본 true; false 면 항목 숨김. 포인터로
+	// 기본-true 보존(omitempty 가 nil 드롭 → 미지정 시 네이티브 기본 true).
+	Visible *bool `json:"visible,omitempty"`
 }
 
 func Item(label, click string) MenuItem {

--- a/sdks/suji-go/menu/menu_test.go
+++ b/sdks/suji-go/menu/menu_test.go
@@ -6,10 +6,14 @@ import (
 )
 
 func TestBuildSetApplicationMenuRequest(t *testing.T) {
+	hidden := false
+	runItem := Item("Run", "run")
+	runItem.ID = "run-item"
+	runItem.Visible = &hidden // visible:false 직렬화
 	req := buildSetApplicationMenuRequest([]MenuItem{
 		Submenu("Tools", []MenuItem{
-			Item("Run", "run"),
-			Checkbox("Flag", "flag", true),
+			runItem,
+			Checkbox("Flag", "flag", true), // Visible nil → omitempty 로 키 생략(기본 true)
 			Separator(),
 		}),
 	})
@@ -27,11 +31,22 @@ func TestBuildSetApplicationMenuRequest(t *testing.T) {
 		t.Fatalf("top item = %#v", top)
 	}
 	sub := top["submenu"].([]any)
-	if sub[0].(map[string]any)["click"] != "run" {
+	item0 := sub[0].(map[string]any)
+	if item0["click"] != "run" {
 		t.Fatalf("first submenu item = %#v", sub[0])
 	}
-	if sub[1].(map[string]any)["checked"] != true {
+	if item0["id"] != "run-item" {
+		t.Fatalf("id = %v", item0["id"])
+	}
+	if item0["visible"] != false {
+		t.Fatalf("visible = %v", item0["visible"])
+	}
+	cb := sub[1].(map[string]any)
+	if cb["checked"] != true {
 		t.Fatalf("checkbox item = %#v", sub[1])
+	}
+	if _, present := cb["visible"]; present {
+		t.Fatalf("nil Visible should be omitted, got %#v", cb["visible"])
 	}
 	if sub[2].(map[string]any)["type"] != "separator" {
 		t.Fatalf("separator item = %#v", sub[2])

--- a/src/main.zig
+++ b/src/main.zig
@@ -4422,6 +4422,8 @@ fn parseApplicationMenuItem(arena: std.mem.Allocator, value: std.json.Value) Men
     const label = util.jsonObjectGetString(obj, "label") orelse "";
     const click = util.jsonObjectGetString(obj, "click") orelse "";
     const enabled = util.jsonObjectGetBool(obj, "enabled") orelse true;
+    const id = util.jsonObjectGetString(obj, "id") orelse "";
+    const visible = util.jsonObjectGetBool(obj, "visible") orelse true;
 
     if (std.mem.eql(u8, typ, "submenu") or obj.get("submenu") != null) {
         const sub_val = obj.get("submenu") orelse return error.InvalidMenuItem;
@@ -4430,6 +4432,8 @@ fn parseApplicationMenuItem(arena: std.mem.Allocator, value: std.json.Value) Men
             .label = label,
             .enabled = enabled,
             .items = try parseApplicationMenuItems(arena, sub_val.array.items),
+            .id = id,
+            .visible = visible,
         } };
     }
     if (std.mem.eql(u8, typ, "checkbox")) {
@@ -4438,12 +4442,16 @@ fn parseApplicationMenuItem(arena: std.mem.Allocator, value: std.json.Value) Men
             .click = click,
             .checked = util.jsonObjectGetBool(obj, "checked") orelse false,
             .enabled = enabled,
+            .id = id,
+            .visible = visible,
         } };
     }
     return .{ .item = .{
         .label = label,
         .click = click,
         .enabled = enabled,
+        .id = id,
+        .visible = visible,
     } };
 }
 

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -24,6 +24,7 @@ pub const representedObjectUtf8 = cef_public_api.representedObjectUtf8;
 pub const nsFileUrlIfExists = cef_public_api.nsFileUrlIfExists;
 pub const ensureSimpleObjcTarget = cef_public_api.ensureSimpleObjcTarget;
 pub const setMenuItemEnabled = cef_public_api.setMenuItemEnabled;
+pub const setMenuItemHidden = cef_public_api.setMenuItemHidden;
 pub const setMenuItemState = cef_public_api.setMenuItemState;
 pub const setMenuItemTag = cef_public_api.setMenuItemTag;
 

--- a/src/platform/cef_menu.zig
+++ b/src/platform/cef_menu.zig
@@ -23,6 +23,7 @@ const addDefaultAppMenu = cef.addDefaultAppMenu;
 const addSubmenuItem = cef.addSubmenuItem;
 const allocNSMenuItem = cef.allocNSMenuItem;
 const setMenuItemEnabled = cef.setMenuItemEnabled;
+const setMenuItemHidden = cef.setMenuItemHidden;
 const setMenuItemState = cef.setMenuItemState;
 const setMenuItemTag = cef.setMenuItemTag;
 const setupMainMenu = cef.setupMainMenu;
@@ -79,6 +80,7 @@ pub fn setApplicationMenu(items: []const ApplicationMenuItem) bool {
         const menu = createMenuFromItems(sub.label, sub.items) orelse continue;
         const top = addSubmenuItem(menubar, sub.label, menu) orelse continue;
         setMenuItemEnabled(top, sub.enabled);
+        if (!sub.visible) setMenuItemHidden(top, true);
     }
 
     msgSendVoid1(app, "setMainMenu:", menubar);
@@ -126,17 +128,18 @@ fn addApplicationMenuItem(menu: *anyopaque, item: ApplicationMenuItem) void {
             const sep = msgSend(NSMenuItem, "separatorItem") orelse return;
             msgSendVoid1(menu, "addItem:", sep);
         },
-        .item => |it| addAppMenuClickable(menu, it.label, it.click, it.enabled, null),
-        .checkbox => |it| addAppMenuClickable(menu, it.label, it.click, it.enabled, it.checked),
+        .item => |it| addAppMenuClickable(menu, it.label, it.click, it.enabled, null, it.visible),
+        .checkbox => |it| addAppMenuClickable(menu, it.label, it.click, it.enabled, it.checked, it.visible),
         .submenu => |sub| {
             const sub_menu = createMenuFromItems(sub.label, sub.items) orelse return;
             const m = addSubmenuItem(menu, sub.label, sub_menu) orelse return;
             setMenuItemEnabled(m, sub.enabled);
+            if (!sub.visible) setMenuItemHidden(m, true);
         },
     }
 }
 
-fn addAppMenuClickable(menu: *anyopaque, label: []const u8, click: []const u8, enabled: bool, checked: ?bool) void {
+fn addAppMenuClickable(menu: *anyopaque, label: []const u8, click: []const u8, enabled: bool, checked: ?bool, visible: bool) void {
     const target = ensureAppMenuTarget() orelse return;
     const ns_label = nsStringFromSlice(label) orelse return;
     const ns_click = nsStringFromSlice(click) orelse return;
@@ -148,5 +151,6 @@ fn addAppMenuClickable(menu: *anyopaque, label: []const u8, click: []const u8, e
         setMenuItemState(m, state);
     }
     setMenuItemEnabled(m, enabled);
+    if (!visible) setMenuItemHidden(m, true);
     msgSendVoid1(menu, "addItem:", m);
 }

--- a/src/platform/cef_menu_linux.zig
+++ b/src/platform/cef_menu_linux.zig
@@ -34,6 +34,8 @@ const impl = if (builtin.os.tag == .linux) struct {
     extern "c" fn gtk_menu_item_set_submenu(menu_item: ?*anyopaque, submenu: ?*anyopaque) callconv(.c) void;
     extern "c" fn gtk_menu_shell_append(menu_shell: ?*anyopaque, child: ?*anyopaque) callconv(.c) void;
     extern "c" fn gtk_widget_set_sensitive(widget: ?*anyopaque, sensitive: c_int) callconv(.c) void;
+    extern "c" fn gtk_widget_set_visible(widget: ?*anyopaque, visible: c_int) callconv(.c) void;
+    extern "c" fn gtk_widget_set_no_show_all(widget: ?*anyopaque, no_show_all: c_int) callconv(.c) void;
     extern "c" fn gtk_widget_show_all(widget: ?*anyopaque) callconv(.c) void;
     extern "c" fn gtk_widget_destroy(widget: ?*anyopaque) callconv(.c) void;
     extern "c" fn gtk_get_current_event_time() callconv(.c) u32;
@@ -131,8 +133,8 @@ const impl = if (builtin.os.tag == .linux) struct {
                 const sep = gtk_separator_menu_item_new() orelse return;
                 gtk_menu_shell_append(menu, sep);
             },
-            .item => |it| addClickable(menu, it.label, it.click, it.enabled, null),
-            .checkbox => |it| addClickable(menu, it.label, it.click, it.enabled, it.checked),
+            .item => |it| addClickable(menu, it.label, it.click, it.enabled, null, it.visible),
+            .checkbox => |it| addClickable(menu, it.label, it.click, it.enabled, it.checked, it.visible),
             .submenu => |sub| {
                 var label_buf: [256]u8 = undefined;
                 const label_z = nullTerminateOrTruncate(sub.label, &label_buf) orelse return;
@@ -140,12 +142,20 @@ const impl = if (builtin.os.tag == .linux) struct {
                 const submenu = createGtkMenuFromItems(sub.items) orelse return;
                 gtk_menu_item_set_submenu(item_widget, submenu);
                 gtk_widget_set_sensitive(item_widget, if (sub.enabled) 1 else 0);
+                applyGtkVisible(item_widget, sub.visible);
                 gtk_menu_shell_append(menu, item_widget);
             },
         }
     }
 
-    fn addClickable(menu: *anyopaque, label: []const u8, click: []const u8, enabled: bool, checked: ?bool) void {
+    // visible=false → no_show_all 로 gtk_widget_show_all 의 강제표시를 막고 hidden 처리.
+    fn applyGtkVisible(widget: *anyopaque, visible: bool) void {
+        if (visible) return;
+        gtk_widget_set_no_show_all(widget, 1);
+        gtk_widget_set_visible(widget, 0);
+    }
+
+    fn addClickable(menu: *anyopaque, label: []const u8, click: []const u8, enabled: bool, checked: ?bool, visible: bool) void {
         var label_buf: [256]u8 = undefined;
         const label_z = nullTerminateOrTruncate(label, &label_buf) orelse return;
         const cb = firstFreeCallback() orelse return;
@@ -157,6 +167,7 @@ const impl = if (builtin.os.tag == .linux) struct {
         } else gtk_menu_item_new_with_label(label_z.ptr) orelse return;
 
         gtk_widget_set_sensitive(item_widget, if (enabled) 1 else 0);
+        applyGtkVisible(item_widget, visible);
         _ = g_signal_connect_data(item_widget, "activate", @ptrCast(&menuItemActivateC), cb, null, 0);
         gtk_menu_shell_append(menu, item_widget);
     }

--- a/src/platform/cef_menu_types.zig
+++ b/src/platform/cef_menu_types.zig
@@ -5,18 +5,26 @@ pub const ApplicationMenuItem = union(enum) {
         label: []const u8,
         click: []const u8,
         enabled: bool = true,
+        /// Electron MenuItem.id — UI 효과 없음(getMenuItemById 라운드트립용 식별자).
+        id: []const u8 = "",
+        /// Electron MenuItem.visible — false 면 메뉴에 존재하되 숨김(setHidden:).
+        visible: bool = true,
     },
     checkbox: struct {
         label: []const u8,
         click: []const u8,
         checked: bool = false,
         enabled: bool = true,
+        id: []const u8 = "",
+        visible: bool = true,
     },
     separator,
     submenu: struct {
         label: []const u8,
         enabled: bool = true,
         items: []const ApplicationMenuItem,
+        id: []const u8 = "",
+        visible: bool = true,
     },
 };
 

--- a/src/platform/cef_objc.zig
+++ b/src/platform/cef_objc.zig
@@ -227,6 +227,12 @@ pub fn setMenuItemEnabled(item: *anyopaque, enabled: bool) void {
     f(item, @ptrCast(objc.sel_registerName("setEnabled:")), if (enabled) 1 else 0);
 }
 
+/// Electron MenuItem.visible=false → NSMenuItem.setHidden:(메뉴에 존재하되 숨김).
+pub fn setMenuItemHidden(item: *anyopaque, hidden: bool) void {
+    const f: *const fn (?*anyopaque, ?*anyopaque, u8) callconv(.c) void = @ptrCast(&objc.objc_msgSend);
+    f(item, @ptrCast(objc.sel_registerName("setHidden:")), if (hidden) 1 else 0);
+}
+
 pub fn setMenuItemState(item: *anyopaque, checked: bool) void {
     const f: *const fn (?*anyopaque, ?*anyopaque, i64) callconv(.c) void = @ptrCast(&objc.objc_msgSend);
     f(item, @ptrCast(objc.sel_registerName("setState:")), if (checked) 1 else 0);

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -70,6 +70,7 @@ pub const representedObjectUtf8 = cef_objc.representedObjectUtf8;
 pub const nsFileUrlIfExists = cef_objc.nsFileUrlIfExists;
 pub const ensureSimpleObjcTarget = cef_objc.ensureSimpleObjcTarget;
 pub const setMenuItemEnabled = cef_objc.setMenuItemEnabled;
+pub const setMenuItemHidden = cef_objc.setMenuItemHidden;
 pub const setMenuItemState = cef_objc.setMenuItemState;
 pub const setMenuItemTag = cef_objc.setMenuItemTag;
 

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -2013,6 +2013,31 @@ test "window min/max size IPC + native wire" {
     }
 }
 
+test "MenuItem id + visible fields wired (types + parse + native apply)" {
+    const menu_main_src = try readMainSource();
+    defer std.testing.allocator.free(menu_main_src);
+    // main.zig parseApplicationMenuItem 가 id/visible 파싱.
+    inline for (.{
+        "util.jsonObjectGetString(obj, \"id\")",
+        "util.jsonObjectGetBool(obj, \"visible\")",
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, menu_main_src, needle) != null);
+    }
+
+    const menu_cef_src = try readCefSource();
+    defer std.testing.allocator.free(menu_cef_src);
+    inline for (.{
+        "id: []const u8 = \"\"", // cef_menu_types 새 필드
+        "visible: bool = true",
+        "pub fn setMenuItemHidden", // cef_objc 네이티브 헬퍼
+        "setMenuItemHidden(top, true)", // setApplicationMenu top-level 적용
+        "if (!visible) setMenuItemHidden(m, true)", // addAppMenuClickable 적용
+        "gtk_widget_set_no_show_all", // GTK visible 처리
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, menu_cef_src, needle) != null);
+    }
+}
+
 test "window mode flags IPC + CEF wire" {
     const mode_main_src = try readMainSource();
     defer std.testing.allocator.free(mode_main_src);

--- a/tests/e2e/menu.test.ts
+++ b/tests/e2e/menu.test.ts
@@ -71,6 +71,28 @@ describe("menu_set_application_menu — wiring + 응답", () => {
     expect(r.success).toBe(true);
   });
 
+  test.skipIf(!isDarwin)("id + visible:false 항목 — 파싱/네이티브 적용 무crash(success)", async () => {
+    // id 는 UI 효과 없음(라운드트립), visible:false 는 NSMenuItem.setHidden:. 네이티브가
+    // 새 필드로 거부/crash 하지 않고 success:true 면 통과(네이티브 메뉴는 DOM 부재라
+    // 가시 상태는 단언 불가 — enabled 와 동일 관측 경계).
+    const r = await core<{ success: boolean }>({
+      cmd: "menu_set_application_menu",
+      items: [
+        {
+          type: "submenu",
+          label: "Tools",
+          id: "tools-menu",
+          submenu: [
+            { label: "Hidden Item", click: "hidden", id: "hidden-item", visible: false },
+            { label: "Shown Item", click: "shown", visible: true },
+            { type: "checkbox", label: "Hidden Check", click: "hc", checked: true, visible: false },
+          ],
+        },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
   test.skipIf(!isDarwin)("Unicode 라벨 + click", async () => {
     const r = await core<{ success: boolean }>({
       cmd: "menu_set_application_menu",


### PR DESCRIPTION
Menu/MenuItem 패리티 배치 **PR-1 (Phase A: id + visible)** — 3-PR 분할 중 첫 PR(최저위험, audit `MenuItem.visible` 완료 + constructor-completeness Phase A).

## API (전 6 언어)
MenuItem 옵션 필드 2개 추가:
- **`id`** — getMenuItemById 식별자(UI 효과 없음, 라운드트립/저장)
- **`visible`** — false 면 항목 숨김(기본 true)

JS/Node optional 필드, Rust enum 필드, Go `*bool` omitempty(nil=기본 true 보존), lua/python `__core__` raw.

## 네이티브
- `cef_menu_types` ApplicationMenuItem(item/checkbox/submenu) + `main.zig` parseApplicationMenuItem 파싱.
- `cef_objc.setMenuItemHidden`(NSMenuItem.setHidden:) + re-export, `cef_menu`(macOS) top-level/clickable/submenu 적용.
- `cef_menu_linux`(GTK): `set_no_show_all`+`set_visible`(show_all 강제표시 회피), `applyGtkVisible` 헬퍼.
- 정직 경계: macOS/Linux 실효, **Windows no-op**(네이티브 메뉴 백엔드 부재).

## 검증
- e2e(menu): id+visible:false 항목 조합 → **success:true** (7 pass). 네이티브 메뉴는 DOM 부재라 가시상태 자동 단언 불가(enabled 동일 경계) — 직렬화는 Rust/Go 단위 테스트가 결정적 커버.
- unit: Rust/Go request-builder(id/visible 직렬화 + Go nil-omit 검증) + `cef_ipc_test`(types/parse/네이티브-apply/GTK substring 가드).
- 4 SDK 빌드 + suji-js dist rebuild + typecheck.

`/simplify` + `/code-review max`: **zero issues**(크로스플랫폼 가드 정상, Rust 브레이킹은 인-파일 테스트만 영향·갱신됨, Go pointer 의미 정확).

후속: PR-2(role/accelerator/icon — macOS NSMenuItem selector/keyEquivalent/NSImage), PR-3(Menu.getApplicationMenu/getMenuItemById/insert/sendActionToFirstResponder/will-close 이벤트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)