### PR TITLE
feat(menu): Menu.sendActionToFirstResponder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -583,6 +583,8 @@ suji.send('my-event', JSON.stringify({ msg: 'hello' }))
 // await menu.getMenuItemById(id) → MenuItem | null  — 스냅샷에서 id 재귀 탐색(submenu 포함).
 //   네이티브: set 성공 시 items 배열 raw 저장(g_app_menu_buf), reset 시 클리어. getMenuItemById
 //   는 SDK 가 getApplicationMenu 위에 구현(JS/Node/Rust/Go). 전 6개 언어.
+// await menu.sendActionToFirstResponder("copy:")  — macOS first responder(포커스된 web view)에
+//   표준 셀렉터 전달(NSApp.sendAction:to:from:). macOS only, Win/Linux no-op. 전 6개 언어.
 // await menu.popup([{label:"Run",click:"run"}], {x:10,y:10}) — suji.on('menu:click', ({click}) => ...)
 // import { screen, powerSaveBlocker, safeStorage, app, webRequest, session, crashReporter, autoUpdater } from '@suji/node'
 // const displays = await screen.getAllDisplays()                         (macOS NSScreen / Linux X11 screen)

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2275,6 +2275,17 @@ pub mod menu {
         invoke("__core__", r#"{"cmd":"menu_get_application_menu"}"#)
     }
 
+    /// Electron Menu.sendActionToFirstResponder — macOS first responder 에 표준 셀렉터
+    /// (예 "copy:") 전달. macOS only(Win/Linux no-op). raw `{"success":bool}`.
+    pub fn send_action_to_first_responder(action: &str) -> Option<String> {
+        let req = serde_json::json!({
+            "cmd": "menu_send_action_to_first_responder",
+            "action": action,
+        })
+        .to_string();
+        invoke("__core__", &req)
+    }
+
     /// Electron Menu.getMenuItemById — getApplicationMenu 스냅샷에서 id 로 재귀 탐색,
     /// 매칭 항목의 raw JSON 반환(없으면 None). 라이브 객체 아님.
     pub fn get_menu_item_by_id(id: &str) -> Option<String> {

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -117,7 +117,7 @@
 ### menu
 
 - ~~**[medium]** `Menu.getApplicationMenu()`~~ ✅ (Menu PR-4) — set 성공 시 items 배열 raw 스냅샷 저장(main.zig g_app_menu_buf, util.extractJsonArrayRaw), menu_get_application_menu cmd 에코, reset 시 클리어. 전 6개 언어. 정직 경계: 스냅샷(라이브 mutation 아님 — fire-and-forget).
-- **[medium]** `Menu.sendActionToFirstResponder` — Add menu.sendActionToFirstResponder(action: string): Promise<boolean> as a macOS-only API across all SDKs. In Zig core (cef.zig), implement a new cmd handler invoking NSApplication.sendAction(selector
+- ~~**[medium]** `Menu.sendActionToFirstResponder`~~ ✅ (Menu PR) — menu_send_action_to_first_responder cmd → cef_menu.sendActionToFirstResponder(NSApp `sendAction:to:from:` 로 셀렉터를 first responder 전달). 전 6개 언어. macOS only(Win/Linux no-op). 정직 경계: 결과는 responder chain(포커스) 의존이라 e2e 는 success boolean(무crash)만 검증.
 - ~~**[medium]** `menu.items / menu.getApplicationMenu()`~~ ✅ (Menu PR-4) — #119 와 동일(getApplicationMenu 전 SDK). menu.items 는 getApplicationMenu() 반환 배열.
 - **[medium]** `menu-will-close event` — Add `menu:will-close` (and ideally `menu:will-show` for parity) event emissions around the NSMenu modal popup lifecycle in cef.zig. Specifically: (1) Emit menu:will-show before line 3097's popUpMenuPo
 - **[medium]** `Menu.insert(pos: Integer, menuItem: MenuItem)` — Add Menu.insert(pos: number, menuItem: MenuItem) method to both @suji/api and @suji/node packages. Implementation: new IPC cmd menu_insert with pos + menuItem args, routed to cef.zig's menu handler (N

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -784,6 +784,9 @@ export declare const menu: {
     /** Electron `Menu.getMenuItemById(id)` — getApplicationMenu 스냅샷에서 id 로 재귀 탐색.
      *  없으면 null. (submenu 까지 깊이 탐색.) */
     getMenuItemById(id: string): Promise<MenuItem | null>;
+    /** Electron `Menu.sendActionToFirstResponder(action)` — macOS first responder(포커스된
+     *  web view)에 표준 셀렉터 전달(예 "copy:", "selectAll:"). macOS only, Win/Linux no-op. */
+    sendActionToFirstResponder(action: string): Promise<boolean>;
     /** 임의 위치 컨텍스트 메뉴 (Electron `Menu.popup({x?,y?})`). x/y 미지정 시
      *  현재 커서(화면 좌표, macOS bottom-up). 선택은 `suji.on('menu:click',
      *  ({click}) => ...)` 로 수신 (setApplicationMenu 와 동일). macOS NSMenu

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -1001,6 +1001,12 @@ export const menu = {
         };
         return find(await menu.getApplicationMenu());
     },
+    /** Electron `Menu.sendActionToFirstResponder(action)` — macOS first responder(포커스된
+     *  web view)에 표준 셀렉터 전달(예 "copy:", "selectAll:"). macOS only, Win/Linux no-op. */
+    async sendActionToFirstResponder(action) {
+        const r = await coreCall({ cmd: "menu_send_action_to_first_responder", action });
+        return r.success === true;
+    },
     /** 임의 위치 컨텍스트 메뉴 (Electron `Menu.popup({x?,y?})`). x/y 미지정 시
      *  현재 커서(화면 좌표, macOS bottom-up). 선택은 `suji.on('menu:click',
      *  ({click}) => ...)` 로 수신 (setApplicationMenu 와 동일). macOS NSMenu

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -1510,6 +1510,13 @@ export const menu = {
     return find(await menu.getApplicationMenu());
   },
 
+  /** Electron `Menu.sendActionToFirstResponder(action)` — macOS first responder(포커스된
+   *  web view)에 표준 셀렉터 전달(예 "copy:", "selectAll:"). macOS only, Win/Linux no-op. */
+  async sendActionToFirstResponder(action: string): Promise<boolean> {
+    const r = await coreCall<{ success: boolean }>({ cmd: "menu_send_action_to_first_responder", action });
+    return r.success === true;
+  },
+
   /** 임의 위치 컨텍스트 메뉴 (Electron `Menu.popup({x?,y?})`). x/y 미지정 시
    *  현재 커서(화면 좌표, macOS bottom-up). 선택은 `suji.on('menu:click',
    *  ({click}) => ...)` 로 수신 (setApplicationMenu 와 동일). macOS NSMenu

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -1777,6 +1777,13 @@ export const menu = {
     };
     return find(await menu.getApplicationMenu());
   },
+
+  /** Electron `Menu.sendActionToFirstResponder(action)` — macOS first responder 에 표준
+   *  셀렉터 전달(예 "copy:"). macOS only, Win/Linux no-op. */
+  async sendActionToFirstResponder(action: string): Promise<boolean> {
+    const r = await invoke<{ success: boolean }>('__core__', { cmd: 'menu_send_action_to_first_responder', action });
+    return r.success === true;
+  },
 };
 
 // ============================================

--- a/sdks/suji-go/menu/menu.go
+++ b/sdks/suji-go/menu/menu.go
@@ -69,6 +69,16 @@ func GetApplicationMenu() string {
 	return suji.Invoke("__core__", `{"cmd":"menu_get_application_menu"}`)
 }
 
+// SendActionToFirstResponder sends a standard selector (e.g. "copy:") to the macOS
+// first responder (Electron Menu.sendActionToFirstResponder). macOS only; Win/Linux no-op.
+func SendActionToFirstResponder(action string) string {
+	req, _ := json.Marshal(map[string]any{
+		"cmd":    "menu_send_action_to_first_responder",
+		"action": action,
+	})
+	return suji.Invoke("__core__", string(req))
+}
+
 // GetMenuItemByID searches the getApplicationMenu snapshot for an item with the given
 // id (recursing into submenus) and returns it, or nil if not found (Electron
 // Menu.getMenuItemById). Not a live object.

--- a/src/main.zig
+++ b/src/main.zig
@@ -2957,6 +2957,11 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
     if (std.mem.eql(u8, cmd, "menu_get_application_menu")) {
         return handleMenuGetApplicationMenu(response_buf);
     }
+    if (std.mem.eql(u8, cmd, "menu_send_action_to_first_responder")) {
+        const action = util.extractJsonString(req_clean, "action") orelse "";
+        const ok = cef.sendActionToFirstResponder(action);
+        return std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"menu_send_action_to_first_responder\",\"success\":{}}}", .{ok}) catch null;
+    }
     if (std.mem.eql(u8, cmd, "menu_popup")) {
         return handleMenuPopup(req_clean, response_buf);
     }

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -119,6 +119,7 @@ pub const MenuEmitHandler = cef_public_api.MenuEmitHandler;
 pub const setMenuEmitHandler = cef_public_api.setMenuEmitHandler;
 pub const setApplicationMenu = cef_public_api.setApplicationMenu;
 pub const resetApplicationMenu = cef_public_api.resetApplicationMenu;
+pub const sendActionToFirstResponder = cef_public_api.sendActionToFirstResponder;
 pub const popupContextMenu = cef_public_api.popupContextMenu;
 pub const TrayMenuItem = cef_public_api.TrayMenuItem;
 pub const TrayEmitHandler = cef_public_api.TrayEmitHandler;

--- a/src/platform/cef_menu.zig
+++ b/src/platform/cef_menu.zig
@@ -96,6 +96,24 @@ pub fn resetApplicationMenu() bool {
     return true;
 }
 
+/// Electron `Menu.sendActionToFirstResponder(action)` — macOS `[NSApp sendAction:to:from:]`
+/// 로 표준 셀렉터(예 "copy:", "selectAll:")를 first responder(포커스된 web view)에 전달.
+/// macOS only(Win/Linux no-op). action 은 ObjC 셀렉터명. 전달 성공 시 true.
+pub fn sendActionToFirstResponder(action: []const u8) bool {
+    if (!comptime is_macos) return false;
+    if (action.len == 0 or action.len >= 255) return false;
+    var buf: [256]u8 = undefined;
+    @memcpy(buf[0..action.len], action);
+    buf[action.len] = 0;
+    const NSApplication = getClass("NSApplication") orelse return false;
+    const app = msgSend(NSApplication, "sharedApplication") orelse return false;
+    const action_sel = objc.sel_registerName(@ptrCast(&buf));
+    const send_sel = objc.sel_registerName("sendAction:to:from:");
+    const f: *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) u8 =
+        @ptrCast(&objc.objc_msgSend);
+    return f(app, @ptrCast(send_sel), @ptrCast(action_sel), null, null) != 0;
+}
+
 /// Electron `Menu.popup({x?,y?})` 대응 — 임의 위치 컨텍스트 메뉴.
 /// NSMenu `popUpMenuPositioningItem:atLocation:inView:` (item=nil →
 /// 메뉴 좌상단이 location, view=nil → location 을 화면 좌표로 해석).

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -313,6 +313,7 @@ pub const MenuEmitHandler = cef_menu.MenuEmitHandler;
 pub const setMenuEmitHandler = cef_menu.setMenuEmitHandler;
 pub const setApplicationMenu = cef_menu.setApplicationMenu;
 pub const resetApplicationMenu = cef_menu.resetApplicationMenu;
+pub const sendActionToFirstResponder = cef_menu.sendActionToFirstResponder;
 pub const popupContextMenu = cef_menu.popupContextMenu;
 
 pub const TrayMenuItem = cef_tray.TrayMenuItem;

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -2063,6 +2063,25 @@ test "Menu.getApplicationMenu IPC + items 스냅샷 저장/에코" {
     }
 }
 
+test "Menu.sendActionToFirstResponder IPC + CEF wire" {
+    const sa_main_src = try readMainSource();
+    defer std.testing.allocator.free(sa_main_src);
+    inline for (.{
+        "\"menu_send_action_to_first_responder\"",
+        "cef.sendActionToFirstResponder",
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, sa_main_src, needle) != null);
+    }
+    const sa_cef_src = try readCefSource();
+    defer std.testing.allocator.free(sa_cef_src);
+    inline for (.{
+        "pub fn sendActionToFirstResponder",
+        "sendAction:to:from:", // NSApp 셀렉터 전달
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, sa_cef_src, needle) != null);
+    }
+}
+
 test "window mode flags IPC + CEF wire" {
     const mode_main_src = try readMainSource();
     defer std.testing.allocator.free(mode_main_src);

--- a/tests/e2e/menu.test.ts
+++ b/tests/e2e/menu.test.ts
@@ -148,6 +148,24 @@ describe("menu_set_application_menu — wiring + 응답", () => {
     expect(got.items).toEqual([]);
   });
 
+  test.skipIf(!isDarwin)("sendActionToFirstResponder: 셀렉터 전달 → success boolean", async () => {
+    // NSApp.sendAction:to:from: 결과는 responder chain(포커스) 의존이라 값 단언 불가 —
+    // 무crash + success boolean(wire/네이티브 호출 정상)만 검증.
+    const r = await core<{ success: boolean }>({
+      cmd: "menu_send_action_to_first_responder",
+      action: "selectAll:",
+    });
+    expect(typeof r.success).toBe("boolean");
+  });
+
+  test.skipIf(isDarwin)("sendActionToFirstResponder non-darwin → success:false", async () => {
+    const r = await core<{ success: boolean }>({
+      cmd: "menu_send_action_to_first_responder",
+      action: "selectAll:",
+    });
+    expect(r.success).toBe(false);
+  });
+
   test.skipIf(!isDarwin)("resetApplicationMenu 정상", async () => {
     const r = await core<{ success: boolean }>({ cmd: "menu_reset_application_menu" });
     expect(r.success).toBe(true);


### PR DESCRIPTION
Menu 마무리 — Electron `Menu.sendActionToFirstResponder(action)`. audit 완료.

## API (전 6 언어)
`menu.sendActionToFirstResponder("copy:")` → macOS first responder(포커스된 web view)에 표준 ObjC 셀렉터 전달. macOS only, Win/Linux no-op.

## 네이티브
`menu_send_action_to_first_responder` cmd → `cef_menu.sendActionToFirstResponder`(NSApp `sendAction:to:from:`). re-export cef_menu→cef_public_api→cef.

## 검증
- e2e(menu): `selectAll:` 전달 → success boolean(darwin), non-darwin→false (9 pass). 정직 경계: sendAction 결과는 responder chain(포커스) 의존이라 success boolean(무crash)만 검증.
- unit: `cef_ipc_test`(cmd/handler/`sendAction:to:from:` 가드). 4 SDK 빌드 + suji-js dist.

`/simplify` + `/code-review max`: **zero bugs**(msgSend 5-param 캐스트, 버퍼 null-term, 크로스플랫폼, SDK 일관성).

남은 Menu(저가치 tail): icon(per-item fs-gate+param refactor), insert(snapshot splice — fire-and-forget 모델상 redundant), menu-will-close(event, 새 emit 채널 plumbing, popup-only best-effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)