### PR TITLE
feat(ipc,powerSaveBlocker): removeAllListeners + handleOnce + isStarted (+Zig SDK catch-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,9 @@ fn onAllClosed(_: suji.Event) void {
 //   (CEF Crashpad/Breakpad 1차. 첫 프로세스 enable은 app.crashReporter cfg 필요,
 //   getUploadedReports/getLastCrashReport는 로컬 Crashpad DB(completed dumps) 조회,
 //   실제 crash 유발/upload 서버 검증은 후속 정직 경계)
-// suji.powerSaveBlocker.start("prevent_display_sleep") / stop(id)
-//   (macOS IOPMAssertion, Linux XScreenSaverSuspend, Windows Power Request API)
+// suji.powerSaveBlocker.start("prevent_display_sleep") / stop(id) / isStarted(id)
+//   (macOS IOPMAssertion, Linux XScreenSaverSuspend, Windows Power Request API;
+//    isStarted=전 플랫폼 power_save_started_ids 추적 테이블)
 // suji.safeStorage.setItem(svc, acc, "v") / getItem(svc, acc) / deleteItem(svc, acc)
 //                                       (macOS Keychain, Linux libsecret, Windows Credential Manager)
 // suji.dock.setBadge("99") / getBadge()        — dock 배지 (macOS NSDockTile)
@@ -489,7 +490,7 @@ suji.platform                                                // "macos" | "linux
 // await autoUpdater.quitAndInstall(prepared, {relaunch:true})              (macOS/Linux shell helper, Windows PowerShell helper)
 //                                                                         (manifest check + download + SHA-256 verify + quit-and-install)
 // const id = await powerSaveBlocker.start("prevent_display_sleep")
-// await powerSaveBlocker.stop(id)                                         (macOS/Linux/Windows)
+// await powerSaveBlocker.stop(id) / await powerSaveBlocker.isStarted(id)  (macOS/Linux/Windows)
 // await safeStorage.setItem(svc, acc, "v") / getItem(svc, acc) / deleteItem(svc, acc)
 //                                                                         (macOS Keychain, Linux libsecret, Windows Credential Manager)
 // await app.dock.setBadge("99") / app.dock.getBadge()                     (macOS NSDockTile)

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2731,6 +2731,10 @@ pub mod power_save_blocker {
         serde_json::json!({ "cmd": "power_save_blocker_stop", "id": id }).to_string()
     }
 
+    pub(crate) fn is_started_request(id: u32) -> String {
+        serde_json::json!({ "cmd": "power_save_blocker_is_started", "id": id }).to_string()
+    }
+
     /// `"prevent_app_suspension"` | `"prevent_display_sleep"`. 응답: `{"id":N}`.
     pub fn start(type_str: &str) -> Option<String> {
         invoke("__core__", &start_request(type_str))
@@ -2739,6 +2743,11 @@ pub mod power_save_blocker {
     /// 응답: `{"success":bool}`.
     pub fn stop(id: u32) -> Option<String> {
         invoke("__core__", &stop_request(id))
+    }
+
+    /// blocker 활성 여부(Electron powerSaveBlocker.isStarted). 응답: `{"started":bool}`.
+    pub fn is_started(id: u32) -> Option<String> {
+        invoke("__core__", &is_started_request(id))
     }
 }
 

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -106,13 +106,13 @@
 
 - ~~**[medium]** `globalShortcut.registerAll`~~ ✅ (globalShortcut PR) — registerAll(accelerators[], click) 전 4 SDK. 기존 register 를 순회(JS/Node=Promise.all → 집계 boolean; Rust=Vec<Option<String>>, Go=[]string raw 응답 배열, 각 SDK register 규약 따름). 신규 IPC 없음. 성공분 유지/롤백 없음(Electron 은 void 반환).
 - ~~**[medium]** `globalShortcut.unregisterAll`~~ ✅ — Change return type of unregisterAll from Promise<boolean> to Promise<void> in: (1) packages/suji-js/src/index.ts lines 1001-1003, and (2) packages/suji-node/src/index.ts lines 1141-1144. This matches 
-- ~~**[medium]** `globalShortcut.setSuspended`~~ ✅ (globalShortcut PR) — setSuspended(bool) 전 4 SDK. `global_shortcut_set_suspended` cmd → cef_global_shortcut_state.g_suspended. suspended 동안 emit() 게이트가 trigger 발신만 차단(등록 유지, isRegistered true). 전 플랫폼 공용(emit 단일 게이트, 네이티브 unregister 아님 — 정직 경계: OS-level grab 은 유지).
-- ~~**[medium]** `globalShortcut.isSuspended`~~ ✅ (globalShortcut PR) — isSuspended() 전 4 SDK. `global_shortcut_is_suspended` cmd → cef_global_shortcut_state.g_suspended getter. setSuspended 와 짝(emit 게이트). ※ .m 의 static 대신 Zig gs_state 의 공용 게이트로 구현(전 플랫폼 단일 출처).
+- ~~**[medium]** `globalShortcut.setSuspended`~~ ✅ (globalShortcut PR; Zig SDK ipc/power PR) — setSuspended(bool) 전 5 SDK(Zig 백엔드 포함). `global_shortcut_set_suspended` cmd → cef_global_shortcut_state.g_suspended. suspended 동안 emit() 게이트가 trigger 발신만 차단(등록 유지, isRegistered true). 전 플랫폼 공용(emit 단일 게이트, 네이티브 unregister 아님 — 정직 경계: OS-level grab 은 유지).
+- ~~**[medium]** `globalShortcut.isSuspended`~~ ✅ (globalShortcut PR; Zig SDK ipc/power PR) — isSuspended() 전 5 SDK(Zig 백엔드 포함). `global_shortcut_is_suspended` cmd → cef_global_shortcut_state.g_suspended getter. setSuspended 와 짝(emit 게이트). ※ .m 의 static 대신 Zig gs_state 의 공용 게이트로 구현(전 플랫폼 단일 출처).
 
 ### ipc
 
-- **[medium]** `ipcRenderer.removeAllListeners([channel])` — In /Users/yoonhb/Documents/workspace/suji/packages/suji-js/src/index.ts (line 136-139): Add a TypeScript overload: `export function off(event?: string): void;` then update implementation to handle und
-- **[medium]** `ipcMainHandleOnce` — Add handleOnce to packages/suji-node/src/index.ts after handle() at line 114. Wrapper that registers handler and auto-unregisters after first invocation using closure variable. Maintains HandlerFn typ
+- ~~**[medium]** `ipcRenderer.removeAllListeners([channel])`~~ ✅ (ipc PR) — `off(event?)` optional: 채널 지정 시 해당 채널, 생략 시 전 채널 리스너 해제. 렌더러 브릿지 `s.off` 가 event 미지정 시 `_listeners` 전체 클리어(frozen bridge 라 property 재할당 불가 → inner 키 delete 로 클리어). e2e(off(channel) 단일 vs off() 전체) 검증.
+- ~~**[medium]** `ipcMainHandleOnce`~~ ✅ (ipc PR) — `handleOnce(channel, handler)` @suji/node. 첫 invoke 만 처리 후 채널을 consumed 핸들러로 교체(g_handlers 덮어쓰기). 정직 경계: suji 네이티브 removeHandler 부재라 진짜 unregister 아님 — 이후 invoke 는 `{error:"handler consumed (handleOnce)"}` 반환(Electron 의 'no handler' reject 와 관측 차이).
 
 ### menu
 
@@ -130,13 +130,13 @@
 
 ### nativeImage
 
-- ~~**[medium]** `image.isEmpty()`~~ ✅ (nativeImage PR) — nativeImage.isEmpty(path) @suji/api + @suji/node. `native_image_is_empty` cmd → cef.nativeImageIsEmpty(nativeImageGetSize 재사용 — 로드 실패/크기 0=true). 렌더러 경로 rendererPathFsGate.
-- ~~**[medium]** `nativeImage.isTemplateImage()`~~ ✅ (nativeImage PR) — nativeImage.isTemplateImage(path) @suji/api + @suji/node. `native_image_is_template` cmd → cef.nativeImageIsTemplate(macOS NSImage.isTemplate). 렌더러 경로 rendererPathFsGate. 정직 경계: macOS only(Win/Linux false). CEF feasibility 분석은 cef_image_t 기준 BLOCKED 라 봤으나 suji 는 NSImage 직접 사용이라 NATIVE-OK.
+- ~~**[medium]** `image.isEmpty()`~~ ✅ (nativeImage PR; Zig SDK ipc/power PR) — nativeImage.isEmpty(path) 전 5 SDK(@suji/api + @suji/node + Rust + Go + Zig 백엔드). `native_image_is_empty` cmd → cef.nativeImageIsEmpty(nativeImageGetSize 재사용 — 로드 실패/크기 0=true). 렌더러 경로 rendererPathFsGate.
+- ~~**[medium]** `nativeImage.isTemplateImage()`~~ ✅ (nativeImage PR; Zig SDK ipc/power PR) — nativeImage.isTemplateImage(path) 전 5 SDK(@suji/api + @suji/node + Rust + Go + Zig 백엔드). `native_image_is_template` cmd → cef.nativeImageIsTemplate(macOS NSImage.isTemplate). 렌더러 경로 rendererPathFsGate. 정직 경계: macOS only(Win/Linux false). CEF feasibility 분석은 cef_image_t 기준 BLOCKED 라 봤으나 suji 는 NSImage 직접 사용이라 NATIVE-OK.
 
 ### nativeTheme
 
-- ~~**[medium]** `nativeTheme.shouldUseHighContrastColors`~~ ✅ (nativeTheme PR) — shouldUseHighContrastColors() 전 4 SDK(@suji/api + @suji/node + Rust + Go). macOS NSWorkspace.accessibilityDisplayShouldIncreaseContrast(workspaceBool→msgSendBool 공용 헬퍼) + **Windows SystemParametersInfo(SPI_GETHIGHCONTRAST) HCF_HIGHCONTRASTON**(win_theme.highContrast). `native_theme_high_contrast` cmd. 정직 경계: Linux false(미지원).
-- ~~**[medium]** `nativeTheme.prefersReducedTransparency`~~ ✅ (nativeTheme PR) — prefersReducedTransparency() 전 4 SDK. macOS NSWorkspace.accessibilityDisplayShouldReduceTransparency + **Windows HKCU EnableTransparency==0**(win_theme.reducedTransparency). `native_theme_reduced_transparency` cmd. 정직 경계: Linux false(미지원).
+- ~~**[medium]** `nativeTheme.shouldUseHighContrastColors`~~ ✅ (nativeTheme PR; Zig SDK ipc/power PR) — shouldUseHighContrastColors() 전 5 SDK(@suji/api + @suji/node + Rust + Go + Zig 백엔드). macOS NSWorkspace.accessibilityDisplayShouldIncreaseContrast(workspaceBool→msgSendBool 공용 헬퍼) + **Windows SystemParametersInfo(SPI_GETHIGHCONTRAST) HCF_HIGHCONTRASTON**(win_theme.highContrast). `native_theme_high_contrast` cmd. 정직 경계: Linux false(미지원).
+- ~~**[medium]** `nativeTheme.prefersReducedTransparency`~~ ✅ (nativeTheme PR; Zig SDK ipc/power PR) — prefersReducedTransparency() 전 5 SDK(Zig 백엔드 포함). macOS NSWorkspace.accessibilityDisplayShouldReduceTransparency + **Windows HKCU EnableTransparency==0**(win_theme.reducedTransparency). `native_theme_reduced_transparency` cmd. 정직 경계: Linux false(미지원).
 
 ### notification
 
@@ -154,7 +154,7 @@
 
 ### powerSaveBlocker
 
-- **[medium]** `powerSaveBlocker.isStarted(id)` — Add isStarted(id: number) -> Promise<boolean> method to powerSaveBlocker in both @suji/api and @suji/node. Implement a new Zig command handler power_save_blocker_is_started in src/main.zig that mainta
+- ~~**[medium]** `powerSaveBlocker.isStarted(id)`~~ ✅ (ipc/power PR) — isStarted(id) **전 5 SDK**(@suji/api + @suji/node + Rust + Go + Zig 백엔드 src/core/app.zig). `power_save_blocker_is_started` cmd → cef.powerSaveBlockerIsStarted. 전 플랫폼 단일 추적 테이블(power_save_started_ids) — start 시 기록/stop 시 제거(성공 무관: stop 요청=추적 해제, 네이티브 release 실패에도 isStarted 거짓-true 방지). macOS 는 IOPMAssertion id 라 entry table 미사용 → 이 테이블로 통일. 정직 경계: 64개 동시 추적(macOS uncapped start 65번째+ 는 추적 슬롯 부족, 비현실적). e2e(start→true, stop→false, unknown→false). **catch-up: 이 PR 이 Zig 백엔드 SDK(app.zig)에 nativeTheme highContrast/reducedTransparency, nativeImage isEmpty/isTemplateImage, globalShortcut setSuspended/isSuspended, powerSaveBlocker isStarted 를 추가 — #117/#118 누락분 보강(5번째 SDK 파리티).**
 
 ### screen
 

--- a/documents/events.mdx
+++ b/documents/events.mdx
@@ -100,7 +100,9 @@ session.setPermissionRequestHandler((details) => {
 | `ipcRenderer.invoke(ch, ...args)` | `suji.invoke(ch, data, options)` — data는 단일 객체 |
 | `ipcRenderer.send(ch, data)` | `suji.send(ch, data)` |
 | `ipcRenderer.on(ch, fn)` | `suji.on(ch, fn)` |
+| `ipcRenderer.removeAllListeners([ch])` | `suji.off(ch?)` — ch 생략 시 전 채널 해제 |
 | `ipcMain.handle(ch, (event, ...args) => {})` | 백엔드 `handle(ch, (req, event) => {})` |
+| `ipcMain.handleOnce(ch, fn)` | 백엔드 `handleOnce(ch, fn)` — 첫 invoke 만 처리(이후 consumed 응답) |
 | `ipcMain.on(ch, fn)` | 백엔드 `on(ch, fn)` |
 | `event.sender` / `BrowserWindow.fromWebContents(e.sender)` | `event.window` rich 객체 (`{id, name}`) |
 | `win.webContents.send(ch, data)` | `suji.send(ch, data, {to: winId})` / Zig `suji.sendTo(id, ch, data)` |

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -83,9 +83,10 @@ export declare function once(event: string, callback: Listener): () => void;
  */
 export declare function send(event: string, data: unknown, options?: SendOptions): void;
 /**
- * 채널의 모든 리스너 해제 (Electron: ipcRenderer.removeAllListeners)
+ * 리스너 해제 (Electron: ipcRenderer.removeAllListeners([channel])).
+ * `event` 지정 시 해당 채널의 모든 리스너 해제, 생략 시 **전 채널** 리스너 해제.
  */
-export declare function off(event: string): void;
+export declare function off(event?: string): void;
 export type TitleBarStyle = "default" | "hidden" | "hiddenInset";
 export interface WindowOptions {
     /** 창 타이틀 */
@@ -1284,6 +1285,8 @@ export declare const powerSaveBlocker: {
     start(type: PowerSaveBlockerType): Promise<number>;
     /** start로 받은 id를 해제. unknown id는 false. */
     stop(id: number): Promise<boolean>;
+    /** blocker 가 활성(시작됨) 상태인지 (Electron `powerSaveBlocker.isStarted`). */
+    isStarted(id: number): Promise<boolean>;
 };
 export declare const safeStorage: {
     /** service+account에 utf-8 value 저장. 같은 키면 update (idempotent). */

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -74,7 +74,8 @@ export function send(event, data, options) {
     getBridge().emit(event, JSON.stringify(data ?? {}), options?.to);
 }
 /**
- * 채널의 모든 리스너 해제 (Electron: ipcRenderer.removeAllListeners)
+ * 리스너 해제 (Electron: ipcRenderer.removeAllListeners([channel])).
+ * `event` 지정 시 해당 채널의 모든 리스너 해제, 생략 시 **전 채널** 리스너 해제.
  */
 export function off(event) {
     const bridge = window.__suji__;
@@ -1699,6 +1700,11 @@ export const powerSaveBlocker = {
     async stop(id) {
         const r = await coreCall({ cmd: "power_save_blocker_stop", id });
         return r.success === true;
+    },
+    /** blocker 가 활성(시작됨) 상태인지 (Electron `powerSaveBlocker.isStarted`). */
+    async isStarted(id) {
+        const r = await coreCall({ cmd: "power_save_blocker_is_started", id });
+        return r.started === true;
     },
 };
 // ============================================

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -131,9 +131,10 @@ export function send(event: string, data: unknown, options?: SendOptions): void 
 }
 
 /**
- * 채널의 모든 리스너 해제 (Electron: ipcRenderer.removeAllListeners)
+ * 리스너 해제 (Electron: ipcRenderer.removeAllListeners([channel])).
+ * `event` 지정 시 해당 채널의 모든 리스너 해제, 생략 시 **전 채널** 리스너 해제.
  */
-export function off(event: string): void {
+export function off(event?: string): void {
   const bridge = (window as any).__suji__;
   if (bridge?.off) bridge.off(event);
 }
@@ -2655,6 +2656,12 @@ export const powerSaveBlocker = {
   async stop(id: number): Promise<boolean> {
     const r = await coreCall<{ success: boolean }>({ cmd: "power_save_blocker_stop", id });
     return r.success === true;
+  },
+
+  /** blocker 가 활성(시작됨) 상태인지 (Electron `powerSaveBlocker.isStarted`). */
+  async isStarted(id: number): Promise<boolean> {
+    const r = await coreCall<{ started: boolean }>({ cmd: "power_save_blocker_is_started", id });
+    return r.started === true;
   },
 };
 

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -113,6 +113,29 @@ export function handle<TReq = unknown, TRes = unknown>(
   });
 }
 
+/**
+ * Electron `ipcMain.handleOnce(channel, handler)` — 첫 invoke 만 처리하고 소비.
+ * ※ suji 는 네이티브 removeHandler 가 없어 진짜 unregister 가 아니라, 첫 호출 후
+ *   채널을 "consumed" 핸들러로 교체한다(이후 invoke 는 `{error:"handler consumed (handleOnce)"}`
+ *   를 반환 — Electron 의 'no handler' reject 와 관측 차이, 정직 경계).
+ */
+export function handleOnce<TReq = unknown, TRes = unknown>(
+  channel: string,
+  handler: HandlerFn<TReq, TRes>,
+): void {
+  // onceWrapper 는 arity 2 → handle 이 항상 (data, event) 전달. 사용자 handler 가 arity 1
+  // 이면 여분 event 는 JS 가 무시(별도 arity 분기 불필요 — handle 이 이미 처리).
+  const onceWrapper = (data: TReq, event: InvokeEvent): TRes => {
+    try {
+      return (handler as (d: TReq, e: InvokeEvent) => TRes)(data, event);
+    } finally {
+      // 소비 후 교체 — g_handlers[channel] 덮어쓰기(재등록). 다음 invoke 부터 consumed.
+      handle(channel, (() => JSON.stringify({ error: 'handler consumed (handleOnce)' })) as HandlerFn);
+    }
+  };
+  handle<TReq, TRes>(channel, onceWrapper as HandlerFn<TReq, TRes>);
+}
+
 // ============================================
 // Cross-backend invocation
 // ============================================
@@ -2324,6 +2347,12 @@ export const powerSaveBlocker = {
   async stop(id: number): Promise<boolean> {
     const r = await invoke<{ success: boolean }>('__core__', { cmd: 'power_save_blocker_stop', id });
     return r.success === true;
+  },
+
+  /** blocker 가 활성(시작됨) 상태인지 (Electron `powerSaveBlocker.isStarted`). */
+  async isStarted(id: number): Promise<boolean> {
+    const r = await invoke<{ started: boolean }>('__core__', { cmd: 'power_save_blocker_is_started', id });
+    return r.started === true;
   },
 };
 

--- a/sdks/suji-go/powersaveblocker/powersaveblocker.go
+++ b/sdks/suji-go/powersaveblocker/powersaveblocker.go
@@ -20,10 +20,20 @@ func Stop(id uint32) string {
 	return suji.Invoke("__core__", buildStopRequest(id))
 }
 
+// IsStarted reports whether the blocker id is active (Electron powerSaveBlocker.isStarted).
+// Response: `{"started":bool}`.
+func IsStarted(id uint32) string {
+	return suji.Invoke("__core__", buildIsStartedRequest(id))
+}
+
 func buildStartRequest(typeStr string) string {
 	return fmt.Sprintf(`{"cmd":"power_save_blocker_start","type":"%s"}`, jsonesc.Full(typeStr))
 }
 
 func buildStopRequest(id uint32) string {
 	return fmt.Sprintf(`{"cmd":"power_save_blocker_stop","id":%d}`, id)
+}
+
+func buildIsStartedRequest(id uint32) string {
+	return fmt.Sprintf(`{"cmd":"power_save_blocker_is_started","id":%d}`, id)
 }

--- a/src/core/app.zig
+++ b/src/core/app.zig
@@ -1049,6 +1049,24 @@ pub const nativeImage = struct {
         const fields = std.fmt.bufPrint(&fields_buf, "\"path\":\"{s}\",\"quality\":{d}", .{ p_buf[0..p_n], quality }) catch return null;
         return coreCmd("native_image_to_jpeg", fields);
     }
+
+    /// 이미지가 비어있는지(로드 실패/크기 0). 응답: `{"isEmpty":bool}`.
+    pub fn isEmpty(path: []const u8) ?[]const u8 {
+        var p_buf: [4096]u8 = undefined;
+        const p_n = util.escapeJsonStrFull(path, &p_buf) orelse return null;
+        var fields_buf: [4200]u8 = undefined;
+        const fields = std.fmt.bufPrint(&fields_buf, "\"path\":\"{s}\"", .{p_buf[0..p_n]}) catch return null;
+        return coreCmd("native_image_is_empty", fields);
+    }
+
+    /// template 이미지 여부(macOS NSImage.isTemplate). 응답: `{"isTemplate":bool}`.
+    pub fn isTemplateImage(path: []const u8) ?[]const u8 {
+        var p_buf: [4096]u8 = undefined;
+        const p_n = util.escapeJsonStrFull(path, &p_buf) orelse return null;
+        var fields_buf: [4200]u8 = undefined;
+        const fields = std.fmt.bufPrint(&fields_buf, "\"path\":\"{s}\"", .{p_buf[0..p_n]}) catch return null;
+        return coreCmd("native_image_is_template", fields);
+    }
 };
 
 pub const nativeTheme = struct {
@@ -1064,6 +1082,16 @@ pub const nativeTheme = struct {
         var fields_buf: [64]u8 = undefined;
         const fields = std.fmt.bufPrint(&fields_buf, "\"source\":\"{s}\"", .{s_buf[0..s_n]}) catch return null;
         return coreCmd("native_theme_set_source", fields);
+    }
+
+    /// 고대비 모드 여부(macOS/Windows; Linux false). 응답: `{"highContrast":bool}`.
+    pub fn shouldUseHighContrastColors() ?[]const u8 {
+        return coreCmd("native_theme_high_contrast", "");
+    }
+
+    /// 투명도 감소 선호(macOS/Windows; Linux false). 응답: `{"reducedTransparency":bool}`.
+    pub fn prefersReducedTransparency() ?[]const u8 {
+        return coreCmd("native_theme_reduced_transparency", "");
     }
 };
 
@@ -1309,6 +1337,20 @@ pub const globalShortcut = struct {
         const fields = std.fmt.bufPrint(&fields_buf, "\"accelerator\":\"{s}\"", .{a_buf[0..a_n]}) catch return null;
         return coreCmd("global_shortcut_is_registered", fields);
     }
+
+    /// suspended 토글(Electron globalShortcut.setSuspended). 등록 유지, trigger 발신만 차단.
+    /// 응답: `{"success":bool}`.
+    pub fn setSuspended(suspended: bool) ?[]const u8 {
+        var fields_buf: [32]u8 = undefined;
+        const fields = std.fmt.bufPrint(&fields_buf, "\"suspended\":{}", .{suspended}) catch return null;
+        return coreCmd("global_shortcut_set_suspended", fields);
+    }
+
+    /// 현재 suspended 상태(Electron globalShortcut.isSuspended). 응답: `{"suspended":bool}`.
+    /// registerAll 은 Zig 백엔드가 register 를 직접 순회(공유 응답 버퍼라 SDK 집계 미제공).
+    pub fn isSuspended() ?[]const u8 {
+        return coreCmd("global_shortcut_is_suspended", "");
+    }
 };
 
 pub const dialog = struct {
@@ -1475,6 +1517,13 @@ pub const powerSaveBlocker = struct {
         var fields_buf: [32]u8 = undefined;
         const fields = std.fmt.bufPrint(&fields_buf, "\"id\":{d}", .{id}) catch return null;
         return coreCmd("power_save_blocker_stop", fields);
+    }
+
+    /// blocker 활성 여부(Electron powerSaveBlocker.isStarted). 응답: `{"started":bool}`.
+    pub fn isStarted(id: u32) ?[]const u8 {
+        var fields_buf: [32]u8 = undefined;
+        const fields = std.fmt.bufPrint(&fields_buf, "\"id\":{d}", .{id}) catch return null;
+        return coreCmd("power_save_blocker_is_started", fields);
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -2445,6 +2445,14 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         ) catch return null;
         return result;
     }
+    if (std.mem.eql(u8, cmd, "power_save_blocker_is_started")) {
+        const id_n = util.extractJsonInt(req_clean, "id") orelse 0;
+        return std.fmt.bufPrint(
+            response_buf,
+            "{{\"from\":\"zig-core\",\"cmd\":\"power_save_blocker_is_started\",\"started\":{}}}",
+            .{cef.powerSaveBlockerIsStarted(util.nonNegU32(id_n))},
+        ) catch null;
+    }
 
     // app.getName / app.getVersion — config.app exposure (Electron `app.getName/getVersion`).
     if (std.mem.eql(u8, cmd, "app_get_name")) {

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -93,6 +93,7 @@ pub const appSetBadgeCount = cef_public_api.appSetBadgeCount;
 pub const PowerSaveBlockerType = cef_public_api.PowerSaveBlockerType;
 pub const powerSaveBlockerStart = cef_public_api.powerSaveBlockerStart;
 pub const powerSaveBlockerStop = cef_public_api.powerSaveBlockerStop;
+pub const powerSaveBlockerIsStarted = cef_public_api.powerSaveBlockerIsStarted;
 pub const safeStorageSet = cef_public_api.safeStorageSet;
 pub const safeStorageGet = cef_public_api.safeStorageGet;
 pub const safeStorageDelete = cef_public_api.safeStorageDelete;

--- a/src/platform/cef_power_save_blocker.zig
+++ b/src/platform/cef_power_save_blocker.zig
@@ -71,6 +71,14 @@ var power_save_next_id: u32 = 1;
 var power_save_entries = [_]PowerSaveBlockerEntry{.{}} ** max_power_save_blockers;
 var linux_power_save_display: ?*anyopaque = null;
 
+/// Electron `powerSaveBlocker.isStarted(id)` 용 활성 id 추적 — start 시 기록, stop 시 제거.
+/// 전 플랫폼 단일 메커니즘(macOS 는 IOPMAssertion id 라 entry table 미사용 → isStarted 는 이
+/// 테이블로 통일). powerSaveLock 으로 보호. 정직 경계: 64개(max_power_save_blockers) 동시
+/// 추적 — Linux/Win 은 entry table 이 65번째 start 를 실패시켜 오버플로 없음. macOS 는 start
+/// 가 무제한이라 65번째+ 는 추적 슬롯 부족으로 isStarted 가 false(실 blocker 는 활성). 동시
+/// 64+ blocker 는 비현실적(앱당 보통 1~2개)이라 정직 경계로 둠.
+var power_save_started_ids = [_]u32{0} ** max_power_save_blockers;
+
 fn powerSaveLock() void {
     while (power_save_lock_flag.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {
         std.atomic.spinLoopHint();
@@ -215,8 +223,48 @@ fn windowsPowerSaveStop(id: u32) bool {
     return ok;
 }
 
-/// powerSaveBlocker 시작 — 0이면 실패 (id는 1+).
+fn powerSaveRecordStartedLocked(id: u32) void {
+    if (id == 0) return;
+    for (&power_save_started_ids) |*s| {
+        if (s.* == 0) {
+            s.* = id;
+            return;
+        }
+    }
+}
+
+fn powerSaveForgetStartedLocked(id: u32) void {
+    for (&power_save_started_ids) |*s| {
+        if (s.* == id) {
+            s.* = 0;
+            return;
+        }
+    }
+}
+
+/// Electron `powerSaveBlocker.isStarted(id)` — 활성(시작됨) 여부.
+pub fn powerSaveBlockerIsStarted(id: u32) bool {
+    if (id == 0) return false;
+    powerSaveLock();
+    defer powerSaveUnlock();
+    for (power_save_started_ids) |s| {
+        if (s == id) return true;
+    }
+    return false;
+}
+
+/// powerSaveBlocker 시작 — 0이면 실패 (id는 1+). 성공 id 를 started 테이블에 기록.
 pub fn powerSaveBlockerStart(t: PowerSaveBlockerType) u32 {
+    const id = powerSaveBlockerStartInner(t);
+    if (id != 0) {
+        powerSaveLock();
+        powerSaveRecordStartedLocked(id);
+        powerSaveUnlock();
+    }
+    return id;
+}
+
+fn powerSaveBlockerStartInner(t: PowerSaveBlockerType) u32 {
     if (comptime is_linux) {
         powerSaveLock();
         defer powerSaveUnlock();
@@ -241,7 +289,18 @@ pub fn powerSaveBlockerStart(t: PowerSaveBlockerType) u32 {
     return if (r == 0) id else 0;
 }
 
+/// powerSaveBlocker 중지 — started 테이블에서 제거(성공 여부 무관: 사용자가 stop 을 요청하면
+/// 더 이상 "started" 로 추적하지 않음. 네이티브 release 가 실패해도 isStarted 가 거짓으로 true
+/// 를 보고하지 않게, entry-table 의 stop-시-제거 동작과 일관).
 pub fn powerSaveBlockerStop(id: u32) bool {
+    const ok = powerSaveBlockerStopInner(id);
+    powerSaveLock();
+    powerSaveForgetStartedLocked(id); // 미존재 id 는 no-op.
+    powerSaveUnlock();
+    return ok;
+}
+
+fn powerSaveBlockerStopInner(id: u32) bool {
     if (comptime is_linux) {
         powerSaveLock();
         defer powerSaveUnlock();

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -278,6 +278,7 @@ pub const appSetBadgeCount = cef_dock.appSetBadgeCount;
 pub const PowerSaveBlockerType = cef_power_save_blocker.PowerSaveBlockerType;
 pub const powerSaveBlockerStart = cef_power_save_blocker.powerSaveBlockerStart;
 pub const powerSaveBlockerStop = cef_power_save_blocker.powerSaveBlockerStop;
+pub const powerSaveBlockerIsStarted = cef_power_save_blocker.powerSaveBlockerIsStarted;
 
 pub const safeStorageSet = cef_safe_storage.safeStorageSet;
 pub const safeStorageGet = cef_safe_storage.safeStorageGet;

--- a/src/platform/cef_render_bootstrap.zig
+++ b/src/platform/cef_render_bootstrap.zig
@@ -78,6 +78,10 @@ pub fn injectJsHelpers(ctx: *c._cef_v8_context_t) void {
         \\    };
         \\  };
         \\  s.off = function(event) {
+        \\    if (event === undefined || event === null) {
+        \\      for (var k in s._listeners) delete s._listeners[k];
+        \\      return;
+        \\    }
         \\    delete s._listeners[event];
         \\  };
         \\  s.__dispatch__ = function(event, data) {

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -1265,10 +1265,12 @@ test "powerSaveBlocker IPC — start/stop + 두 type 모두 노출" {
     inline for (.{
         "\"power_save_blocker_start\"",
         "\"power_save_blocker_stop\"",
+        "\"power_save_blocker_is_started\"",
         "\"prevent_app_suspension\"",
         "\"prevent_display_sleep\"",
         "cef.powerSaveBlockerStart",
         "cef.powerSaveBlockerStop",
+        "cef.powerSaveBlockerIsStarted",
     }) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, main_src, needle) != null);
     }
@@ -1278,6 +1280,8 @@ test "powerSaveBlocker IPC — start/stop + 두 type 모두 노출" {
     inline for (.{
         "pub fn powerSaveBlockerStart",
         "pub fn powerSaveBlockerStop",
+        "pub fn powerSaveBlockerIsStarted",
+        "power_save_started_ids", // 활성 id 추적 테이블(전 플랫폼 isStarted 단일 출처)
         "IOPMAssertionCreateWithName",
         "IOPMAssertionRelease",
         "XScreenSaverSuspend",
@@ -1322,6 +1326,14 @@ test "powerSaveBlocker IPC — start/stop + 두 type 모두 노출" {
     }) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, workflow_src, needle) != null);
     }
+}
+
+test "ipcRenderer.removeAllListeners — bridge off(undefined) 가 전 채널 클리어" {
+    const cef_src = try readCefSource();
+    defer std.testing.allocator.free(cef_src);
+    // 브릿지 off 가 event 미지정 시 _listeners 전체를 비운다(전 채널 removeAllListeners).
+    // frozen bridge(shallow) 라 property 재할당 금지 → inner 객체 키를 delete 로 클리어.
+    try std.testing.expect(std.mem.indexOf(u8, cef_src, "for (var k in s._listeners) delete s._listeners[k];") != null);
 }
 
 test "find_result IPC — find_handler 등록 + main.zig final-only forward + display struct 통합" {

--- a/tests/e2e/power-save-blocker.test.ts
+++ b/tests/e2e/power-save-blocker.test.ts
@@ -63,6 +63,21 @@ describe("powerSaveBlocker", () => {
     expect(stopped.success).toBe(false);
   });
 
+  test("isStarted: start → true, stop → false; unknown id → false", async () => {
+    const id = await startBlocker("prevent_display_sleep");
+    const s1 = await core<{ started: boolean }>({ cmd: "power_save_blocker_is_started", id });
+    expect(s1.started).toBe(true);
+
+    await stopBlocker(id);
+    const s2 = await core<{ started: boolean }>({ cmd: "power_save_blocker_is_started", id });
+    expect(s2.started).toBe(false);
+
+    const s3 = await core<{ started: boolean }>({ cmd: "power_save_blocker_is_started", id: 999999 });
+    expect(s3.started).toBe(false);
+    const s0 = await core<{ started: boolean }>({ cmd: "power_save_blocker_is_started", id: 0 });
+    expect(s0.started).toBe(false);
+  });
+
   test("stopping the same id twice is false on the second stop", async () => {
     const id = await startBlocker("prevent_display_sleep");
     const first = await stopBlocker(id);

--- a/tests/e2e/system-integration.test.ts
+++ b/tests/e2e/system-integration.test.ts
@@ -1851,3 +1851,29 @@ describe("session.setProxy", () => {
     expect(await sdk<boolean>("session.setProxy", { mode: "direct" })).toBe(true);
   });
 });
+
+describe("ipcRenderer.removeAllListeners (bridge off)", () => {
+  test("off(channel) 는 해당 채널만, off() 는 전 채널 리스너 해제", async () => {
+    const r = await page.evaluate(() => {
+      const s = (window as any).__suji__;
+      const fired: string[] = [];
+      s.on("ipc-rm-a", () => fired.push("a"));
+      s.on("ipc-rm-b", () => fired.push("b"));
+      s.__dispatch__("ipc-rm-a", "{}");
+      s.__dispatch__("ipc-rm-b", "{}");
+      const after2 = fired.length; // 2
+
+      s.off("ipc-rm-a"); // 단일 채널 해제
+      s.__dispatch__("ipc-rm-a", "{}"); // 미발화
+      s.__dispatch__("ipc-rm-b", "{}"); // b 발화 → 3
+      const afterSingle = fired.length;
+
+      s.off(); // 전 채널 해제
+      s.__dispatch__("ipc-rm-b", "{}"); // 미발화
+      return { after2, afterSingle, afterAll: fired.length };
+    });
+    expect(r.after2).toBe(2);
+    expect(r.afterSingle).toBe(3); // a 해제, b만 발화
+    expect(r.afterAll).toBe(3); // off() 후 미발화
+  });
+});


### PR DESCRIPTION
## 요약

Electron 패리티 **ipc + powerSaveBlocker 잔여** + **Zig 백엔드 SDK catch-up**.

| API | 구현 |
|---|---|
| `ipcRenderer.removeAllListeners([ch])` | suji-js `off(event?)` optional. 렌더러 브릿지 `s.off(undefined)` 가 `_listeners` inner 키를 delete 로 클리어(frozen bridge 라 property 재할당 불가). |
| `ipcMain.handleOnce(ch, fn)` | @suji/node. 첫 invoke 후 channel 을 consumed 핸들러로 교체. |
| `powerSaveBlocker.isStarted(id)` | 전 5 SDK. 전 플랫폼 단일 추적 테이블 `power_save_started_ids`. |

**Zig 백엔드 SDK(`src/core/app.zig`) catch-up**: #117/#118 이 4 SDK 만 갱신하고 5번째 SDK(Zig 백엔드)를 누락 → 이 PR 이 nativeTheme(highContrast/reducedTransparency)·nativeImage(isEmpty/isTemplateImage)·globalShortcut(setSuspended/isSuspended)·powerSaveBlocker(isStarted)를 app.zig 에 추가(파리티 복원).

## 품질 게이트

- **/simplify + /code-review**: 실 버그 수정 — ① **frozen-bridge 버그**(off() 가 `s._listeners={}` 재할당이라 freeze 에 막힘 → inner 키 delete; e2e 가 포착), ② **stop-leak**(stop 실패 시 추적 테이블에 stale id 남아 isStarted 거짓-true → 항상 forget), ③ **Zig SDK 누락**(5번째 SDK catch-up), ④ Go/Rust request-builder 일관성, ⑤ handleOnce arity 중복 제거. 정직 경계 문서화: handleOnce(removeHandler 부재), macOS >64 추적 cap.

## 정직 경계

- `handleOnce`: suji 네이티브 removeHandler 부재 → 첫 호출 후 consumed 핸들러로 교체(이후 invoke 는 `{error:"handler consumed"}` 반환, Electron 의 reject 와 관측 차이).
- `isStarted`: 64개 동시 추적(macOS uncapped start 65번째+ 는 추적 슬롯 부족 — 비현실적).

## 검증
- `zig build test` 938/940 (2 skip)
- e2e power-save-blocker 6/6 (isStarted) · system-integration 125/125 (off(channel)/off() round-trip)
- `cef_ipc_test.zig` source guards (started 테이블 + off no-arg + isStarted dispatch)
- Rust/Go build+fmt, suji-js tsc

🤖 Generated with [Claude Code](https://claude.com/claude-code)