### PR TITLE
feat(webRequest): responseHeaders + statusText in completed (onHeadersReceived)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -537,7 +537,8 @@ suji.platform                                                // "macos" | "linux
 //     suji.on('app:second-instance', ({argv}) => myWindow.focus())       (Electron second-instance;
 //     argv 전달 IPC: macOS/Linux Unix 소켓, Windows named pipe)
 // await webRequest.setBlockedUrls(["https://*.ad/*"])                     (CEF ResourceRequestHandler)
-//   → suji.on('webRequest:completed', ({url, statusCode, ...}) => ...)
+//   → suji.on('webRequest:completed', ({url, statusCode, statusText, requestStatus, receivedBytes, responseHeaders}) => ...)
+//     responseHeaders={헤더명:값} 객체(Electron onHeadersReceived 패리티, cef_response_t.get_header_map iterate)
 // await webRequest.onBeforeRequest({urls:["https://*.tracker/*"]}, (details, cb) => cb({cancel:true}))
 //   → RV_CONTINUE_ASYNC + listener round-trip cancel/allow (e2e 13 pass)
 ```

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -187,7 +187,7 @@
 ### webRequest
 
 - **[medium]** `webRequest.onBeforeSendHeaders` — Extend WebRequestDecision interface to include optional requestHeaders field (Record<string, string | string[]>), matching Electron's callback signature. Update the native handler to respect the retur
-- **[medium]** `webRequest.onHeadersReceived` — Add responseHeaders to webRequest:completed event (array of header objects), optionally implement onHeadersReceived listener method. Minimum: extend event payload to include headers captured from CEF 
+- ~~**[medium]** `webRequest.onHeadersReceived`~~ ✅ (PR #128 — `webRequest:completed` 이벤트에 `responseHeaders`(헤더맵 객체) + `statusText` 추가. cef_response_t.get_header_map 을 cef_string_multimap 으로 iterate→escape→JSON, graceful truncation. e2e 실 응답 헤더 검증) — Add responseHeaders to webRequest:completed event (array of header objects), optionally implement onHeadersReceived listener method. Minimum: extend event payload to include headers captured from CEF 
 
 ### BrowserWindow
 

--- a/src/platform/cef_web_request.zig
+++ b/src/platform/cef_web_request.zig
@@ -8,6 +8,7 @@ const c = cef.c;
 const zeroCefStruct = cef.zeroCefStruct;
 const initBaseRefCounted = cef.initBaseRefCounted;
 const cefUserfreeToUtf8 = cef.cefUserfreeToUtf8;
+const cefStringToUtf8 = cef.cefStringToUtf8;
 
 // ============================================
 // CEF Request Handler — webRequest URL filter (Electron `session.webRequest`)
@@ -204,7 +205,8 @@ pub fn getResourceRequestHandler(
 
 fn emitWebRequestEvent(channel_cstr: [*:0]const u8, url: []const u8, extra_json: []const u8) void {
     const emit = g_webrequest_emit_fn orelse return;
-    var payload_buf: [3072]u8 = undefined;
+    // responseHeaders(completed) 가 수 KB 가 될 수 있어 넉넉히.
+    var payload_buf: [16384]u8 = undefined;
     var url_esc_buf: [2048]u8 = undefined;
     const url_esc_n = util.escapeJsonStrFull(url, &url_esc_buf) orelse return;
     const payload = std.fmt.bufPrintZ(
@@ -213,6 +215,69 @@ fn emitWebRequestEvent(channel_cstr: [*:0]const u8, url: []const u8, extra_json:
         .{ url_esc_buf[0..url_esc_n], if (extra_json.len > 0) "," else "", extra_json },
     ) catch return;
     emit(channel_cstr, payload.ptr);
+}
+
+/// buf 에 s 를 append, n 갱신. 초과 시 false(미변경).
+fn appendStr(buf: []u8, n: *usize, s: []const u8) bool {
+    if (n.* + s.len > buf.len) return false;
+    @memcpy(buf[n.*..][0..s.len], s);
+    n.* += s.len;
+    return true;
+}
+
+/// response 헤더맵 → `{"k":"v",...}` JSON 을 buf 에 작성, 슬라이스 반환. 마지막 1바이트는
+/// 닫는 '}' 예약(brace 항상 보장). 한 헤더가 안 들어가면 거기서 멈추고 객체를 닫는다
+/// (graceful truncation — 유효 JSON 유지). 키/값 cef_string 은 escape + dtor 해제.
+fn buildResponseHeadersJson(resp: *c.cef_response_t, buf: []u8) []const u8 {
+    const work = buf[0 .. buf.len - 1]; // '}' 1바이트 예약
+    var n: usize = 0;
+    _ = appendStr(work, &n, "{");
+    const get_map = resp.get_header_map orelse {
+        buf[n] = '}';
+        return buf[0 .. n + 1];
+    };
+    const map = c.cef_string_multimap_alloc();
+    if (map == null) {
+        buf[n] = '}';
+        return buf[0 .. n + 1];
+    }
+    defer c.cef_string_multimap_free(map);
+    get_map(resp, map);
+    const size = c.cef_string_multimap_size(map);
+    var first = true;
+    var i: usize = 0;
+    while (i < size) : (i += 1) {
+        var key_cs: c.cef_string_t = .{};
+        var val_cs: c.cef_string_t = .{};
+        const has_key = c.cef_string_multimap_key(map, i, &key_cs) == 1;
+        const has_val = c.cef_string_multimap_value(map, i, &val_cs) == 1;
+        defer {
+            if (key_cs.dtor) |d| d(key_cs.str);
+            if (val_cs.dtor) |d| d(val_cs.str);
+        }
+        if (!has_key or !has_val) continue;
+        var k_utf8: [256]u8 = undefined;
+        var v_utf8: [2048]u8 = undefined;
+        var k_esc: [512]u8 = undefined;
+        var v_esc: [4096]u8 = undefined;
+        const ke = util.escapeJsonStrFull(cefStringToUtf8(&key_cs, &k_utf8), &k_esc) orelse continue;
+        const ve = util.escapeJsonStrFull(cefStringToUtf8(&val_cs, &v_utf8), &v_esc) orelse continue;
+        const checkpoint = n;
+        var ok = true;
+        if (!first) ok = ok and appendStr(work, &n, ",");
+        ok = ok and appendStr(work, &n, "\"");
+        ok = ok and appendStr(work, &n, k_esc[0..ke]);
+        ok = ok and appendStr(work, &n, "\":\"");
+        ok = ok and appendStr(work, &n, v_esc[0..ve]);
+        ok = ok and appendStr(work, &n, "\"");
+        if (!ok) {
+            n = checkpoint; // 이 헤더가 안 들어가면 되돌리고 객체 닫기
+            break;
+        }
+        first = false;
+    }
+    buf[n] = '}';
+    return buf[0 .. n + 1];
 }
 
 fn onBeforeResourceLoad(
@@ -274,14 +339,23 @@ fn onResourceLoadComplete(
     if (url.len == 0) return;
 
     var status_code: c_int = 0;
+    var status_text_buf: [256]u8 = undefined;
+    var status_text: []const u8 = "";
+    var headers_buf: [12288]u8 = undefined;
+    var headers_json: []const u8 = "{}";
     if (response) |resp| {
         if (resp.get_status) |get_status| status_code = get_status(resp);
+        if (resp.get_status_text) |get_status_text| status_text = cefUserfreeToUtf8(get_status_text(resp), &status_text_buf);
+        headers_json = buildResponseHeadersJson(resp, &headers_buf);
     }
-    var extra_buf: [128]u8 = undefined;
+    var st_esc: [512]u8 = undefined;
+    const st_n = util.escapeJsonStrFull(status_text, &st_esc) orelse 0;
+    // Electron onHeadersReceived 패리티 — statusText + responseHeaders 를 completed 에 포함.
+    var extra_buf: [13312]u8 = undefined;
     const extra = std.fmt.bufPrint(
         &extra_buf,
-        "\"statusCode\":{d},\"requestStatus\":{d},\"receivedBytes\":{d}",
-        .{ status_code, @as(i32, @intCast(status)), received_content_length },
+        "\"statusCode\":{d},\"requestStatus\":{d},\"receivedBytes\":{d},\"statusText\":\"{s}\",\"responseHeaders\":{s}",
+        .{ status_code, @as(i32, @intCast(status)), received_content_length, st_esc[0..st_n], headers_json },
     ) catch return;
     emitWebRequestEvent("webRequest:completed", url, extra);
 }

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -1589,6 +1589,11 @@ test "webRequest — CefRequestHandler wiring + URL glob blocklist + 2 이벤트
         "client_ptr.get_request_handler",
         "\"webRequest:before-request\"",
         "\"webRequest:completed\"",
+        // onHeadersReceived 패리티 — completed 에 responseHeaders + statusText.
+        "fn buildResponseHeadersJson",
+        "cef_string_multimap_alloc",
+        "responseHeaders", // completed 페이로드 필드
+        "statusText", // completed 페이로드 필드
     }) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, cef_src, needle) != null);
     }

--- a/tests/e2e/web-request.test.ts
+++ b/tests/e2e/web-request.test.ts
@@ -232,6 +232,53 @@ describe("webRequest blocklist", () => {
     expect(found.url).toContain(tag);
   });
 
+  test("webRequest:completed — 성공 응답에 responseHeaders + statusText (onHeadersReceived 패리티)", async () => {
+    await core({ cmd: "web_request_set_blocked_urls", patterns: [] }); // 차단 해제
+    const listenerKey = await page.evaluate(() => {
+      const events: any[] = [];
+      const off = (window as any).__suji__.on(
+        "webRequest:completed",
+        (payload: string) => {
+          try { events.push(JSON.parse(payload)); } catch { events.push(payload); }
+        },
+      );
+      const reg = ((window as any).__wr_test__ ||= {});
+      const k = String(Math.random());
+      reg[k] = { events, off };
+      return k;
+    });
+
+    const tag = `rh-${Date.now()}`;
+    await page.evaluate(async (t) => {
+      // dev server origin = 실제 응답(200 + content-type 등 헤더) → responseHeaders 채워짐.
+      await fetch(window.location.origin + "/?rh=" + t).catch(() => {});
+    }, tag);
+
+    const found = await page.evaluate(
+      async ({ k, tag }) => {
+        const reg = (window as any).__wr_test__;
+        const c = reg[k];
+        const start = Date.now();
+        while (Date.now() - start < 5000) {
+          const hit = c.events.find((e: any) =>
+            typeof e.url === "string" && e.url.includes(tag) &&
+            e.responseHeaders && Object.keys(e.responseHeaders).length > 0,
+          );
+          if (hit) { c.off(); delete reg[k]; return hit; }
+          await new Promise((r) => setTimeout(r, 100));
+        }
+        c.off(); delete reg[k]; return null;
+      },
+      { k: listenerKey, tag },
+    );
+    expect(found).not.toBeNull();
+    expect(found.url).toContain(tag);
+    expect(typeof found.responseHeaders).toBe("object");
+    expect(found.statusCode).toBeGreaterThan(0);
+    expect(Object.keys(found.responseHeaders).length).toBeGreaterThan(0);
+    expect(typeof found.statusText).toBe("string");
+  });
+
   test("middle wildcard 매칭 — `*/blocked-mid/*`은 origin 무관하게 path 매칭", async () => {
     await core({
       cmd: "web_request_set_blocked_urls",


### PR DESCRIPTION
## 요약

Electron `webRequest.onHeadersReceived` 패리티 (audit 190):

- `webRequest:completed` 이벤트에 **`responseHeaders`**(헤더명→값 JSON 객체) + **`statusText`** 추가.
- `cef_response_t.get_header_map` 을 `cef_string_multimap` 으로 iterate → 키/값 escape → `{"k":"v",...}` 빌드(`buildResponseHeadersJson`). 닫는 `}` 1바이트 예약 + 헤더 단위 graceful truncation 으로 버퍼 초과 시에도 유효 JSON 유지. 키/값 `cef_string` 은 dtor 해제.

native-only(이벤트 페이로드 enrichment) — SDK 는 기존 `suji.on('webRequest:completed')` 구독으로 새 필드를 자동 수신, API 변경 없음.

## 검증

- `zig build test` **948/950 (2 skip)** — `cef_ipc` 소스 계약 가드(buildResponseHeadersJson/multimap/responseHeaders/statusText)
- e2e `web-request` **14 pass** — dev server 실 응답 fetch → completed 이벤트에 responseHeaders(키>0 객체) + statusText + statusCode>0 검증

## 후속 (webRequest 카테고리)

`onBeforeSendHeaders`(요청 헤더 수정, audit 189)는 별도 PR — deferred-resolve 에 requestHeaders 적용 + 5 SDK 콜백 시그니처 변경 + echo 서버 검증 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)