### PR TITLE
feat(WebContentsView): View.getBounds + setBackgroundColor + WebContentsView 클래스

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,10 @@ suji.platform                                                // "macos" | "linux
 // await windows.createView({hostId, url, bounds}) → {viewId}              (Phase 17-B WebContentsView)
 // await windows.addChildView(host, view, index?) / setTopView / removeChildView
 // await windows.setViewBounds(viewId, {...}) / setViewVisible(viewId, bool) / getChildViews(host)
+//   / getViewBounds(viewId) → {ok,x,y,width,height} (추적값) / setViewBackgroundColor(viewId, "#RRGGBB[AA]")
+//     (cef_view_t.set_background_color). class WebContentsView (BrowserWindow 동형 OO facade):
+//     WebContentsView.create({hostId,url,bounds}) + setBounds/getBounds/setVisible/
+//     setBackgroundColor/destroy/loadURL/executeJavaScript/openDevTools (viewId=windowId 풀)
 //   viewId는 windowId와 같은 풀 — windows.loadURL(viewId,...) / executeJavaScript / openDevTools
 //   등 모든 webContents API가 view에도 동작.
 //   destroyView는 17-B CEF Views 경로에서 안정화 — target child cleanup/host 생존/

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -85,9 +85,9 @@
 
 ### WebContentsView
 
-- **[medium]** `View.getBounds()` — Add getViewBounds handler in window_ipc.zig mirroring the pattern of existing view getters. Add public getViewBounds method to WindowManager in window.zig that retrieves the bounds from the stored Win
-- **[medium]** `View.setBackgroundColor(color)` — Add windows.setViewBackgroundColor(viewId: number, color: string) method in packages/suji-js/src/index.ts (mirror of windows.setBackgroundColor but for views, using cmd 'set_view_background_color'). T
-- **[medium]** `BrowserWindow facade for views` — Export a WebContentsView class in packages/suji-js/src/index.ts (after BrowserWindow, around line 708) that mirrors BrowserWindow's pattern: static create(opts): Promise<WebContentsView> delegating to
+- ~~**[medium]** `View.getBounds()`~~ ✅ (WebContentsView PR) — windows.getViewBounds(viewId)/WebContentsView.getBounds() @suji/api + @suji/node. `get_view_bounds` cmd → window_ipc.handleGetViewBounds → WindowManager.getViewBounds 가 **추적 view.bounds** 반환(window 게터 동형 결정적, native/VTable 불요). 없으면 ok:false.
+- ~~**[medium]** `View.setBackgroundColor(color)`~~ ✅ (WebContentsView PR) — windows.setViewBackgroundColor(viewId, "#RRGGBB[AA]"). `set_view_background_color` cmd → VTable → cef_web_contents_view.setViewBackgroundColor(cef_view_t.set_background_color, parseHexColorArgb). 모든 variant(child/overlay/views-parent)의 browser_view 에 적용.
+- ~~**[medium]** `BrowserWindow facade for views`~~ ✅ (WebContentsView PR) — `class WebContentsView`(@suji/api + @suji/node, BrowserWindow 동형): create({hostId,url,bounds})/fromId + setBounds/getBounds/setVisible/setBackgroundColor/destroy/loadURL/executeJavaScript/openDevTools(viewId=windowId 풀 위임).
 
 ### app
 

--- a/documents/multi-webview.mdx
+++ b/documents/multi-webview.mdx
@@ -80,8 +80,35 @@ const { viewIds } = await windows.getChildViews(parentWindowId);
 await windows.loadURL(viewId, 'https://example.com');  // 기존 windows.* 동일
 await windows.executeJavaScript(viewId, "document.title");
 
+const b = await windows.getViewBounds(viewId);          // {ok,x,y,width,height} (추적값)
+await windows.setViewBackgroundColor(viewId, '#202020'); // 로드 중 배경(cef_view_t)
+
 await windows.destroyView(viewId);  // child target 정리, host/남은 view 생존
 ```
+
+### WebContentsView 클래스 (OO facade — Electron 동형)
+
+`windows.*`(raw viewId)의 객체지향 래퍼. `BrowserWindow` 와 동일 패턴이고 viewId 는
+windowId 풀이라 모든 webContents 메서드가 동작한다.
+
+```ts
+import { WebContentsView } from '@suji/api';
+
+const view = await WebContentsView.create({ hostId: win.id, url: 'https://example.com', bounds: { x: 0, y: 80, width: 1024, height: 600 } });
+await view.setBounds({ x: 0, y: 80, width: 1024, height: 520 });
+await view.getBounds();
+await view.setBackgroundColor('#202020');
+await view.setVisible(false);
+await view.loadURL('https://other.example');
+await view.destroy();
+```
+
+> `getViewBounds` 는 추적된 마지막 set/create 값을 반환(window 게터 동형 결정적).
+> `setViewBackgroundColor` 는 view 의 cef_view_t 배경색(로드 중 표시)이다. window
+> `setBackgroundColor` 와 **동일 hex 파서**(`#RRGGBB[AA]`, 잘못된 값은 no-op).
+> 정직 경계: macOS 기본 child_window 경로는 child가 별도 `NSWindow` 라 로드-시점
+> 배경은 NSWindow 가 그릴 수 있어 cef_view_t 색이 안 보일 수 있다(overlay /
+> views-parent 경로는 cef_view_t 가 직접 그림).
 
 ### 구현 — CEF Views 기반 (17-B)
 

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -290,6 +290,13 @@ export interface ViewOpResponse {
     viewId: number;
     ok: boolean;
 }
+/** get_view_bounds 응답 — 추적된 view bounds(없으면 ok:false + 0). */
+export interface ViewBoundsResponse extends ViewOpResponse {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
 export interface GetChildViewsResponse {
     cmd: "get_child_views";
     from: "zig-core";
@@ -507,6 +514,10 @@ export declare const windows: {
     setViewVisible(viewId: number, visible: boolean): Promise<ViewOpResponse>;
     /** host의 child view id들을 z-order 순서로 조회 (0=bottom, 마지막=top) */
     getChildViews(hostId: number): Promise<GetChildViewsResponse>;
+    /** Electron `View.getBounds()` — view 의 추적 bounds {x,y,width,height} (없으면 ok:false+0). */
+    getViewBounds(viewId: number): Promise<ViewBoundsResponse>;
+    /** Electron `View.setBackgroundColor(color)` — view cef_view_t 배경색 "#RRGGBB[AA]". */
+    setViewBackgroundColor(viewId: number, color: string): Promise<ViewOpResponse>;
 };
 /**
  * `windows.*`(raw windowId)의 객체지향 facade (Electron `BrowserWindow` 패리티).
@@ -625,6 +636,29 @@ export declare class BrowserWindow {
     }): Promise<{
         success: boolean;
     }>;
+}
+/**
+ * Electron `WebContentsView` 패리티 OO facade — host 창에 합성하는 child view.
+ * viewId 는 windowId 와 같은 풀이라 모든 webContents 메서드(loadURL/executeJavaScript 등)가
+ * view 에 동작한다. view 합성/조작은 `windows.*` 에 위임(BrowserWindow 와 동형 패턴).
+ */
+export declare class WebContentsView {
+    #private;
+    private constructor();
+    /** view 식별자(= windowId 풀). webContents 메서드 인자로 사용. */
+    get id(): number;
+    /** host 창에 child view 생성 후 인스턴스 반환 (Electron `new WebContentsView()` + addChildView). */
+    static create(opts: ViewOptions): Promise<WebContentsView>;
+    /** 기존 viewId 를 인스턴스로 래핑. */
+    static fromId(id: number): WebContentsView;
+    setBounds(bounds: SetBoundsArgs): Promise<ViewOpResponse>;
+    getBounds(): Promise<ViewBoundsResponse>;
+    setVisible(visible: boolean): Promise<ViewOpResponse>;
+    setBackgroundColor(color: string): Promise<ViewOpResponse>;
+    destroy(): Promise<ViewOpResponse>;
+    loadURL(url: string): Promise<WindowOpResponse>;
+    executeJavaScript(code: string): Promise<WindowOpResponse>;
+    openDevTools(): Promise<WindowOpResponse>;
 }
 export declare const powerMonitor: {
     /** 시스템 유휴 시간 (초). 활성 입력 후 0으로 리셋.

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -26,7 +26,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 };
-var _BrowserWindow_id, _Notification_id;
+var _BrowserWindow_id, _WebContentsView_id, _Notification_id;
 function getBridge() {
     const bridge = window.__suji__;
     if (!bridge)
@@ -517,6 +517,14 @@ export const windows = {
     getChildViews(hostId) {
         return coreCall({ cmd: "get_child_views", hostId });
     },
+    /** Electron `View.getBounds()` — view 의 추적 bounds {x,y,width,height} (없으면 ok:false+0). */
+    getViewBounds(viewId) {
+        return coreCall({ cmd: "get_view_bounds", viewId });
+    },
+    /** Electron `View.setBackgroundColor(color)` — view cef_view_t 배경색 "#RRGGBB[AA]". */
+    setViewBackgroundColor(viewId, color) {
+        return coreCall({ cmd: "set_view_background_color", viewId, color });
+    },
 };
 /**
  * `windows.*`(raw windowId)의 객체지향 facade (Electron `BrowserWindow` 패리티).
@@ -810,6 +818,59 @@ export class BrowserWindow {
     }
 }
 _BrowserWindow_id = new WeakMap();
+/**
+ * Electron `WebContentsView` 패리티 OO facade — host 창에 합성하는 child view.
+ * viewId 는 windowId 와 같은 풀이라 모든 webContents 메서드(loadURL/executeJavaScript 등)가
+ * view 에 동작한다. view 합성/조작은 `windows.*` 에 위임(BrowserWindow 와 동형 패턴).
+ */
+export class WebContentsView {
+    constructor(id) {
+        _WebContentsView_id.set(this, void 0);
+        __classPrivateFieldSet(this, _WebContentsView_id, id, "f");
+    }
+    /** view 식별자(= windowId 풀). webContents 메서드 인자로 사용. */
+    get id() {
+        return __classPrivateFieldGet(this, _WebContentsView_id, "f");
+    }
+    /** host 창에 child view 생성 후 인스턴스 반환 (Electron `new WebContentsView()` + addChildView). */
+    static async create(opts) {
+        const res = await windows.createView(opts);
+        if (typeof res.viewId !== "number") {
+            throw new Error(`create_view: no viewId in response (${JSON.stringify(res)})`);
+        }
+        return new WebContentsView(res.viewId);
+    }
+    /** 기존 viewId 를 인스턴스로 래핑. */
+    static fromId(id) {
+        return new WebContentsView(id);
+    }
+    setBounds(bounds) {
+        return windows.setViewBounds(__classPrivateFieldGet(this, _WebContentsView_id, "f"), bounds);
+    }
+    getBounds() {
+        return windows.getViewBounds(__classPrivateFieldGet(this, _WebContentsView_id, "f"));
+    }
+    setVisible(visible) {
+        return windows.setViewVisible(__classPrivateFieldGet(this, _WebContentsView_id, "f"), visible);
+    }
+    setBackgroundColor(color) {
+        return windows.setViewBackgroundColor(__classPrivateFieldGet(this, _WebContentsView_id, "f"), color);
+    }
+    destroy() {
+        return windows.destroyView(__classPrivateFieldGet(this, _WebContentsView_id, "f"));
+    }
+    // webContents 메서드 — viewId 가 windowId 풀이라 그대로 위임.
+    loadURL(url) {
+        return windows.loadURL(__classPrivateFieldGet(this, _WebContentsView_id, "f"), url);
+    }
+    executeJavaScript(code) {
+        return windows.executeJavaScript(__classPrivateFieldGet(this, _WebContentsView_id, "f"), code);
+    }
+    openDevTools() {
+        return windows.openDevTools(__classPrivateFieldGet(this, _WebContentsView_id, "f"));
+    }
+}
+_WebContentsView_id = new WeakMap();
 // ============================================
 // clipboard — 시스템 클립보드 (Electron `clipboard.readText/writeText`)
 // ============================================

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -369,6 +369,14 @@ export interface ViewOpResponse {
   ok: boolean;
 }
 
+/** get_view_bounds 응답 — 추적된 view bounds(없으면 ok:false + 0). */
+export interface ViewBoundsResponse extends ViewOpResponse {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export interface GetChildViewsResponse {
   cmd: "get_child_views";
   from: "zig-core";
@@ -878,6 +886,16 @@ export const windows = {
   getChildViews(hostId: number): Promise<GetChildViewsResponse> {
     return coreCall<GetChildViewsResponse>({ cmd: "get_child_views", hostId });
   },
+
+  /** Electron `View.getBounds()` — view 의 추적 bounds {x,y,width,height} (없으면 ok:false+0). */
+  getViewBounds(viewId: number): Promise<ViewBoundsResponse> {
+    return coreCall<ViewBoundsResponse>({ cmd: "get_view_bounds", viewId });
+  },
+
+  /** Electron `View.setBackgroundColor(color)` — view cef_view_t 배경색 "#RRGGBB[AA]". */
+  setViewBackgroundColor(viewId: number, color: string): Promise<ViewOpResponse> {
+    return coreCall<ViewOpResponse>({ cmd: "set_view_background_color", viewId, color });
+  },
 };
 
 /**
@@ -1174,6 +1192,61 @@ export class BrowserWindow {
   }
   capturePage(path: string, rect?: { x: number; y: number; width: number; height: number }) {
     return windows.capturePage(this.#id, path, rect);
+  }
+}
+
+/**
+ * Electron `WebContentsView` 패리티 OO facade — host 창에 합성하는 child view.
+ * viewId 는 windowId 와 같은 풀이라 모든 webContents 메서드(loadURL/executeJavaScript 등)가
+ * view 에 동작한다. view 합성/조작은 `windows.*` 에 위임(BrowserWindow 와 동형 패턴).
+ */
+export class WebContentsView {
+  readonly #id: number;
+  private constructor(id: number) {
+    this.#id = id;
+  }
+  /** view 식별자(= windowId 풀). webContents 메서드 인자로 사용. */
+  get id(): number {
+    return this.#id;
+  }
+
+  /** host 창에 child view 생성 후 인스턴스 반환 (Electron `new WebContentsView()` + addChildView). */
+  static async create(opts: ViewOptions): Promise<WebContentsView> {
+    const res = await windows.createView(opts);
+    if (typeof res.viewId !== "number") {
+      throw new Error(`create_view: no viewId in response (${JSON.stringify(res)})`);
+    }
+    return new WebContentsView(res.viewId);
+  }
+  /** 기존 viewId 를 인스턴스로 래핑. */
+  static fromId(id: number): WebContentsView {
+    return new WebContentsView(id);
+  }
+
+  setBounds(bounds: SetBoundsArgs) {
+    return windows.setViewBounds(this.#id, bounds);
+  }
+  getBounds() {
+    return windows.getViewBounds(this.#id);
+  }
+  setVisible(visible: boolean) {
+    return windows.setViewVisible(this.#id, visible);
+  }
+  setBackgroundColor(color: string) {
+    return windows.setViewBackgroundColor(this.#id, color);
+  }
+  destroy() {
+    return windows.destroyView(this.#id);
+  }
+  // webContents 메서드 — viewId 가 windowId 풀이라 그대로 위임.
+  loadURL(url: string) {
+    return windows.loadURL(this.#id, url);
+  }
+  executeJavaScript(code: string) {
+    return windows.executeJavaScript(this.#id, code);
+  }
+  openDevTools() {
+    return windows.openDevTools(this.#id);
   }
 }
 

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -620,6 +620,14 @@ export interface ViewOpResponse {
   ok: boolean;
 }
 
+/** get_view_bounds 응답 — 추적된 view bounds(없으면 ok:false + 0). */
+export interface ViewBoundsResponse extends ViewOpResponse {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export interface GetChildViewsResponse {
   cmd: 'get_child_views';
   from: 'zig-core';
@@ -704,6 +712,14 @@ export const windows = {
   },
   getChildViews(hostId: number): Promise<GetChildViewsResponse> {
     return invoke<GetChildViewsResponse>('__core__', { cmd: 'get_child_views', hostId });
+  },
+  /** Electron View.getBounds() — view 추적 bounds. */
+  getViewBounds(viewId: number): Promise<ViewBoundsResponse> {
+    return invoke<ViewBoundsResponse>('__core__', { cmd: 'get_view_bounds', viewId });
+  },
+  /** Electron View.setBackgroundColor(color) — "#RRGGBB[AA]". */
+  setViewBackgroundColor(viewId: number, color: string): Promise<ViewOpResponse> {
+    return invoke<ViewOpResponse>('__core__', { cmd: 'set_view_background_color', viewId, color });
   },
 
   openDevTools(windowId: number): Promise<WindowOpResponse> {
@@ -1357,6 +1373,51 @@ export class BrowserWindow {
   }
   capturePage(path: string, rect?: { x: number; y: number; width: number; height: number }) {
     return windows.capturePage(this.#id, path, rect);
+  }
+}
+
+/** Electron `WebContentsView` 패리티 OO facade (suji-js 동형). viewId 는 windowId 풀. */
+export class WebContentsView {
+  readonly #id: number;
+  private constructor(id: number) {
+    this.#id = id;
+  }
+  get id(): number {
+    return this.#id;
+  }
+  static async create(opts: CreateViewOptions): Promise<WebContentsView> {
+    const res = await windows.createView(opts);
+    if (typeof res.viewId !== 'number') {
+      throw new Error(`create_view: no viewId in response (${JSON.stringify(res)})`);
+    }
+    return new WebContentsView(res.viewId);
+  }
+  static fromId(id: number): WebContentsView {
+    return new WebContentsView(id);
+  }
+  setBounds(bounds: SetBoundsArgs) {
+    return windows.setViewBounds(this.#id, bounds);
+  }
+  getBounds() {
+    return windows.getViewBounds(this.#id);
+  }
+  setVisible(visible: boolean) {
+    return windows.setViewVisible(this.#id, visible);
+  }
+  setBackgroundColor(color: string) {
+    return windows.setViewBackgroundColor(this.#id, color);
+  }
+  destroy() {
+    return windows.destroyView(this.#id);
+  }
+  loadURL(url: string) {
+    return windows.loadURL(this.#id, url);
+  }
+  executeJavaScript(code: string) {
+    return windows.executeJavaScript(this.#id, code);
+  }
+  openDevTools() {
+    return windows.openDevTools(this.#id);
   }
 }
 

--- a/src/core/window.zig
+++ b/src/core/window.zig
@@ -335,6 +335,8 @@ pub const Native = struct {
         destroy_view: *const fn (ctx: ?*anyopaque, view_handle: u64) void,
         set_view_bounds: *const fn (ctx: ?*anyopaque, view_handle: u64, bounds: Bounds) void,
         set_view_visible: *const fn (ctx: ?*anyopaque, view_handle: u64, visible: bool) void,
+        // Electron View.setBackgroundColor — view 의 cef_view_t 배경색("#RRGGBB[AA]").
+        set_view_background_color: *const fn (ctx: ?*anyopaque, view_handle: u64, hex: []const u8) void,
         reorder_view: *const fn (ctx: ?*anyopaque, host_handle: u64, view_handle: u64, index_in_host: u32) void,
         // Phase 5: 라이프사이클 제어 — minimize/maximize/fullscreen.
         // 모두 멱등 (이미 같은 상태면 no-op). is_* 게터는 platform 호출 결과 그대로 반환.
@@ -557,6 +559,9 @@ pub const Native = struct {
     }
     pub fn setViewVisible(self: Native, view_handle: u64, visible: bool) void {
         self.vtable.set_view_visible(self.ctx, view_handle, visible);
+    }
+    pub fn setViewBackgroundColor(self: Native, view_handle: u64, hex: []const u8) void {
+        self.vtable.set_view_background_color(self.ctx, view_handle, hex);
     }
     pub fn reorderView(self: Native, host_handle: u64, view_handle: u64, index_in_host: u32) void {
         self.vtable.reorder_view(self.ctx, host_handle, view_handle, index_in_host);
@@ -1922,6 +1927,23 @@ pub const WindowManager = struct {
         if (view.visible_in_host == visible) return;
         view.visible_in_host = visible;
         self.native.setViewVisible(view.native_handle, visible);
+    }
+
+    /// Electron View.getBounds() — 추적된 view.bounds(마지막 set/create 값; window getter 동형
+    /// 결정적). view 없으면 NotAView.
+    pub fn getViewBounds(self: *WindowManager, view_id: u32) Error!Bounds {
+        self.lock.lockUncancelable(self.io);
+        defer self.lock.unlock(self.io);
+        const view = try self.getLiveViewLocked(view_id);
+        return view.bounds;
+    }
+
+    /// Electron View.setBackgroundColor(color) — view 의 cef_view_t 배경색. "#RRGGBB[AA]".
+    pub fn setViewBackgroundColor(self: *WindowManager, view_id: u32, hex: []const u8) Error!void {
+        self.lock.lockUncancelable(self.io);
+        defer self.lock.unlock(self.io);
+        const view = try self.getLiveViewLocked(view_id);
+        self.native.setViewBackgroundColor(view.native_handle, hex);
     }
 
     /// host의 child view id들을 z-order 순(0=bottom, 마지막=top)으로 owned slice로 반환.

--- a/src/core/window_ipc.zig
+++ b/src/core/window_ipc.zig
@@ -846,6 +846,30 @@ pub fn handleSetViewVisible(view_id: u32, visible: bool, response_buf: []u8, wm:
     return respondViewOp(response_buf, "set_view_visible", view_id, ok);
 }
 
+/// Electron View.getBounds() — 추적된 view.bounds. 없으면 ok:false + 0 rect.
+pub fn handleGetViewBounds(view_id: u32, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
+    if (response_buf.len < RESPONSE_MIN_LEN) return null;
+    const b = wm.getViewBounds(view_id) catch {
+        return std.fmt.bufPrint(
+            response_buf,
+            "{{\"from\":\"zig-core\",\"cmd\":\"get_view_bounds\",\"viewId\":{d},\"ok\":false,\"x\":0,\"y\":0,\"width\":0,\"height\":0}}",
+            .{view_id},
+        ) catch null;
+    };
+    return std.fmt.bufPrint(
+        response_buf,
+        "{{\"from\":\"zig-core\",\"cmd\":\"get_view_bounds\",\"viewId\":{d},\"ok\":true,\"x\":{d},\"y\":{d},\"width\":{d},\"height\":{d}}}",
+        .{ view_id, b.x, b.y, b.width, b.height },
+    ) catch null;
+}
+
+/// Electron View.setBackgroundColor(color) — view cef_view_t 배경색.
+pub fn handleSetViewBackgroundColor(view_id: u32, hex: []const u8, response_buf: []u8, wm: *window.WindowManager) ?[]const u8 {
+    if (response_buf.len < RESPONSE_MIN_LEN) return null;
+    const ok = if (wm.setViewBackgroundColor(view_id, hex)) |_| true else |_| false;
+    return respondViewOp(response_buf, "set_view_background_color", view_id, ok);
+}
+
 /// get_child_views 응답: `{from, cmd, hostId, ok, viewIds: [...]}`. host destroyed/not-window면
 /// ok=false + 빈 배열. allocator는 임시 슬라이스 alloc용 (호출자 owned).
 pub fn handleGetChildViews(host_id: u32, response_buf: []u8, wm: *window.WindowManager, allocator: std.mem.Allocator) ?[]const u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1831,6 +1831,19 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         const visible = util.extractJsonBool(req_clean, "visible") orelse true;
         return window_ipc.handleSetViewVisible(view_id, visible, response_buf, wm);
     }
+    if (std.mem.eql(u8, cmd, "get_view_bounds")) {
+        const wm = window_mod.WindowManager.global orelse return null;
+        const view_id: u32 = util.nonNegU32(util.extractJsonInt(req_clean, "viewId") orelse return null);
+        return window_ipc.handleGetViewBounds(view_id, response_buf, wm);
+    }
+    if (std.mem.eql(u8, cmd, "set_view_background_color")) {
+        const wm = window_mod.WindowManager.global orelse return null;
+        const view_id: u32 = util.nonNegU32(util.extractJsonInt(req_clean, "viewId") orelse return null);
+        const raw_hex = util.extractJsonString(req_clean, "color") orelse "";
+        var hex_buf: [32]u8 = undefined;
+        const hex_n = util.unescapeJsonStr(raw_hex, &hex_buf) orelse 0;
+        return window_ipc.handleSetViewBackgroundColor(view_id, hex_buf[0..hex_n], response_buf, wm);
+    }
     if (std.mem.eql(u8, cmd, "get_child_views")) {
         const wm = window_mod.WindowManager.global orelse return null;
         const host_id: u32 = util.nonNegU32(util.extractJsonInt(req_clean, "hostId") orelse return null);

--- a/src/platform/cef_native_vtable.zig
+++ b/src/platform/cef_native_vtable.zig
@@ -81,6 +81,7 @@ pub const vtable: window_mod.Native.VTable = .{
     .destroy_view = cef_web_contents_view.destroyView,
     .set_view_bounds = cef_web_contents_view.setViewBounds,
     .set_view_visible = cef_web_contents_view.setViewVisible,
+    .set_view_background_color = cef_web_contents_view.setViewBackgroundColor,
     .reorder_view = cef_web_contents_view.reorderView,
     .minimize = cef_window_state.minimizeImpl,
     .restore_window = cef_window_state.restoreWindowImpl,

--- a/src/platform/cef_web_contents_view.zig
+++ b/src/platform/cef_web_contents_view.zig
@@ -6,6 +6,7 @@ const runtime = @import("runtime");
 const window_mod = @import("window");
 const logger = @import("logger");
 const cef_views_policy = @import("cef_views_policy.zig");
+const cef_views_delegate = @import("cef_views_delegate.zig");
 const cef_web_contents_view_child_window = @import("cef_web_contents_view_child_window.zig");
 const cef_web_contents_view_overlay = @import("cef_web_contents_view_overlay.zig");
 const cef = @import("cef.zig");
@@ -105,6 +106,19 @@ pub fn setViewBounds(ctx: ?*anyopaque, view_handle: u64, bounds: window_mod.Boun
             return;
         }
     }
+}
+
+/// Electron `View.setBackgroundColor(color)` — view 의 cef_view_t 배경색(로드 중 표시).
+/// "#RRGGBB[AA]". 모든 variant 의 browser_view(cef_view_t)에 set_background_color.
+/// window setBackgroundColor 와 동일 파서(cefColorFromHex) — 잘못된 hex 는 no-op.
+pub fn setViewBackgroundColor(ctx: ?*anyopaque, view_handle: u64, hex: []const u8) void {
+    const self = fromCtx(ctx);
+    assertUiThread();
+    const entry = self.browsers.get(view_handle) orelse return;
+    const browser_view = entry.browser_view orelse return;
+    const set_bg = browser_view.base.set_background_color orelse return;
+    const color = cef_views_delegate.cefColorFromHex(hex) orelse return;
+    set_bg(&browser_view.base, color);
 }
 
 pub fn setViewVisible(ctx: ?*anyopaque, view_handle: u64, visible: bool) void {

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -1147,6 +1147,41 @@ test "screen.getAllDisplays IPC — main.zig dispatch + cef.zig 함수" {
     }
 }
 
+test "WebContentsView.getBounds/setBackgroundColor IPC + cef_view_t wire" {
+    const main_src = try readMainSource();
+    defer std.testing.allocator.free(main_src);
+    inline for (.{
+        "\"get_view_bounds\"",
+        "\"set_view_background_color\"",
+        "window_ipc.handleGetViewBounds",
+        "window_ipc.handleSetViewBackgroundColor",
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, main_src, needle) != null);
+    }
+
+    const cef_src = try readCefSource();
+    defer std.testing.allocator.free(cef_src);
+    inline for (.{
+        "pub fn setViewBackgroundColor", // native cef_view_t.set_background_color
+        "cef_views_delegate.cefColorFromHex", // window setter 와 동일 hex 파서 재사용
+        "set_background_color orelse return", // cef_view_t base
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, cef_src, needle) != null);
+    }
+
+    // window.zig: VTable + WindowManager(getViewBounds=tracked view.bounds).
+    const win_src = try readProjectFile("src/core/window.zig", 1024 * 1024);
+    defer std.testing.allocator.free(win_src);
+    inline for (.{
+        "set_view_background_color:",
+        "pub fn getViewBounds",
+        "pub fn setViewBackgroundColor",
+        "return view.bounds", // getViewBounds = tracked
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, win_src, needle) != null);
+    }
+}
+
 test "screen display-added/removed/metrics-changed 이벤트 옵저버 wired" {
     const main_src = try readMainSource();
     defer std.testing.allocator.free(main_src);

--- a/tests/e2e/view-lifecycle.test.ts
+++ b/tests/e2e/view-lifecycle.test.ts
@@ -267,6 +267,32 @@ describe("WebContentsView: setViewBounds / setViewVisible", () => {
     expect(r.ok).toBe(true);
   });
 
+  test("getViewBounds reflects last setViewBounds (tracked)", async () => {
+    const host = await freshHost();
+    const view = await mkView(host);
+    await coreCall({ cmd: "set_view_bounds", viewId: view, x: 11, y: 22, width: 333, height: 444 });
+    const b = (await coreCall({ cmd: "get_view_bounds", viewId: view })) as {
+      ok: boolean; x: number; y: number; width: number; height: number;
+    };
+    expect(b.ok).toBe(true);
+    expect(b.x).toBe(11);
+    expect(b.y).toBe(22);
+    expect(b.width).toBe(333);
+    expect(b.height).toBe(444);
+  });
+
+  test("getViewBounds on unknown view → ok:false", async () => {
+    const b = (await coreCall({ cmd: "get_view_bounds", viewId: 999999 })) as { ok: boolean };
+    expect(b.ok).toBe(false);
+  });
+
+  test("setViewBackgroundColor returns ok:true", async () => {
+    const host = await freshHost();
+    const view = await mkView(host);
+    const r = (await coreCall({ cmd: "set_view_background_color", viewId: view, color: "#3366ff" })) as { ok: boolean };
+    expect(r.ok).toBe(true);
+  });
+
   test("setViewVisible toggle ok:true", async () => {
     const host = await freshHost();
     const view = await mkView(host);

--- a/tests/test_native.zig
+++ b/tests/test_native.zig
@@ -117,6 +117,7 @@ pub const TestNative = struct {
     destroy_view_calls: usize = 0,
     set_view_bounds_calls: usize = 0,
     set_view_visible_calls: usize = 0,
+    set_view_bg_calls: usize = 0,
     reorder_view_calls: usize = 0,
     last_create_view_host_handle: ?u64 = null,
     last_create_view_bounds: ?window.Bounds = null,
@@ -208,6 +209,7 @@ pub const TestNative = struct {
         .destroy_view = destroyView,
         .set_view_bounds = setViewBounds,
         .set_view_visible = setViewVisible,
+        .set_view_background_color = setViewBackgroundColor,
         .reorder_view = reorderView,
         .minimize = minimize,
         .restore_window = restoreWindow,
@@ -524,6 +526,11 @@ pub const TestNative = struct {
         const self = fromCtx(ctx);
         self.set_view_visible_calls += 1;
         self.last_set_view_visible = visible;
+    }
+
+    fn setViewBackgroundColor(ctx: ?*anyopaque, _: u64, _: []const u8) void {
+        const self = fromCtx(ctx);
+        self.set_view_bg_calls += 1;
     }
 
     fn reorderView(ctx: ?*anyopaque, host_handle: u64, view_handle: u64, idx: u32) void {


### PR DESCRIPTION
## 요약

Electron `WebContentsView` 패리티 마무리 (audit 88/89/90):

- **`View.getBounds()`** — 추적된 `view.bounds` 반환(window 게터 동형 결정적, native read 불요)
- **`View.setBackgroundColor("#RRGGBB[AA]")`** — `cef_view_t.set_background_color`. window `setBackgroundColor` 와 **동일 `cefColorFromHex` 파서 재사용**(중복 제거; 잘못된 hex 는 no-op)
- **`WebContentsView` OO facade 클래스** (`@suji/api` + `@suji/node`) — `BrowserWindow` 동형: `create`/`fromId` + `setBounds`/`getBounds`/`setBackgroundColor`/`setVisible`/`destroy`/`loadURL`/`executeJavaScript`/`openDevTools` (viewId 가 windowId 풀이라 전 webContents API 동작)

## 구현

7-layer plumbing: `window.zig` VTable(`set_view_background_color`)/Native/WindowManager → `cef_native_vtable` → `cef_web_contents_view` → `window_ipc`(`handleGetViewBounds`/`handleSetViewBackgroundColor`) → `main.zig` dispatch → SDKs. `test_native` stub 추가.

## 검증

- `zig build test` → **943/945 pass (2 skip), 78/78 steps**
- `@suji/api` build + `@suji/node` `tsc` clean
- `tests/cef_ipc_test.zig` 소스 계약 가드 + `view-lifecycle` e2e 3케이스(getViewBounds tracked / unknown ok:false / setViewBackgroundColor ok:true)

## 정직 경계

macOS 기본 child_window 경로는 child 가 별도 `NSWindow` 라 로드-시점 배경이 cef_view_t 색과 다를 수 있음(overlay / views-parent 경로는 직접 적용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)