### PR TITLE
feat(notification): caller id + groupId/removeGroup + Notification class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,8 @@ fn onAllClosed(_: suji.Event) void {
 // suji.dialog.showErrorBox("Title", "content")
 // suji.tray.createWithIcon("App", "tooltip", "/tmp/tray.png")
 //   / setMenuRaw(id, "...items with submenu/checkbox...") / destroy(id)
+//   / setToolTip(id, tip) (setTooltip Electron 별칭) / getBounds(id) → {x,y,width,height}
+//     (getBounds=macOS NSStatusItem.button window frame, Win/Linux 0 rect)
 //                                                                       (macOS NSStatusItem / Linux GTK StatusIcon / Windows Shell_NotifyIconW)
 // suji.notification.show("Title", "Body", false) / requestPermission() / close(id)
 //                                       (macOS UNUserNotificationCenter, .app 번들 필수 / Linux D-Bus / Windows Shell_NotifyIcon balloon)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,9 @@ fn onAllClosed(_: suji.Event) void {
 //     (getBounds=macOS NSStatusItem.button window frame, Win/Linux 0 rect)
 //                                                                       (macOS NSStatusItem / Linux GTK StatusIcon / Windows Shell_NotifyIconW)
 // suji.notification.show("Title", "Body", false) / requestPermission() / close(id)
+//   / removeAll() / removeGroup(groupId)  — groupId=macOS threadIdentifier (Win/Linux false)
+//   NotificationOptions {id?, groupId?} — caller-id + 그룹화. Notification 클래스(JS/Node):
+//   new Notification(opts); await n.show(); n.id (readonly) / n.close()
 //                                       (macOS UNUserNotificationCenter, .app 번들 필수 / Linux D-Bus / Windows Shell_NotifyIcon balloon)
 // suji.menu.setApplicationMenuRaw("\"items\":[...]") / resetApplicationMenu()
 //   / popup(items, {x?,y?})  — 임의 위치 컨텍스트 메뉴(macOS NSMenu

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2155,6 +2155,20 @@ pub mod tray {
         )
     }
 
+    /// Electron 명명(`tray.setToolTip`) 별칭 — set_tooltip 과 동일.
+    pub fn set_tool_tip(tray_id: u32, tool_tip: &str) -> Option<String> {
+        set_tooltip(tray_id, tool_tip)
+    }
+
+    /// 트레이 아이콘 화면 좌표 rect(Electron tray.getBounds). raw JSON: `{"x","y","width","height"}`.
+    /// macOS only(Win/Linux 0 rect).
+    pub fn get_bounds(tray_id: u32) -> Option<String> {
+        invoke(
+            "__core__",
+            &format!(r#"{{"cmd":"tray_get_bounds","trayId":{}}}"#, tray_id),
+        )
+    }
+
     /// 메뉴 설정 — items 배열을 serde_json으로 안전하게 직렬화.
     /// 클릭 시 `tray:menu-click {trayId, click}` 이벤트 발화.
     pub fn set_menu(tray_id: u32, items: &[MenuItem]) -> Option<String> {

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2085,6 +2085,34 @@ pub mod notification {
     pub fn remove_all() -> Option<String> {
         invoke("__core__", r#"{"cmd":"notification_remove_all"}"#)
     }
+
+    /// 그룹 식별자(macOS threadIdentifier) + caller-id 를 지정해 표시 — removeGroup 대상.
+    /// 응답: `{"notificationId":"...","success":bool}`. id 빈 문자열이면 자동 생성.
+    pub fn show_grouped(id: &str, title: &str, body: &str, silent: bool, group_id: &str) -> Option<String> {
+        invoke(
+            "__core__",
+            &format!(
+                r#"{{"cmd":"notification_show","id":"{}","title":"{}","body":"{}","silent":{},"groupId":"{}"}}"#,
+                escape_json_full(id),
+                escape_json_full(title),
+                escape_json_full(body),
+                silent,
+                escape_json_full(group_id),
+            ),
+        )
+    }
+
+    /// 그룹(groupId=macOS threadIdentifier) 알림 제거 (Electron `Notification.removeGroup`).
+    /// macOS only(Win/Linux false). 응답: `{"success":bool}`.
+    pub fn remove_group(group_id: &str) -> Option<String> {
+        invoke(
+            "__core__",
+            &format!(
+                r#"{{"cmd":"notification_remove_group","groupId":"{}"}}"#,
+                escape_json_full(group_id),
+            ),
+        )
+    }
 }
 
 pub mod tray {

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -172,8 +172,8 @@
 
 ### tray
 
-- **[medium]** `setToolTip(toolTip)` — Add setToolTip method alongside setTooltip in tray export (packages/suji-js/src/index.ts line 906), packages/suji-node/src/index.ts, and all language SDKs. Alternatively, rename setTooltip → setToolTi
-- **[medium]** `tray.getBounds()` — Add getBounds(trayId: number): Promise<{x: number, y: number, width: number, height: number}> to the tray API in packages/suji-js/src/index.ts (and equivalent methods in suji-node and backend SDKs). I
+- ~~**[medium]** `setToolTip(toolTip)`~~ ✅ (tray PR) — setToolTip 별칭(Electron 명명) 전 5 SDK — 기존 setTooltip 위임(동일 `tray_set_tooltip` cmd). 네이티브 setToolTip: 이미 존재.
+- ~~**[medium]** `tray.getBounds()`~~ ✅ (tray PR) — getBounds(trayId) 전 5 SDK. `tray_get_bounds` cmd → cef.trayGetBounds(macOS NSStatusItem.button.window.frame, g_trays 룩업). 정직 경계: macOS only(Win/Linux 0 rect — Shell_NotifyIconGetRect/GTK geometry 후속).
 
 ### webContents
 

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -141,9 +141,9 @@
 ### notification
 
 - ~~**[medium]** `notification.show()`~~ ✅ — Create a `Notification` class mirroring Electron's pattern. Signature: `class Notification { constructor(opts: NotificationOptions); async show(): Promise<{notificationId: string; success: boolean}>; 
-- **[medium]** `Notification.removeGroup(groupId)` — Add notification.removeGroup(groupId: string) → Promise<boolean>. Steps: (1) Extend NotificationOptions with optional groupId: string; (2) Pass groupId through show() IPC to native layer (modify src/m
-- **[medium]** `NotificationOptions.id` — Add `id?: string` to NotificationOptions interface in packages/suji-js/src/index.ts (line 835). In src/main.zig notification_show handler (line 2472), extract the optional id field using util.extractJ
-- **[medium]** `notification.id (readonly getter)` — Introduce a Notification class (similar to BrowserWindow) with: constructor(options: NotificationOptions & {id?: string}), readonly id property (exposed post-construction), and async show()/close() me
+- ~~**[medium]** `Notification.removeGroup(groupId)`~~ ✅ (notification PR) — removeGroup(groupId) 전 5 SDK. `notification_remove_group` cmd → cef.notificationRemoveGroup → notification.m getDeliveredNotifications 필터 후 removeDelivered. groupId 는 show 시 macOS UNMutableNotificationContent.threadIdentifier 로 설정. 정직 경계: macOS only(Win/Linux false — threadIdentifier 그룹 개념 없음).
+- ~~**[medium]** `NotificationOptions.id`~~ ✅ (notification PR) — id? 옵션. main.zig notification_show 가 caller-supplied id 사용(없으면 자동 생성). JS/Node 는 NotificationOptions.id, Rust/Go/Zig 는 show_grouped/ShowGrouped/showGrouped 의 id 파라미터.
+- ~~**[medium]** `notification.id (readonly getter)`~~ ✅ (notification PR) — `class Notification`(JS/Node, BrowserWindow 동형 OO 래퍼): constructor(opts) + readonly `id`(show 후 채워짐) + show()/close(). Rust/Go/Zig 는 함수형이라 클래스 대신 show 반환 notificationId 직접 사용(정직 경계).
 
 ### powerMonitor
 

--- a/documents/notification.mdx
+++ b/documents/notification.mdx
@@ -17,6 +17,10 @@ deprecated 후 macOS 26 제거), Linux freedesktop notification D-Bus, Windows
 | `notification.requestPermission` | ✅ OS 다이얼로그 | ✅ daemon reachable (no prompt) | ✅ true (권한 프롬프트 없음) |
 | `notification.show` | ✅ UNUserNotificationCenter | ✅ D-Bus `Notify` | ✅ `NIF_INFO` balloon |
 | `notification.close` | ✅ pending + delivered | ✅ D-Bus `CloseNotification` | ✅ backing tray icon 제거 |
+| `notification.removeAll` | ✅ removeAll* | ⬜ false | ⬜ false |
+| `notification.removeGroup(groupId)` | ✅ threadIdentifier 필터 | ⬜ false | ⬜ false |
+| `NotificationOptions.id` / `.groupId` | ✅ caller-id / threadIdentifier | id ✅ / group ⬜ | id ✅ / group ⬜ |
+| `Notification` 클래스 (id getter) | ✅ (JS/Node OO) | ✅ | ✅ |
 | Click event | ✅ `notification:click` | — | ✅ balloon click |
 
 Linux는 `org.freedesktop.Notifications` 서비스가 없으면 graceful false.
@@ -78,7 +82,23 @@ suji.on('notification:click', ({ notificationId: clickedId }) => {
 
 // 명시 close (자동 dismiss 외에)
 await notification.close(notificationId);
+
+// 그룹화(macOS threadIdentifier) + 그룹 제거
+await notification.show({ title: 'Sync', body: '1/3', groupId: 'sync' });
+await notification.show({ title: 'Sync', body: '2/3', groupId: 'sync' });
+await notification.removeGroup('sync');   // macOS: 'sync' 그룹 표시분 제거
+
+// Notification 클래스 (Electron 동형 OO 래퍼 — id getter)
+import { Notification } from '@suji/api';
+const n = new Notification({ title: 'Hi', body: 'World', id: 'my-id' });
+await n.show();
+console.log(n.id);   // 'my-id' (show 후)
+await n.close();
 ```
+
+> `removeGroup`/`groupId`/`Notification` 클래스의 그룹화는 **macOS 전용**(UNUserNotification
+> Center `threadIdentifier`). Win/Linux 는 groupId 를 무시하고 개별 알림으로 표시하며
+> `removeGroup` 은 `false`. `id` 는 전 플랫폼 caller-supplied(생략 시 자동 생성).
 
 ## Backend SDK
 

--- a/documents/tray.mdx
+++ b/documents/tray.mdx
@@ -15,6 +15,8 @@ Windows는 system tray `Shell_NotifyIconW` 경로를 쓴다. Frontend JS + Zig/R
 |---|---|---|---|
 | `tray.create` | ✅ title/tooltip/iconPath | ✅ title/tooltip/iconPath | ✅ tooltip, 기본 icon |
 | `tray.setTitle/setTooltip` | ✅ title + tooltip | ✅ title + tooltip | ✅ tooltip update (`setTitle`도 tooltip으로 매핑) |
+| `tray.setToolTip` (별칭) | ✅ setTooltip 위임 | ✅ | ✅ |
+| `tray.getBounds` | ✅ NSStatusItem.button window frame | ⬜ 0 rect | ⬜ 0 rect |
 | `tray.setMenu` | ✅ item/separator/checkbox/submenu/enabled | ✅ item/separator/checkbox/submenu/enabled | ✅ flat HMENU item/separator, checkbox 표시 best-effort |
 | `tray.destroy` | ✅ | ✅ hide + unref | ✅ `NIM_DELETE` |
 | Click event | ✅ `tray:menu-click` for menu items | ✅ activate + menu item click | ✅ left click + menu item click |

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -689,6 +689,10 @@ export interface NotificationOptions {
     body: string;
     /** 사운드 묻음 */
     silent?: boolean;
+    /** caller-supplied 식별자 (Electron NotificationOptions). 생략 시 자동 생성. */
+    id?: string;
+    /** 그룹 식별자 — macOS threadIdentifier(그룹화 + removeGroup 대상). Win/Linux 무시. */
+    groupId?: string;
 }
 export declare const notification: {
     /** 플랫폼 지원 여부 — macOS bundle/권한, Linux daemon, Windows tray balloon 상태를 반영. */
@@ -703,7 +707,22 @@ export declare const notification: {
     close(notificationId: string): Promise<boolean>;
     /** Electron `Notification` 전체 제거 — 표시/대기 모든 알림(macOS 실동작). */
     removeAll(): Promise<boolean>;
+    /** 그룹(groupId=macOS threadIdentifier) 알림 제거 (Electron `Notification.removeGroup`).
+     *  macOS only — Win/Linux false(그룹 개념 미지원). */
+    removeGroup(groupId: string): Promise<boolean>;
 };
+/** Electron `Notification` 클래스 동등 — OO 래퍼. show() 후 `id` 로 식별자 조회 가능. */
+export declare class Notification {
+    #private;
+    private readonly options;
+    constructor(options: NotificationOptions);
+    /** show() 이후의 알림 식별자(생성 전 null). Electron `notification.id` readonly. */
+    get id(): string | null;
+    /** 알림 표시 — 성공 시 id 가 채워진다. */
+    show(): Promise<boolean>;
+    /** 이 알림 닫기 (show 전이면 false). */
+    close(): Promise<boolean>;
+}
 export interface TrayMenuSeparator {
     type: "separator";
 }

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -744,6 +744,16 @@ export declare const tray: {
     }>;
     setTitle(trayId: number, title: string): Promise<boolean>;
     setTooltip(trayId: number, tooltip: string): Promise<boolean>;
+    /** Electron 명명(`tray.setToolTip`) 별칭 — setTooltip 과 동일. */
+    setToolTip(trayId: number, toolTip: string): Promise<boolean>;
+    /** 트레이 아이콘 화면 좌표 rect (Electron `tray.getBounds()`). macOS NSStatusItem.button
+     *  window frame. macOS only — Win/Linux 는 0 rect(미지원). */
+    getBounds(trayId: number): Promise<{
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+    }>;
     /** 트레이 클릭 시 표시될 컨텍스트 메뉴 설정. macOS/Linux는 submenu/checkbox도 지원.
      *  메뉴 항목 클릭은 `suji.on('tray:menu-click', ({trayId, click}) => ...)` 로 수신. */
     setMenu(trayId: number, items: TrayMenuItem[]): Promise<boolean>;

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -26,7 +26,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 };
-var _BrowserWindow_id;
+var _BrowserWindow_id, _Notification_id;
 function getBridge() {
     const bridge = window.__suji__;
     if (!bridge)
@@ -966,7 +966,37 @@ export const notification = {
         const r = await coreCall({ cmd: "notification_remove_all" });
         return r.success === true;
     },
+    /** 그룹(groupId=macOS threadIdentifier) 알림 제거 (Electron `Notification.removeGroup`).
+     *  macOS only — Win/Linux false(그룹 개념 미지원). */
+    async removeGroup(groupId) {
+        const r = await coreCall({ cmd: "notification_remove_group", groupId });
+        return r.success === true;
+    },
 };
+/** Electron `Notification` 클래스 동등 — OO 래퍼. show() 후 `id` 로 식별자 조회 가능. */
+export class Notification {
+    constructor(options) {
+        this.options = options;
+        _Notification_id.set(this, null);
+    }
+    /** show() 이후의 알림 식별자(생성 전 null). Electron `notification.id` readonly. */
+    get id() {
+        return __classPrivateFieldGet(this, _Notification_id, "f");
+    }
+    /** 알림 표시 — 성공 시 id 가 채워진다. */
+    async show() {
+        const r = await notification.show(this.options);
+        __classPrivateFieldSet(this, _Notification_id, r.notificationId, "f");
+        return r.success;
+    }
+    /** 이 알림 닫기 (show 전이면 false). */
+    async close() {
+        if (!__classPrivateFieldGet(this, _Notification_id, "f"))
+            return false;
+        return notification.close(__classPrivateFieldGet(this, _Notification_id, "f"));
+    }
+}
+_Notification_id = new WeakMap();
 export const tray = {
     /** 새 시스템 트레이 아이콘 생성. 반환된 trayId로 이후 update/destroy. */
     async create(options = {}) {

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -980,6 +980,16 @@ export const tray = {
         const r = await coreCall({ cmd: "tray_set_tooltip", trayId, tooltip });
         return r.success === true;
     },
+    /** Electron 명명(`tray.setToolTip`) 별칭 — setTooltip 과 동일. */
+    async setToolTip(trayId, toolTip) {
+        return tray.setTooltip(trayId, toolTip);
+    },
+    /** 트레이 아이콘 화면 좌표 rect (Electron `tray.getBounds()`). macOS NSStatusItem.button
+     *  window frame. macOS only — Win/Linux 는 0 rect(미지원). */
+    async getBounds(trayId) {
+        const r = await coreCall({ cmd: "tray_get_bounds", trayId });
+        return { x: r.x, y: r.y, width: r.width, height: r.height };
+    },
     /** 트레이 클릭 시 표시될 컨텍스트 메뉴 설정. macOS/Linux는 submenu/checkbox도 지원.
      *  메뉴 항목 클릭은 `suji.on('tray:menu-click', ({trayId, click}) => ...)` 로 수신. */
     async setMenu(trayId, items) {

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -1438,6 +1438,18 @@ export const tray = {
     return r.success === true;
   },
 
+  /** Electron 명명(`tray.setToolTip`) 별칭 — setTooltip 과 동일. */
+  async setToolTip(trayId: number, toolTip: string): Promise<boolean> {
+    return tray.setTooltip(trayId, toolTip);
+  },
+
+  /** 트레이 아이콘 화면 좌표 rect (Electron `tray.getBounds()`). macOS NSStatusItem.button
+   *  window frame. macOS only — Win/Linux 는 0 rect(미지원). */
+  async getBounds(trayId: number): Promise<{ x: number; y: number; width: number; height: number }> {
+    const r = await coreCall<{ x: number; y: number; width: number; height: number }>({ cmd: "tray_get_bounds", trayId });
+    return { x: r.x, y: r.y, width: r.width, height: r.height };
+  },
+
   /** 트레이 클릭 시 표시될 컨텍스트 메뉴 설정. macOS/Linux는 submenu/checkbox도 지원.
    *  메뉴 항목 클릭은 `suji.on('tray:menu-click', ({trayId, click}) => ...)` 로 수신. */
   async setMenu(trayId: number, items: TrayMenuItem[]): Promise<boolean> {

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -1342,6 +1342,10 @@ export interface NotificationOptions {
   body: string;
   /** 사운드 묻음 */
   silent?: boolean;
+  /** caller-supplied 식별자 (Electron NotificationOptions). 생략 시 자동 생성. */
+  id?: string;
+  /** 그룹 식별자 — macOS threadIdentifier(그룹화 + removeGroup 대상). Win/Linux 무시. */
+  groupId?: string;
 }
 
 export const notification = {
@@ -1375,7 +1379,38 @@ export const notification = {
     const r = await coreCall<{ success: boolean }>({ cmd: "notification_remove_all" });
     return r.success === true;
   },
+
+  /** 그룹(groupId=macOS threadIdentifier) 알림 제거 (Electron `Notification.removeGroup`).
+   *  macOS only — Win/Linux false(그룹 개념 미지원). */
+  async removeGroup(groupId: string): Promise<boolean> {
+    const r = await coreCall<{ success: boolean }>({ cmd: "notification_remove_group", groupId });
+    return r.success === true;
+  },
 };
+
+/** Electron `Notification` 클래스 동등 — OO 래퍼. show() 후 `id` 로 식별자 조회 가능. */
+export class Notification {
+  #id: string | null = null;
+  constructor(private readonly options: NotificationOptions) {}
+
+  /** show() 이후의 알림 식별자(생성 전 null). Electron `notification.id` readonly. */
+  get id(): string | null {
+    return this.#id;
+  }
+
+  /** 알림 표시 — 성공 시 id 가 채워진다. */
+  async show(): Promise<boolean> {
+    const r = await notification.show(this.options);
+    this.#id = r.notificationId;
+    return r.success;
+  }
+
+  /** 이 알림 닫기 (show 전이면 false). */
+  async close(): Promise<boolean> {
+    if (!this.#id) return false;
+    return notification.close(this.#id);
+  }
+}
 
 // ============================================
 // tray — 시스템 트레이 아이콘 (Electron `Tray`)

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -1767,6 +1767,17 @@ export const tray = {
     return r.success === true;
   },
 
+  /** Electron 명명(`tray.setToolTip`) 별칭 — setTooltip 과 동일. */
+  async setToolTip(trayId: number, toolTip: string): Promise<boolean> {
+    return tray.setTooltip(trayId, toolTip);
+  },
+
+  /** 트레이 아이콘 화면 좌표 rect (Electron `tray.getBounds()`). macOS only — Win/Linux 0 rect. */
+  async getBounds(trayId: number): Promise<{ x: number; y: number; width: number; height: number }> {
+    const r = await invoke<{ x: number; y: number; width: number; height: number }>('__core__', { cmd: 'tray_get_bounds', trayId });
+    return { x: r.x, y: r.y, width: r.width, height: r.height };
+  },
+
   async setMenu(trayId: number, items: TrayMenuItem[]): Promise<boolean> {
     const r = await invoke<{ success: boolean }>('__core__', { cmd: 'tray_set_menu', trayId, items });
     return r.success === true;

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -1687,6 +1687,10 @@ export interface NotificationOptions {
   title: string;
   body: string;
   silent?: boolean;
+  /** caller-supplied 식별자 (생략 시 자동 생성). */
+  id?: string;
+  /** 그룹 식별자 — macOS threadIdentifier(removeGroup 대상). Win/Linux 무시. */
+  groupId?: string;
 }
 
 export const notification = {
@@ -1717,7 +1721,35 @@ export const notification = {
     const r = await invoke<{ success: boolean }>('__core__', { cmd: 'notification_remove_all' });
     return r.success === true;
   },
+
+  /** 그룹(groupId=macOS threadIdentifier) 알림 제거 (Electron `Notification.removeGroup`).
+   *  macOS only — Win/Linux false. */
+  async removeGroup(groupId: string): Promise<boolean> {
+    const r = await invoke<{ success: boolean }>('__core__', { cmd: 'notification_remove_group', groupId });
+    return r.success === true;
+  },
 };
+
+/** Electron `Notification` 클래스 동등 — OO 래퍼. show() 후 `id` 로 식별자 조회. */
+export class Notification {
+  #id: string | null = null;
+  constructor(private readonly options: NotificationOptions) {}
+
+  get id(): string | null {
+    return this.#id;
+  }
+
+  async show(): Promise<boolean> {
+    const r = await notification.show(this.options);
+    this.#id = r.notificationId;
+    return r.success;
+  }
+
+  async close(): Promise<boolean> {
+    if (!this.#id) return false;
+    return notification.close(this.#id);
+  }
+}
 
 // ============================================
 // tray — 시스템 트레이 (Electron `Tray`). frontend `@suji/api`와 동일 cmd.

--- a/sdks/suji-go/notification/notification.go
+++ b/sdks/suji-go/notification/notification.go
@@ -43,3 +43,18 @@ func Close(notificationID string) string {
 func RemoveAll() string {
 	return suji.Invoke("__core__", `{"cmd":"notification_remove_all"}`)
 }
+
+// ShowGrouped shows a notification with a caller id + group id (macOS threadIdentifier),
+// making it a RemoveGroup target. Empty id → auto-generated. Response: `{"notificationId","success"}`.
+func ShowGrouped(id, title, body string, silent bool, groupID string) string {
+	return suji.Invoke("__core__", fmt.Sprintf(
+		`{"cmd":"notification_show","id":"%s","title":"%s","body":"%s","silent":%t,"groupId":"%s"}`,
+		jsonesc.Full(id), jsonesc.Full(title), jsonesc.Full(body), silent, jsonesc.Full(groupID),
+	))
+}
+
+// RemoveGroup removes delivered notifications whose group (macOS threadIdentifier) matches
+// (Electron Notification.removeGroup). macOS only; Win/Linux false. Response: `{"success":bool}`.
+func RemoveGroup(groupID string) string {
+	return suji.Invoke("__core__", fmt.Sprintf(`{"cmd":"notification_remove_group","groupId":"%s"}`, jsonesc.Full(groupID)))
+}

--- a/sdks/suji-go/tray/tray.go
+++ b/sdks/suji-go/tray/tray.go
@@ -52,6 +52,17 @@ func SetTooltip(trayID uint32, tooltip string) string {
 	))
 }
 
+// SetToolTip is the Electron-named alias of SetTooltip (identical behavior).
+func SetToolTip(trayID uint32, toolTip string) string {
+	return SetTooltip(trayID, toolTip)
+}
+
+// GetBounds returns the tray icon's screen rect (Electron tray.getBounds).
+// Response: `{"x","y","width","height"}`. macOS only; Win/Linux 0 rect.
+func GetBounds(trayID uint32) string {
+	return suji.Invoke("__core__", fmt.Sprintf(`{"cmd":"tray_get_bounds","trayId":%d}`, trayID))
+}
+
 // SetMenu — items 배열로 메뉴 구성. macOS/Linux는 checkbox/submenu/enabled를 지원한다.
 func SetMenu(trayID uint32, items []MenuItem) string {
 	return suji.Invoke("__core__", buildSetMenuRequest(trayID, items))

--- a/src/core/app.zig
+++ b/src/core/app.zig
@@ -1266,6 +1266,36 @@ pub const notification = struct {
         const fields = std.fmt.bufPrint(&fields_buf, "\"notificationId\":\"{s}\"", .{id_buf[0..id_n]}) catch return null;
         return coreCmd("notification_close", fields);
     }
+
+    /// caller-id + groupId(macOS threadIdentifier) 지정 표시 — removeGroup 대상.
+    /// id 빈 문자열이면 자동 생성. 응답: `{"notificationId","success"}`.
+    pub fn showGrouped(id: []const u8, title: []const u8, body: []const u8, silent: bool, group_id: []const u8) ?[]const u8 {
+        var id_buf: [128]u8 = undefined;
+        var t_buf: [4096]u8 = undefined;
+        var b_buf: [4096]u8 = undefined;
+        var g_buf: [512]u8 = undefined;
+        const id_n = util.escapeJsonStrFull(id, &id_buf) orelse return null;
+        const t_n = util.escapeJsonStrFull(title, &t_buf) orelse return null;
+        const b_n = util.escapeJsonStrFull(body, &b_buf) orelse return null;
+        const g_n = util.escapeJsonStrFull(group_id, &g_buf) orelse return null;
+        var fields_buf: [9400]u8 = undefined;
+        const fields = std.fmt.bufPrint(
+            &fields_buf,
+            "\"id\":\"{s}\",\"title\":\"{s}\",\"body\":\"{s}\",\"silent\":{},\"groupId\":\"{s}\"",
+            .{ id_buf[0..id_n], t_buf[0..t_n], b_buf[0..b_n], silent, g_buf[0..g_n] },
+        ) catch return null;
+        return coreCmd("notification_show", fields);
+    }
+
+    /// 그룹(groupId=macOS threadIdentifier) 알림 제거(Electron Notification.removeGroup).
+    /// macOS only. 응답: `{"success":bool}`.
+    pub fn removeGroup(group_id: []const u8) ?[]const u8 {
+        var g_buf: [512]u8 = undefined;
+        const g_n = util.escapeJsonStrFull(group_id, &g_buf) orelse return null;
+        var fields_buf: [600]u8 = undefined;
+        const fields = std.fmt.bufPrint(&fields_buf, "\"groupId\":\"{s}\"", .{g_buf[0..g_n]}) catch return null;
+        return coreCmd("notification_remove_group", fields);
+    }
 };
 
 pub const tray = struct {

--- a/src/core/app.zig
+++ b/src/core/app.zig
@@ -1308,6 +1308,19 @@ pub const tray = struct {
         return coreCmd("tray_set_tooltip", fields);
     }
 
+    /// Electron 명명(tray.setToolTip) 별칭 — setTooltip 과 동일.
+    pub fn setToolTip(tray_id: u32, tool_tip: []const u8) ?[]const u8 {
+        return setTooltip(tray_id, tool_tip);
+    }
+
+    /// 트레이 아이콘 화면 좌표 rect(Electron tray.getBounds). 응답: `{"x","y","width","height"}`.
+    /// macOS only(Win/Linux 0 rect).
+    pub fn getBounds(tray_id: u32) ?[]const u8 {
+        var fields_buf: [32]u8 = undefined;
+        const fields = std.fmt.bufPrint(&fields_buf, "\"trayId\":{d}", .{tray_id}) catch return null;
+        return coreCmd("tray_get_bounds", fields);
+    }
+
     /// 메뉴 설정 — items_json은 cmd 객체에 들어갈 raw JSON `"items":[...]`. caller가 빌드.
     /// 예: `\"items\":[{\"label\":\"Settings\",\"click\":\"open-settings\"},{\"type\":\"separator\"}]`.
     pub fn setMenuRaw(tray_id: u32, items_json: []const u8) ?[]const u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3003,6 +3003,15 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         const result = std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"tray_set_tooltip\",\"success\":{}}}", .{ok}) catch return null;
         return result;
     }
+    if (std.mem.eql(u8, cmd, "tray_get_bounds")) {
+        const tray_id: u32 = util.nonNegU32(util.extractJsonInt(req_clean, "trayId") orelse return null);
+        const r = cef.trayGetBounds(tray_id);
+        return std.fmt.bufPrint(
+            response_buf,
+            "{{\"from\":\"zig-core\",\"cmd\":\"tray_get_bounds\",\"x\":{d},\"y\":{d},\"width\":{d},\"height\":{d}}}",
+            .{ r.x, r.y, r.width, r.height },
+        ) catch null;
+    }
     if (std.mem.eql(u8, cmd, "tray_set_menu")) {
         return handleTraySetMenu(req_clean, response_buf);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3083,14 +3083,24 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         const silent = util.extractJsonBool(req_clean, "silent") orelse false;
         var t_buf: [4096]u8 = undefined;
         var b_buf: [4096]u8 = undefined;
+        var g_buf: [256]u8 = undefined;
         const t_n = util.unescapeJsonStr(title_raw, &t_buf) orelse 0;
         const b_n = util.unescapeJsonStr(body_raw, &b_buf) orelse 0;
+        const g_n = util.unescapeJsonStr(util.extractJsonString(req_clean, "groupId") orelse "", &g_buf) orelse 0;
 
-        const id = nextNotificationId();
-        var id_buf: [32]u8 = undefined;
-        const id_str = std.fmt.bufPrint(&id_buf, "suji-notif-{d}", .{id}) catch return null;
+        // caller 가 id 를 주면 사용(NotificationOptions.id), 없으면 자동 생성. id 한도는 64
+        // byte(네이티브 notificationShow id_buf 와 동형) — 초과 시 graceful 하게 자동 생성으로
+        // 폴백(응답 notificationId 가 generated 라 caller 가 그 값으로 close — uuid 등 정상 id 는 안전).
+        var id_buf: [64]u8 = undefined;
+        const id_str = blk: {
+            const id_override = util.extractJsonString(req_clean, "id") orelse "";
+            if (id_override.len > 0) {
+                if (util.unescapeJsonStr(id_override, &id_buf)) |n| break :blk id_buf[0..n];
+            }
+            break :blk std.fmt.bufPrint(&id_buf, "suji-notif-{d}", .{nextNotificationId()}) catch return null;
+        };
 
-        const ok = cef.notificationShow(id_str, t_buf[0..t_n], b_buf[0..b_n], silent);
+        const ok = cef.notificationShow(id_str, t_buf[0..t_n], b_buf[0..b_n], silent, g_buf[0..g_n]);
         const result = std.fmt.bufPrint(
             response_buf,
             "{{\"from\":\"zig-core\",\"cmd\":\"notification_show\",\"notificationId\":\"{s}\",\"success\":{}}}",
@@ -3110,6 +3120,13 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
     if (std.mem.eql(u8, cmd, "notification_remove_all")) {
         const ok = cef.notificationRemoveAll();
         return std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"notification_remove_all\",\"success\":{}}}", .{ok}) catch null;
+    }
+    // Electron Notification.removeGroup(groupId) — threadIdentifier 일치 알림 제거(macOS).
+    if (std.mem.eql(u8, cmd, "notification_remove_group")) {
+        var g_buf: [256]u8 = undefined;
+        const g_n = util.unescapeJsonStr(util.extractJsonString(req_clean, "groupId") orelse "", &g_buf) orelse 0;
+        const ok = cef.notificationRemoveGroup(g_buf[0..g_n]);
+        return std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"notification_remove_group\",\"success\":{}}}", .{ok}) catch null;
     }
 
     if (std.mem.eql(u8, cmd, "core_info")) {

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -139,6 +139,7 @@ pub const setTrayEmitHandler = cef_public_api.setTrayEmitHandler;
 pub const createTray = cef_public_api.createTray;
 pub const setTrayTitle = cef_public_api.setTrayTitle;
 pub const setTrayTooltip = cef_public_api.setTrayTooltip;
+pub const trayGetBounds = cef_public_api.trayGetBounds;
 pub const setTrayMenu = cef_public_api.setTrayMenu;
 pub const destroyTray = cef_public_api.destroyTray;
 pub const NotificationEmitHandler = cef_public_api.NotificationEmitHandler;

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -149,6 +149,7 @@ pub const notificationRequestPermission = cef_public_api.notificationRequestPerm
 pub const notificationShow = cef_public_api.notificationShow;
 pub const notificationClose = cef_public_api.notificationClose;
 pub const notificationRemoveAll = cef_public_api.notificationRemoveAll;
+pub const notificationRemoveGroup = cef_public_api.notificationRemoveGroup;
 pub const GlobalShortcutEmitHandler = cef_public_api.GlobalShortcutEmitHandler;
 pub const GlobalShortcutStatus = cef_public_api.GlobalShortcutStatus;
 pub const setGlobalShortcutEmitHandler = cef_public_api.setGlobalShortcutEmitHandler;

--- a/src/platform/cef_notification.zig
+++ b/src/platform/cef_notification.zig
@@ -15,7 +15,8 @@ const writeCStr = cef.writeCStr;
 extern "c" fn suji_notification_is_supported() i32;
 extern "c" fn suji_notification_set_click_callback(cb: *const fn ([*:0]const u8) callconv(.c) void) void;
 extern "c" fn suji_notification_request_permission() i32;
-extern "c" fn suji_notification_show(id: [*:0]const u8, title: [*:0]const u8, body: [*:0]const u8, silent: i32) i32;
+extern "c" fn suji_notification_show(id: [*:0]const u8, title: [*:0]const u8, body: [*:0]const u8, silent: i32, group: [*:0]const u8) i32;
+extern "c" fn suji_notification_remove_group(group: [*:0]const u8) void;
 extern "c" fn suji_notification_close(id: [*:0]const u8) void;
 extern "c" fn suji_notification_remove_all() void;
 
@@ -66,17 +67,30 @@ pub fn notificationRequestPermission() bool {
 
 /// 알림 표시. id는 caller-controlled 식별자 (close에 사용). 한도: 64 byte.
 /// title/body는 4KB stack-alloc 한도.
-pub fn notificationShow(id: []const u8, title: []const u8, body: []const u8, silent: bool) bool {
+pub fn notificationShow(id: []const u8, title: []const u8, body: []const u8, silent: bool, group: []const u8) bool {
+    // group(threadIdentifier)은 macOS 전용 — Win/Linux 는 무시(개별 알림으로 표시).
     if (comptime builtin.os.tag == .windows) return notification_windows.win_notify.show(id, title, body, silent);
     if (comptime is_linux) return notification_linux.show(id, title, body, silent);
     if (!comptime is_macos) return false;
     var id_buf: [64]u8 = undefined;
     var t_buf: [4096]u8 = undefined;
     var b_buf: [4096]u8 = undefined;
+    var g_buf: [512]u8 = undefined;
     const id_cstr = writeCStr(id, &id_buf) orelse return false;
     const t_cstr = writeCStr(title, &t_buf) orelse return false;
     const b_cstr = writeCStr(body, &b_buf) orelse return false;
-    return suji_notification_show(id_cstr, t_cstr, b_cstr, if (silent) 1 else 0) != 0;
+    const g_cstr = writeCStr(group, &g_buf) orelse return false;
+    return suji_notification_show(id_cstr, t_cstr, b_cstr, if (silent) 1 else 0, g_cstr) != 0;
+}
+
+/// Electron `Notification.removeGroup(groupId)` — threadIdentifier 가 일치하는 표시된 알림 제거.
+/// macOS only(UNUserNotificationCenter threadIdentifier). Win/Linux 는 그룹 개념 미지원 → false.
+pub fn notificationRemoveGroup(group: []const u8) bool {
+    if (!comptime is_macos) return false;
+    var g_buf: [512]u8 = undefined;
+    const g_cstr = writeCStr(group, &g_buf) orelse return false;
+    suji_notification_remove_group(g_cstr);
+    return true;
 }
 
 pub fn notificationClose(id: []const u8) bool {

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -334,6 +334,7 @@ pub const setTrayEmitHandler = cef_tray.setTrayEmitHandler;
 pub const createTray = cef_tray.createTray;
 pub const setTrayTitle = cef_tray.setTrayTitle;
 pub const setTrayTooltip = cef_tray.setTrayTooltip;
+pub const trayGetBounds = cef_tray.trayGetBounds;
 pub const setTrayMenu = cef_tray.setTrayMenu;
 pub const destroyTray = cef_tray.destroyTray;
 

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -345,6 +345,7 @@ pub const notificationRequestPermission = cef_notification.notificationRequestPe
 pub const notificationShow = cef_notification.notificationShow;
 pub const notificationClose = cef_notification.notificationClose;
 pub const notificationRemoveAll = cef_notification.notificationRemoveAll;
+pub const notificationRemoveGroup = cef_notification.notificationRemoveGroup;
 
 pub const GlobalShortcutEmitHandler = cef_global_shortcut.GlobalShortcutEmitHandler;
 pub const GlobalShortcutStatus = cef_global_shortcut.GlobalShortcutStatus;

--- a/src/platform/cef_tray.zig
+++ b/src/platform/cef_tray.zig
@@ -178,6 +178,29 @@ pub fn setTrayTooltip(tray_id: u32, tooltip: []const u8) bool {
     return true;
 }
 
+/// Electron `tray.getBounds()` — 트레이 아이콘 화면 좌표 rect. macOS: NSStatusItem.button.
+/// window.frame 을 **top-left origin** 으로 변환(Electron/getMacWindowBounds 동일 — Cocoa
+/// bottom-left → top-left: y = screenH - frame.y - frame.height). 미존재/비-macOS 는 0 rect.
+/// 정직 경계: macOS only(Win/Linux 는 0 — Shell_NotifyIconGetRect/GTK geometry 후속).
+pub fn trayGetBounds(tray_id: u32) cef.NSRect {
+    const empty = cef.NSRect{ .x = 0, .y = 0, .width = 0, .height = 0 };
+    if (!comptime is_macos) return empty;
+    if (!g_trays_initialized) return empty;
+    const entry = g_trays.get(tray_id) orelse return empty;
+    const button = msgSend(entry.status_item, "button") orelse return empty;
+    const window = msgSend(button, "window") orelse return empty;
+    const frameFn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) cef.NSRect = @ptrCast(&objc.objc_msgSend);
+    const frame = frameFn(window, @ptrCast(objc.sel_registerName("frame")));
+    // Cocoa bottom-left → Electron top-left.
+    const top_y: f64 = blk: {
+        const NSScreen = getClass("NSScreen") orelse break :blk frame.y;
+        const mainScreen = msgSend(NSScreen, "mainScreen") orelse break :blk frame.y;
+        const screen_frame = frameFn(mainScreen, @ptrCast(objc.sel_registerName("frame")));
+        break :blk screen_frame.height - frame.y - frame.height;
+    };
+    return .{ .x = frame.x, .y = top_y, .width = frame.width, .height = frame.height };
+}
+
 /// items 배열로 NSMenu 빌드 + tray에 attach. 기존 menu가 있으면 NSMenuItem.representedObject
 /// (NSString) 자동 release (NSMenu deinit 연쇄).
 pub fn setTrayMenu(tray_id: u32, items: []const TrayMenuItem) bool {

--- a/src/platform/notification.m
+++ b/src/platform/notification.m
@@ -98,13 +98,15 @@ int suji_notification_request_permission(void) {
 
 // 알림 표시. id는 caller-controlled 식별자 (close에 사용). silent=1이면 sound 없음.
 // 반환: 1 = success, 0 = error (권한 없음 등).
-int suji_notification_show(const char *id, const char *title, const char *body, int silent) {
+int suji_notification_show(const char *id, const char *title, const char *body, int silent, const char *group) {
     if (!suji_notification_is_supported()) return 0;
     if (id == NULL) return 0;
     UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
     if (title && *title) content.title = [NSString stringWithUTF8String:title];
     if (body && *body) content.body = [NSString stringWithUTF8String:body];
     if (!silent) content.sound = [UNNotificationSound defaultSound];
+    // groupId → threadIdentifier (UNUserNotificationCenter 그룹화 + removeGroup 대상).
+    if (group && *group) content.threadIdentifier = [NSString stringWithUTF8String:group];
 
     NSString *identifier = [NSString stringWithUTF8String:id];
     UNNotificationRequest *req = [UNNotificationRequest requestWithIdentifier:identifier
@@ -139,4 +141,25 @@ void suji_notification_remove_all(void) {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     [center removeAllDeliveredNotifications];
     [center removeAllPendingNotificationRequests];
+}
+
+// Notification.removeGroup(groupId) — threadIdentifier 가 group 과 일치하는 표시된 알림 제거.
+// getDelivered 는 async → wait_for_done 으로 동기 대기(show 패턴 동형).
+void suji_notification_remove_group(const char *group) {
+    if (!suji_notification_is_supported()) return;
+    if (group == NULL || !*group) return;
+    NSString *gid = [NSString stringWithUTF8String:group];
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    __block BOOL done = NO;
+    [center getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> *notifications) {
+        NSMutableArray<NSString *> *ids = [NSMutableArray array];
+        for (UNNotification *n in notifications) {
+            if ([n.request.content.threadIdentifier isEqualToString:gid]) {
+                [ids addObject:n.request.identifier];
+            }
+        }
+        if (ids.count > 0) [center removeDeliveredNotificationsWithIdentifiers:ids];
+        done = YES;
+    }];
+    wait_for_done(&done);
 }

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -2737,6 +2737,27 @@ test "clipboard RTF + Buffer IPC + cef pasteboard" {
     }
 }
 
+test "tray.getBounds IPC + cef NSStatusItem frame" {
+    const main_src = try readMainSource();
+    defer std.testing.allocator.free(main_src);
+    inline for (.{
+        "\"tray_get_bounds\"",
+        "cef.trayGetBounds",
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, main_src, needle) != null);
+    }
+
+    const cef_src = try readCefSource();
+    defer std.testing.allocator.free(cef_src);
+    inline for (.{
+        "pub fn trayGetBounds",
+        "\"window\"", // status_item.button.window
+        "\"frame\"", // window frame (NSRect)
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, cef_src, needle) != null);
+    }
+}
+
 test "clipboard writeBookmark/writeFindText/write IPC + cef pasteboard" {
     const main_src = try readMainSource();
     defer std.testing.allocator.free(main_src);

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -2679,6 +2679,39 @@ test "notification Linux D-Bus wiring + runtime E2E" {
     try std.testing.expect(std.mem.indexOf(u8, plan_src, "Linux freedesktop D-Bus") != null);
 }
 
+test "notification id override + groupId/removeGroup IPC + cef threadIdentifier" {
+    const main_src = try readMainSource();
+    defer std.testing.allocator.free(main_src);
+    inline for (.{
+        "util.extractJsonString(req_clean, \"id\")", // caller-supplied id
+        "util.extractJsonString(req_clean, \"groupId\")", // groupId 추출
+        "\"notification_remove_group\"",
+        "cef.notificationRemoveGroup",
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, main_src, needle) != null);
+    }
+
+    const cef_src = try readCefSource();
+    defer std.testing.allocator.free(cef_src);
+    inline for (.{
+        "pub fn notificationRemoveGroup",
+        "suji_notification_remove_group", // extern
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, cef_src, needle) != null);
+    }
+
+    // notification.m — threadIdentifier(그룹) + remove_group(getDelivered 필터).
+    const m_src = try std.Io.Dir.cwd().readFileAlloc(std_io, "src/platform/notification.m", std.testing.allocator, .limited(1024 * 1024));
+    defer std.testing.allocator.free(m_src);
+    inline for (.{
+        "content.threadIdentifier",
+        "void suji_notification_remove_group",
+        "getDeliveredNotificationsWithCompletionHandler",
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, m_src, needle) != null);
+    }
+}
+
 test "app.requestUserAttention IPC — NSApp request/cancel" {
     const main_src = try readMainSource();
     defer std.testing.allocator.free(main_src);

--- a/tests/e2e/notification.test.ts
+++ b/tests/e2e/notification.test.ts
@@ -89,6 +89,29 @@ describe("notification.show — IPC 라우팅", () => {
     });
     expect(r.notificationId).toMatch(/^suji-notif-/);
   });
+
+  test("caller-supplied id → notificationId 그대로 반환 (NotificationOptions.id)", async () => {
+    const r = await core<{ notificationId: string }>({
+      cmd: "notification_show", title: "Custom", body: "id", id: "my-custom-notif-id",
+    });
+    expect(r.notificationId).toBe("my-custom-notif-id");
+  });
+
+  test("groupId 포함 show → notificationId 반환 (threadIdentifier wire)", async () => {
+    const r = await core<{ notificationId: string; success: boolean }>({
+      cmd: "notification_show", title: "Grouped", body: "g", groupId: "grp-1",
+    });
+    expect(typeof r.notificationId).toBe("string");
+    expect(typeof r.success).toBe("boolean");
+  });
+});
+
+describe("notification.removeGroup", () => {
+  test("removeGroup → success boolean", async () => {
+    await core({ cmd: "notification_show", title: "G", body: "g", groupId: "grp-rm" });
+    const r = await core<{ success: boolean }>({ cmd: "notification_remove_group", groupId: "grp-rm" });
+    expect(typeof r.success).toBe("boolean");
+  });
 });
 
 describe("notification.close", () => {

--- a/tests/e2e/tray.test.ts
+++ b/tests/e2e/tray.test.ts
@@ -131,6 +131,16 @@ describe("setTitle / setTooltip / setMenu — 응답", () => {
     expect(r.success).toBe(true);
   });
 
+  test("getBounds → x/y/width/height 숫자 (macOS 는 실 rect)", async () => {
+    const r = await core<{ x: number; y: number; width: number; height: number }>({ cmd: "tray_get_bounds", trayId });
+    expect(typeof r.x).toBe("number");
+    expect(typeof r.y).toBe("number");
+    expect(typeof r.width).toBe("number");
+    expect(typeof r.height).toBe("number");
+    // macOS 메뉴바 status item 은 width > 0(실 아이콘 폭). 비-macOS 는 0.
+    if (process.platform === "darwin") expect(r.width).toBeGreaterThan(0);
+  });
+
   test("setMenu separator + 일반 항목 혼합", async () => {
     const r = await core<{ success: boolean }>({
       cmd: "tray_set_menu", trayId,


### PR DESCRIPTION
## 요약

Electron 패리티 **notification 카테고리 마감** — 전 5 SDK.

| API | 구현 |
|---|---|
| `NotificationOptions.id` | caller-supplied 식별자(없으면 자동 생성, 64 byte 한도) |
| `NotificationOptions.groupId` | macOS UNMutableNotificationContent.threadIdentifier |
| `Notification.removeGroup(groupId)` | notification.m getDelivered 필터 → removeDelivered |
| `Notification` 클래스 (JS/Node) | OO 래퍼(BrowserWindow 동형): `new Notification(opts)` + readonly `id` + show()/close() |

native: `suji_notification_show` 에 group 파라미터(threadIdentifier) 추가, `suji_notification_remove_group` 추가.

## 품질 게이트

- **/simplify**: clean (Notification 클래스 per-SDK dup·show_grouped format dup 모두 기존 BrowserWindow/no-shared-module 선례대로 의도적).
- **/code-review**: **ABI param-count match**(notification.m ↔ Zig extern 5-param 정확 일치) 검증, id_buf reuse·re-export 체인 검증. 수정 — cef `g_buf` 256→512(256-byte group 의 writeCStr off-by-one suppression 방지), 64-byte caller-id 폴백 주석.

## 정직 경계

- `groupId`/`removeGroup`/그룹화 + `Notification` 클래스 그룹 기능 **macOS only**(threadIdentifier). Win/Linux 는 groupId 무시(개별 알림), removeGroup `false`.
- `id` 는 전 플랫폼 caller-supplied(64 byte 한도 — 네이티브 id_buf 동형, 초과 시 graceful 자동생성).
- Rust/Go/Zig 는 함수형 `show_grouped`/`remove_group`(클래스는 JS/Node OO — BrowserWindow 선례).

## 검증
- `zig build test` 941/943 (2 skip)
- e2e notification 13/13 (caller-id passthrough · groupId wire · removeGroup success)
- `cef_ipc_test.zig` guards (threadIdentifier / remove_group / getDelivered)
- Rust/Go build+fmt, suji-js tsc

🤖 Generated with [Claude Code](https://claude.com/claude-code)