### PR TITLE
feat(tray): setToolTip alias + getBounds — 전 5 SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,8 @@ fn onAllClosed(_: suji.Event) void {
 // suji.dialog.showErrorBox("Title", "content")
 // suji.tray.createWithIcon("App", "tooltip", "/tmp/tray.png")
 //   / setMenuRaw(id, "...items with submenu/checkbox...") / destroy(id)
+//   / setToolTip(id, tip) (setTooltip Electron 별칭) / getBounds(id) → {x,y,width,height}
+//     (getBounds=macOS NSStatusItem.button window frame, Win/Linux 0 rect)
 //                                                                       (macOS NSStatusItem / Linux GTK StatusIcon / Windows Shell_NotifyIconW)
 // suji.notification.show("Title", "Body", false) / requestPermission() / close(id)
 //                                       (macOS UNUserNotificationCenter, .app 번들 필수 / Linux D-Bus / Windows Shell_NotifyIcon balloon)

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2155,6 +2155,20 @@ pub mod tray {
         )
     }
 
+    /// Electron 명명(`tray.setToolTip`) 별칭 — set_tooltip 과 동일.
+    pub fn set_tool_tip(tray_id: u32, tool_tip: &str) -> Option<String> {
+        set_tooltip(tray_id, tool_tip)
+    }
+
+    /// 트레이 아이콘 화면 좌표 rect(Electron tray.getBounds). raw JSON: `{"x","y","width","height"}`.
+    /// macOS only(Win/Linux 0 rect).
+    pub fn get_bounds(tray_id: u32) -> Option<String> {
+        invoke(
+            "__core__",
+            &format!(r#"{{"cmd":"tray_get_bounds","trayId":{}}}"#, tray_id),
+        )
+    }
+
     /// 메뉴 설정 — items 배열을 serde_json으로 안전하게 직렬화.
     /// 클릭 시 `tray:menu-click {trayId, click}` 이벤트 발화.
     pub fn set_menu(tray_id: u32, items: &[MenuItem]) -> Option<String> {

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -172,8 +172,8 @@
 
 ### tray
 
-- **[medium]** `setToolTip(toolTip)` — Add setToolTip method alongside setTooltip in tray export (packages/suji-js/src/index.ts line 906), packages/suji-node/src/index.ts, and all language SDKs. Alternatively, rename setTooltip → setToolTi
-- **[medium]** `tray.getBounds()` — Add getBounds(trayId: number): Promise<{x: number, y: number, width: number, height: number}> to the tray API in packages/suji-js/src/index.ts (and equivalent methods in suji-node and backend SDKs). I
+- ~~**[medium]** `setToolTip(toolTip)`~~ ✅ (tray PR) — setToolTip 별칭(Electron 명명) 전 5 SDK — 기존 setTooltip 위임(동일 `tray_set_tooltip` cmd). 네이티브 setToolTip: 이미 존재.
+- ~~**[medium]** `tray.getBounds()`~~ ✅ (tray PR) — getBounds(trayId) 전 5 SDK. `tray_get_bounds` cmd → cef.trayGetBounds(macOS NSStatusItem.button.window.frame, g_trays 룩업). 정직 경계: macOS only(Win/Linux 0 rect — Shell_NotifyIconGetRect/GTK geometry 후속).
 
 ### webContents
 

--- a/documents/tray.mdx
+++ b/documents/tray.mdx
@@ -15,6 +15,8 @@ Windows는 system tray `Shell_NotifyIconW` 경로를 쓴다. Frontend JS + Zig/R
 |---|---|---|---|
 | `tray.create` | ✅ title/tooltip/iconPath | ✅ title/tooltip/iconPath | ✅ tooltip, 기본 icon |
 | `tray.setTitle/setTooltip` | ✅ title + tooltip | ✅ title + tooltip | ✅ tooltip update (`setTitle`도 tooltip으로 매핑) |
+| `tray.setToolTip` (별칭) | ✅ setTooltip 위임 | ✅ | ✅ |
+| `tray.getBounds` | ✅ NSStatusItem.button window frame | ⬜ 0 rect | ⬜ 0 rect |
 | `tray.setMenu` | ✅ item/separator/checkbox/submenu/enabled | ✅ item/separator/checkbox/submenu/enabled | ✅ flat HMENU item/separator, checkbox 표시 best-effort |
 | `tray.destroy` | ✅ | ✅ hide + unref | ✅ `NIM_DELETE` |
 | Click event | ✅ `tray:menu-click` for menu items | ✅ activate + menu item click | ✅ left click + menu item click |

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -744,6 +744,16 @@ export declare const tray: {
     }>;
     setTitle(trayId: number, title: string): Promise<boolean>;
     setTooltip(trayId: number, tooltip: string): Promise<boolean>;
+    /** Electron 명명(`tray.setToolTip`) 별칭 — setTooltip 과 동일. */
+    setToolTip(trayId: number, toolTip: string): Promise<boolean>;
+    /** 트레이 아이콘 화면 좌표 rect (Electron `tray.getBounds()`). macOS NSStatusItem.button
+     *  window frame. macOS only — Win/Linux 는 0 rect(미지원). */
+    getBounds(trayId: number): Promise<{
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+    }>;
     /** 트레이 클릭 시 표시될 컨텍스트 메뉴 설정. macOS/Linux는 submenu/checkbox도 지원.
      *  메뉴 항목 클릭은 `suji.on('tray:menu-click', ({trayId, click}) => ...)` 로 수신. */
     setMenu(trayId: number, items: TrayMenuItem[]): Promise<boolean>;

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -980,6 +980,16 @@ export const tray = {
         const r = await coreCall({ cmd: "tray_set_tooltip", trayId, tooltip });
         return r.success === true;
     },
+    /** Electron 명명(`tray.setToolTip`) 별칭 — setTooltip 과 동일. */
+    async setToolTip(trayId, toolTip) {
+        return tray.setTooltip(trayId, toolTip);
+    },
+    /** 트레이 아이콘 화면 좌표 rect (Electron `tray.getBounds()`). macOS NSStatusItem.button
+     *  window frame. macOS only — Win/Linux 는 0 rect(미지원). */
+    async getBounds(trayId) {
+        const r = await coreCall({ cmd: "tray_get_bounds", trayId });
+        return { x: r.x, y: r.y, width: r.width, height: r.height };
+    },
     /** 트레이 클릭 시 표시될 컨텍스트 메뉴 설정. macOS/Linux는 submenu/checkbox도 지원.
      *  메뉴 항목 클릭은 `suji.on('tray:menu-click', ({trayId, click}) => ...)` 로 수신. */
     async setMenu(trayId, items) {

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -1438,6 +1438,18 @@ export const tray = {
     return r.success === true;
   },
 
+  /** Electron 명명(`tray.setToolTip`) 별칭 — setTooltip 과 동일. */
+  async setToolTip(trayId: number, toolTip: string): Promise<boolean> {
+    return tray.setTooltip(trayId, toolTip);
+  },
+
+  /** 트레이 아이콘 화면 좌표 rect (Electron `tray.getBounds()`). macOS NSStatusItem.button
+   *  window frame. macOS only — Win/Linux 는 0 rect(미지원). */
+  async getBounds(trayId: number): Promise<{ x: number; y: number; width: number; height: number }> {
+    const r = await coreCall<{ x: number; y: number; width: number; height: number }>({ cmd: "tray_get_bounds", trayId });
+    return { x: r.x, y: r.y, width: r.width, height: r.height };
+  },
+
   /** 트레이 클릭 시 표시될 컨텍스트 메뉴 설정. macOS/Linux는 submenu/checkbox도 지원.
    *  메뉴 항목 클릭은 `suji.on('tray:menu-click', ({trayId, click}) => ...)` 로 수신. */
   async setMenu(trayId: number, items: TrayMenuItem[]): Promise<boolean> {

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -1767,6 +1767,17 @@ export const tray = {
     return r.success === true;
   },
 
+  /** Electron 명명(`tray.setToolTip`) 별칭 — setTooltip 과 동일. */
+  async setToolTip(trayId: number, toolTip: string): Promise<boolean> {
+    return tray.setTooltip(trayId, toolTip);
+  },
+
+  /** 트레이 아이콘 화면 좌표 rect (Electron `tray.getBounds()`). macOS only — Win/Linux 0 rect. */
+  async getBounds(trayId: number): Promise<{ x: number; y: number; width: number; height: number }> {
+    const r = await invoke<{ x: number; y: number; width: number; height: number }>('__core__', { cmd: 'tray_get_bounds', trayId });
+    return { x: r.x, y: r.y, width: r.width, height: r.height };
+  },
+
   async setMenu(trayId: number, items: TrayMenuItem[]): Promise<boolean> {
     const r = await invoke<{ success: boolean }>('__core__', { cmd: 'tray_set_menu', trayId, items });
     return r.success === true;

--- a/sdks/suji-go/tray/tray.go
+++ b/sdks/suji-go/tray/tray.go
@@ -52,6 +52,17 @@ func SetTooltip(trayID uint32, tooltip string) string {
 	))
 }
 
+// SetToolTip is the Electron-named alias of SetTooltip (identical behavior).
+func SetToolTip(trayID uint32, toolTip string) string {
+	return SetTooltip(trayID, toolTip)
+}
+
+// GetBounds returns the tray icon's screen rect (Electron tray.getBounds).
+// Response: `{"x","y","width","height"}`. macOS only; Win/Linux 0 rect.
+func GetBounds(trayID uint32) string {
+	return suji.Invoke("__core__", fmt.Sprintf(`{"cmd":"tray_get_bounds","trayId":%d}`, trayID))
+}
+
 // SetMenu — items 배열로 메뉴 구성. macOS/Linux는 checkbox/submenu/enabled를 지원한다.
 func SetMenu(trayID uint32, items []MenuItem) string {
 	return suji.Invoke("__core__", buildSetMenuRequest(trayID, items))

--- a/src/core/app.zig
+++ b/src/core/app.zig
@@ -1308,6 +1308,19 @@ pub const tray = struct {
         return coreCmd("tray_set_tooltip", fields);
     }
 
+    /// Electron 명명(tray.setToolTip) 별칭 — setTooltip 과 동일.
+    pub fn setToolTip(tray_id: u32, tool_tip: []const u8) ?[]const u8 {
+        return setTooltip(tray_id, tool_tip);
+    }
+
+    /// 트레이 아이콘 화면 좌표 rect(Electron tray.getBounds). 응답: `{"x","y","width","height"}`.
+    /// macOS only(Win/Linux 0 rect).
+    pub fn getBounds(tray_id: u32) ?[]const u8 {
+        var fields_buf: [32]u8 = undefined;
+        const fields = std.fmt.bufPrint(&fields_buf, "\"trayId\":{d}", .{tray_id}) catch return null;
+        return coreCmd("tray_get_bounds", fields);
+    }
+
     /// 메뉴 설정 — items_json은 cmd 객체에 들어갈 raw JSON `"items":[...]`. caller가 빌드.
     /// 예: `\"items\":[{\"label\":\"Settings\",\"click\":\"open-settings\"},{\"type\":\"separator\"}]`.
     pub fn setMenuRaw(tray_id: u32, items_json: []const u8) ?[]const u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3003,6 +3003,15 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         const result = std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"tray_set_tooltip\",\"success\":{}}}", .{ok}) catch return null;
         return result;
     }
+    if (std.mem.eql(u8, cmd, "tray_get_bounds")) {
+        const tray_id: u32 = util.nonNegU32(util.extractJsonInt(req_clean, "trayId") orelse return null);
+        const r = cef.trayGetBounds(tray_id);
+        return std.fmt.bufPrint(
+            response_buf,
+            "{{\"from\":\"zig-core\",\"cmd\":\"tray_get_bounds\",\"x\":{d},\"y\":{d},\"width\":{d},\"height\":{d}}}",
+            .{ r.x, r.y, r.width, r.height },
+        ) catch null;
+    }
     if (std.mem.eql(u8, cmd, "tray_set_menu")) {
         return handleTraySetMenu(req_clean, response_buf);
     }

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -139,6 +139,7 @@ pub const setTrayEmitHandler = cef_public_api.setTrayEmitHandler;
 pub const createTray = cef_public_api.createTray;
 pub const setTrayTitle = cef_public_api.setTrayTitle;
 pub const setTrayTooltip = cef_public_api.setTrayTooltip;
+pub const trayGetBounds = cef_public_api.trayGetBounds;
 pub const setTrayMenu = cef_public_api.setTrayMenu;
 pub const destroyTray = cef_public_api.destroyTray;
 pub const NotificationEmitHandler = cef_public_api.NotificationEmitHandler;

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -334,6 +334,7 @@ pub const setTrayEmitHandler = cef_tray.setTrayEmitHandler;
 pub const createTray = cef_tray.createTray;
 pub const setTrayTitle = cef_tray.setTrayTitle;
 pub const setTrayTooltip = cef_tray.setTrayTooltip;
+pub const trayGetBounds = cef_tray.trayGetBounds;
 pub const setTrayMenu = cef_tray.setTrayMenu;
 pub const destroyTray = cef_tray.destroyTray;
 

--- a/src/platform/cef_tray.zig
+++ b/src/platform/cef_tray.zig
@@ -178,6 +178,29 @@ pub fn setTrayTooltip(tray_id: u32, tooltip: []const u8) bool {
     return true;
 }
 
+/// Electron `tray.getBounds()` — 트레이 아이콘 화면 좌표 rect. macOS: NSStatusItem.button.
+/// window.frame 을 **top-left origin** 으로 변환(Electron/getMacWindowBounds 동일 — Cocoa
+/// bottom-left → top-left: y = screenH - frame.y - frame.height). 미존재/비-macOS 는 0 rect.
+/// 정직 경계: macOS only(Win/Linux 는 0 — Shell_NotifyIconGetRect/GTK geometry 후속).
+pub fn trayGetBounds(tray_id: u32) cef.NSRect {
+    const empty = cef.NSRect{ .x = 0, .y = 0, .width = 0, .height = 0 };
+    if (!comptime is_macos) return empty;
+    if (!g_trays_initialized) return empty;
+    const entry = g_trays.get(tray_id) orelse return empty;
+    const button = msgSend(entry.status_item, "button") orelse return empty;
+    const window = msgSend(button, "window") orelse return empty;
+    const frameFn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) cef.NSRect = @ptrCast(&objc.objc_msgSend);
+    const frame = frameFn(window, @ptrCast(objc.sel_registerName("frame")));
+    // Cocoa bottom-left → Electron top-left.
+    const top_y: f64 = blk: {
+        const NSScreen = getClass("NSScreen") orelse break :blk frame.y;
+        const mainScreen = msgSend(NSScreen, "mainScreen") orelse break :blk frame.y;
+        const screen_frame = frameFn(mainScreen, @ptrCast(objc.sel_registerName("frame")));
+        break :blk screen_frame.height - frame.y - frame.height;
+    };
+    return .{ .x = frame.x, .y = top_y, .width = frame.width, .height = frame.height };
+}
+
 /// items 배열로 NSMenu 빌드 + tray에 attach. 기존 menu가 있으면 NSMenuItem.representedObject
 /// (NSString) 자동 release (NSMenu deinit 연쇄).
 pub fn setTrayMenu(tray_id: u32, items: []const TrayMenuItem) bool {

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -2737,6 +2737,27 @@ test "clipboard RTF + Buffer IPC + cef pasteboard" {
     }
 }
 
+test "tray.getBounds IPC + cef NSStatusItem frame" {
+    const main_src = try readMainSource();
+    defer std.testing.allocator.free(main_src);
+    inline for (.{
+        "\"tray_get_bounds\"",
+        "cef.trayGetBounds",
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, main_src, needle) != null);
+    }
+
+    const cef_src = try readCefSource();
+    defer std.testing.allocator.free(cef_src);
+    inline for (.{
+        "pub fn trayGetBounds",
+        "\"window\"", // status_item.button.window
+        "\"frame\"", // window frame (NSRect)
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, cef_src, needle) != null);
+    }
+}
+
 test "clipboard writeBookmark/writeFindText/write IPC + cef pasteboard" {
     const main_src = try readMainSource();
     defer std.testing.allocator.free(main_src);

--- a/tests/e2e/tray.test.ts
+++ b/tests/e2e/tray.test.ts
@@ -131,6 +131,16 @@ describe("setTitle / setTooltip / setMenu — 응답", () => {
     expect(r.success).toBe(true);
   });
 
+  test("getBounds → x/y/width/height 숫자 (macOS 는 실 rect)", async () => {
+    const r = await core<{ x: number; y: number; width: number; height: number }>({ cmd: "tray_get_bounds", trayId });
+    expect(typeof r.x).toBe("number");
+    expect(typeof r.y).toBe("number");
+    expect(typeof r.width).toBe("number");
+    expect(typeof r.height).toBe("number");
+    // macOS 메뉴바 status item 은 width > 0(실 아이콘 폭). 비-macOS 는 0.
+    if (process.platform === "darwin") expect(r.width).toBeGreaterThan(0);
+  });
+
   test("setMenu separator + 일반 항목 혼합", async () => {
     const r = await core<{ success: boolean }>({
       cmd: "tray_set_menu", trayId,


### PR DESCRIPTION
## 요약

Electron 패리티 **tray 카테고리 마감** — 전 5 SDK(@suji/api + @suji/node + Rust + Go + Zig 백엔드).

| API | 구현 |
|---|---|
| `tray.setToolTip(id, tip)` | Electron 명명 별칭 — 기존 `setTooltip` 위임(동일 `tray_set_tooltip` cmd) |
| `tray.getBounds(id)` → `{x,y,width,height}` | macOS NSStatusItem.button.window.frame → **top-left origin** 변환 |

## 품질 게이트

- **/simplify + /code-review**: NSRect struct-return msgSend(arm64 no-stret) 검증, `{d}` f64 포맷 검증, 재export 체인 검증. **수정**: 초안 getBounds 가 raw Cocoa **bottom-left** y 를 반환했으나 Electron `tray.getBounds()` 는 top-left → `getMacWindowBounds` 와 동일한 y-flip(`screenH - frame.y - frame.height`) 적용.

## 정직 경계

- `getBounds` macOS only(Win/Linux `0 rect` — Shell_NotifyIconGetRect / GTK geometry 후속).

## 검증
- `zig build test` 940/942 (2 skip)
- e2e tray 21/21 (getBounds 숫자 반환 + macOS width>0)
- `cef_ipc_test.zig` source guard (tray_get_bounds / window / frame)
- Rust/Go build+fmt, suji-js tsc

🤖 Generated with [Claude Code](https://claude.com/claude-code)