### PR TITLE
feat(powerMonitor): shutdown + on-battery/on-ac events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,9 +261,11 @@ fn onAllClosed(_: suji.Event) void {
 //                                       — App Sandbox 영속 파일 접근 (NSURL bookmark,
 //                                       비-sandbox=일반 bookmark / MAS 만 실 격상)
 // powerMonitor 이벤트 — 자동 install (macOS NSWorkspace, Linux logind/ScreenSaver DBus,
-//   Windows WM_POWERBROADCAST/WTS), 4 채널 발신:
+//   Windows WM_POWERBROADCAST/WTS), 채널 발신:
 //   `power:suspend` / `power:resume` / `power:lock-screen` / `power:unlock-screen`
-//   → suji.on("power:suspend", cb) / 다른 SDK도 동일 채널명으로 listen
+//   + macOS: `power:shutdown`(NSWorkspaceWillPowerOff) / `power:on-battery` /
+//   `power:on-ac`(IOPS run-loop source, AC↔배터리 전환) → suji.on("power:shutdown", cb)
+//   → 다른 SDK도 동일 채널명으로 listen. (shutdown/배터리 이벤트는 macOS 한정)
 // suji.process.run(allocator, suji.io(), &.{ "echo", "hi" })  — std.process.run wrap (백엔드 only)
 //   → RunResult { code, stdout, stderr }, caller가 stdout/stderr free
 // suji.http.fetch(allocator, suji.io(), "https://...", null)   — std.http.Client.fetch wrap

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -148,9 +148,9 @@
 ### powerMonitor
 
 - ~~**[medium]** `powerMonitor.getSystemIdleState(threshold: number)`~~ ✅ — Update TypeScript return type in packages/suji-js/src/index.ts:724 from Promise<'active' | 'idle'> to Promise<'active' | 'idle' | 'locked'> and the coreCall generic from { state: 'active' | 'idle' } t
-- **[medium]** `powerMonitor.onBatteryPower (property)` — Implement isOnBatteryPower() method first (platform-specific: macOS via IOKit or IOPowerSources, fetch AC adapter status). Then add onBatteryPower as a getter property delegating to isOnBatteryPower()
-- **[medium]** `powerMonitor.on('on-battery') event` — Extend src/platform/power_monitor.m to use IOPowerSources.framework for battery state detection. Add 'power:on-battery' and 'power:on-ac' event emissions via existing NSWorkspace observer callback pat
-- **[medium]** `powerMonitor 'shutdown' event` — Add NSWorkspaceWillPowerOffNotification observer to power_monitor.m. Add onPowerOff method to SujiPowerObserver that calls callback with shutdown string. Register notification with NSWorkspace notific
+- ~~**[medium]** `powerMonitor.onBatteryPower (property)`~~ ✅ (이미 isOnBatteryPower()로 충족) — suji 는 IPC 라 sync property 불가 → `powerMonitor.isOnBatteryPower()` async 메서드가 Electron onBatteryPower 동등(macOS IOKit IOPSGetProvidingPowerSourceType). 전 SDK 기존 제공.
+- ~~**[medium]** `powerMonitor.on('on-battery') event`~~ ✅ (powerMonitor events PR) — `power:on-battery`/`power:on-ac` — power_monitor.m IOPSNotificationCreateRunLoopSource(메인 런루프 부착) 가 AC↔배터리 전환 시 발신(power_source_changed, 중복 억제). suji.on 수신. 정직 경계: macOS only(Linux/Win 후속), 실 전환은 헤드리스 미발화(suspend/resume 동급 — compile+wire 검증).
+- ~~**[medium]** `powerMonitor 'shutdown' event`~~ ✅ (powerMonitor events PR) — `power:shutdown` — power_monitor.m onPowerOff: (NSWorkspaceWillPowerOffNotification). suji.on 수신. 정직 경계: macOS only, 실 종료 미발화(honest).
 
 ### powerSaveBlocker
 

--- a/src/platform/power_monitor.m
+++ b/src/platform/power_monitor.m
@@ -35,9 +35,26 @@ static void (*g_power_callback)(const char *event) = NULL;
     (void)note;
     if (g_power_callback) g_power_callback("unlock-screen");
 }
+- (void)onPowerOff:(NSNotification *)note {
+    (void)note;
+    if (g_power_callback) g_power_callback("shutdown");
+}
 @end
 
 static SujiPowerObserver *g_observer = nil;
+static CFRunLoopSourceRef g_power_source = NULL;
+static int g_last_on_battery = -1;
+
+int suji_power_monitor_is_on_battery(void); // 아래 정의 — power_source_changed 가 먼저 참조.
+
+// IOPS power-source 변경 콜백 — AC↔배터리 전환 시에만 emit(스풀리어스 중복 억제).
+static void power_source_changed(void *ctx) {
+    (void)ctx;
+    int ob = suji_power_monitor_is_on_battery();
+    if (ob == g_last_on_battery) return;
+    g_last_on_battery = ob;
+    if (g_power_callback) g_power_callback(ob ? "on-battery" : "on-ac");
+}
 
 void suji_power_monitor_install(void (*cb)(const char *)) {
     g_power_callback = cb;
@@ -48,6 +65,12 @@ void suji_power_monitor_install(void (*cb)(const char *)) {
     [nc addObserver:g_observer selector:@selector(onWake:) name:NSWorkspaceDidWakeNotification object:nil];
     [nc addObserver:g_observer selector:@selector(onScreenSleep:) name:NSWorkspaceScreensDidSleepNotification object:nil];
     [nc addObserver:g_observer selector:@selector(onScreenWake:) name:NSWorkspaceScreensDidWakeNotification object:nil];
+    [nc addObserver:g_observer selector:@selector(onPowerOff:) name:NSWorkspaceWillPowerOffNotification object:nil];
+
+    // IOPS run-loop source — AC/배터리 전환 이벤트(on-battery/on-ac). 메인 런루프에 부착.
+    g_last_on_battery = suji_power_monitor_is_on_battery();
+    g_power_source = IOPSNotificationCreateRunLoopSource(power_source_changed, NULL);
+    if (g_power_source) CFRunLoopAddSource(CFRunLoopGetMain(), g_power_source, kCFRunLoopDefaultMode);
 }
 
 void suji_power_monitor_uninstall(void) {
@@ -56,6 +79,11 @@ void suji_power_monitor_uninstall(void) {
     [nc removeObserver:g_observer];
     g_observer = nil;
     g_power_callback = NULL;
+    if (g_power_source) {
+        CFRunLoopRemoveSource(CFRunLoopGetMain(), g_power_source, kCFRunLoopDefaultMode);
+        CFRelease(g_power_source);
+        g_power_source = NULL;
+    }
 }
 
 // Electron powerMonitor.isOnBatteryPower() — 현재 전원이 배터리인지(IOKit IOPS).

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -1546,10 +1546,16 @@ test "powerMonitor — install hook + 4 이벤트 채널 emit 패턴" {
         "NSWorkspaceDidWakeNotification",
         "NSWorkspaceScreensDidSleepNotification",
         "NSWorkspaceScreensDidWakeNotification",
+        "NSWorkspaceWillPowerOffNotification", // shutdown
         "\"suspend\"",
         "\"resume\"",
         "\"lock-screen\"",
         "\"unlock-screen\"",
+        "\"shutdown\"",
+        "\"on-battery\"",
+        "\"on-ac\"",
+        "IOPSNotificationCreateRunLoopSource", // 배터리 전환 run-loop source
+        "power_source_changed", // AC↔배터리 콜백
     }) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, m_src, needle) != null);
     }


### PR DESCRIPTION
## 요약

Electron 패리티 **powerMonitor 카테고리 마감** (macOS).

| 이벤트/API | 구현 |
|---|---|
| `power:shutdown` | `power_monitor.m` onPowerOff: (NSWorkspaceWillPowerOffNotification) |
| `power:on-battery` / `power:on-ac` | IOPSNotificationCreateRunLoopSource(메인 런루프) — AC↔배터리 전환 시 발신, `g_last_on_battery` 중복 억제, uninstall 정리 |
| `onBatteryPower` (property) | 이미 `isOnBatteryPower()` async 메서드로 충족 (suji 는 IPC → sync property 불가) |

이벤트는 기존 `powerMonitorEmitHandler`(`power:` prefix) + `suji.on` 으로 수신 — **신규 SDK 메서드 0**.

## 품질 게이트

- **/code-review**: IOPS 콜백 시그니처(IOPowerSourceCallbackType match)·CFRunLoopGetMain/AddSource·forward declaration·leak/double-free(guarded)·중복-억제 로직 검증. 리뷰 에이전트가 `power_monitor.m` 를 **독립 컴파일(exit 0)** 해 clean 확인.

## 정직 경계

- macOS only(Linux/Win shutdown·배터리 이벤트 후속).
- 실 종료/배터리 전환은 **헤드리스 미발화** → compile + wire + source-guard 검증(기존 suspend/resume 이벤트와 동일 honest bar).

## 검증
- `zig build test` 941/943 (2 skip)
- `cef_ipc_test.zig` source guard (NSWorkspaceWillPowerOff / IOPSNotificationCreateRunLoopSource / power_source_changed / shutdown·on-battery·on-ac)

🤖 Generated with [Claude Code](https://claude.com/claude-code)