### PR TITLE
feat(app): before-quit 이벤트 — quit chokepoint 훅

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,9 @@ fn onAllClosed(_: suji.Event) void {
 // suji.webRequest.setBlockedUrls(&.{ "https://*.ad/*" })   — URL glob blocklist
 //   → 매칭 요청 cancel + `webRequest:before-request` / `webRequest:completed` 이벤트
 // suji.quit()                  — 앱 종료 요청 (Electron app.quit())
+//   → quit 직전 `app:before-quit` 이벤트 1회 발신(모든 quit 경로: Cmd+Q/suji.quit/
+//     all-closed/IPC 가 cef.quit chokepoint 경유). suji.on("app:before-quit", cb) 로 정리/저장.
+//     ⚠️ preventDefault(종료 취소)는 IPC 비동기상 미지원(window:close 렌더러 경계 동일, 정직 경계)
 // suji.exit()                  — 앱 강제 종료 (Electron app.exit(), code 무시)
 // suji.session.clearCookies() / flushStore() — CEF cookie_manager fire-and-forget
 //   / setCookieRaw(args) / getCookiesRaw(args) / removeCookiesRaw(args)

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -91,7 +91,7 @@
 
 ### app
 
-- **[medium]** `app.before-quit event` — Add app:before-quit event hook to Suji quit() path. Modify the quit flow in Zig core to emit a 'app:before-quit' event before termination begins, allowing handlers to call an event.preventDefault() eq
+- ~~**[medium]** `app.before-quit event`~~ ✅ (PR #129 — cef.quit() chokepoint(모든 quit 경로: Cmd+Q/suji.quit/all-closed/IPC)에서 idempotent 1회 `app:before-quit` 발신. in-process(백엔드) listener 동기 실행, 렌더러 best-effort. 정직 경계: preventDefault(quit 취소)는 IPC 비동기 모델상 미지원 — window:close 렌더러 경계와 동일. 검증=source-contract guard(quit 은 프로세스 종료라 자동 e2e 불가)) — Add app:before-quit event hook to Suji quit() path. Modify the quit flow in Zig core to emit a 'app:before-quit' event before termination begins, allowing handlers to call an event.preventDefault() eq
 - **[medium]** `app.removeAsDefaultProtocolClient(protocol: string, path?: string, args?: string[]) : boolean` — Add app.setAsDefaultProtocolClient(protocol: string, path?: string, args?: string[]): Promise<boolean> and app.removeAsDefaultProtocolClient(protocol: string, path?: string, args?: string[]): Promise<
 - ~~**[medium]** `app.requestSingleInstanceLock()`~~ ✅ (#94) — Add app.requestSingleInstanceLock(additionalData?) method across all SDKs. Zig: implement with temp file lock or NSFileManager (macOS). JS/Node: expose as async method returning boolean. Rust/Go: wrap
 - ~~**[medium]** `hasSingleInstanceLock() method`~~ ✅ (#94) — Implement three methods in the app object across both suji-js and suji-node SDKs: (1) app.requestSingleInstanceLock() → Promise<boolean> indicating lock acquisition success, (2) app.hasSingleInstanceL

--- a/documents/events.mdx
+++ b/documents/events.mdx
@@ -46,6 +46,26 @@ fn onAllClosed(_: suji.Event) void {
 
 macOS는 창이 모두 닫혀도 앱은 dock에 유지 (Electron과 동일). 나머지 플랫폼은 종료.
 
+### app 종료 직전 (before-quit)
+
+| 채널 | payload | 발화 시점 |
+|---|---|---|
+| `app:before-quit` | `{}` | 앱이 종료되기 직전(모든 quit 경로: Cmd+Q / `suji.quit()` / window:all-closed 자동 quit / IPC quit) |
+
+종료 전 정리/상태 저장 훅으로 쓴다. 모든 quit 경로가 거치는 단일 chokepoint에서
+정확히 1회 발신한다(중복 quit 호출에도 1회).
+
+```js
+suji.on('app:before-quit', () => {
+  // 종료 직전 정리/저장 — 백엔드(in-process) listener 는 동기 실행
+  localStorage.setItem('lastClosed', String(Date.now()));
+});
+```
+
+> **정직 경계**: `event.preventDefault()`(종료 취소)는 지원하지 않는다. 렌더러 listener 는
+> IPC 비동기 모델상 quit 을 동기적으로 막을 수 없다(`window:close` 렌더러 경계와 동일).
+> 백엔드 listener 는 동기 실행되지만 현재 quit-veto 경로는 미배선이다(후속).
+
 ### app 단일 인스턴스 (second-instance)
 
 | 채널 | payload | 발화 시점 |

--- a/src/main.zig
+++ b/src/main.zig
@@ -698,6 +698,7 @@ fn runDev(allocator: std.mem.Allocator) !void {
     cef.setWebRequestEmitHandler(&webRequestEmitHandler);
     cef.setPermissionEmitHandler(&permissionEmitHandler);
     cef.setDownloadEmitHandler(&downloadEmitHandler);
+    cef.setBeforeQuitHandler(&beforeQuitHandler);
     cef.setWindowLifecycleHandlers(window_lifecycle_handlers);
     cef.setWindowDisplayHandlers(.{
         .ready_to_show = &windowReadyToShowHandler,
@@ -891,6 +892,7 @@ fn runProd(allocator: std.mem.Allocator) !void {
     cef.setWebRequestEmitHandler(&webRequestEmitHandler);
     cef.setPermissionEmitHandler(&permissionEmitHandler);
     cef.setDownloadEmitHandler(&downloadEmitHandler);
+    cef.setBeforeQuitHandler(&beforeQuitHandler);
     cef.setWindowLifecycleHandlers(window_lifecycle_handlers);
     cef.setWindowDisplayHandlers(.{
         .ready_to_show = &windowReadyToShowHandler,
@@ -4776,6 +4778,11 @@ fn permissionEmitHandler(channel: [*:0]const u8, payload: [*:0]const u8) callcon
 
 fn downloadEmitHandler(channel: [*:0]const u8, payload: [*:0]const u8) callconv(.c) void {
     emitBusRaw(std.mem.span(channel), std.mem.span(payload));
+}
+
+/// Electron `app.on('before-quit')` — quit 직전 1회 발신(cef.quit chokepoint).
+fn beforeQuitHandler() callconv(.c) void {
+    emitBusRaw("app:before-quit", "{}");
 }
 
 fn globalShortcutEmitHandler(accelerator: []const u8, click: []const u8) void {

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -287,6 +287,8 @@ pub const run = cef_public_api.run;
 pub const shutdown = cef_public_api.shutdown;
 pub const quit = cef_public_api.quit;
 pub const quitAfterNextResponse = cef_public_api.quitAfterNextResponse;
+pub const BeforeQuitFn = cef_public_api.BeforeQuitFn;
+pub const setBeforeQuitHandler = cef_public_api.setBeforeQuitHandler;
 
 // ============================================
 // Window display/load/find/print handlers — cef_window_display.zig 로 분리(동작 무변경).

--- a/src/platform/cef_message_loop.zig
+++ b/src/platform/cef_message_loop.zig
@@ -37,9 +37,23 @@ pub fn shutdown() void {
 var g_quit_called: bool = false;
 pub const quitAfterNextResponse = cef_browser_ipc.quitAfterNextResponse;
 
+/// Electron `app.on('before-quit')` 훅 — quit 직전 1회 호출(main 이 주입해
+/// `app:before-quit` 이벤트를 EventBus 로 발신). 모든 quit 경로(Cmd+Q, suji.quit,
+/// window:all-closed 자동 quit, IPC quit)가 cef.quit() 를 거치므로 단일 chokepoint.
+pub const BeforeQuitFn = *const fn () callconv(.c) void;
+var g_before_quit_fn: ?BeforeQuitFn = null;
+pub fn setBeforeQuitHandler(fn_ptr: BeforeQuitFn) void {
+    g_before_quit_fn = fn_ptr;
+}
+
 pub fn quit() void {
     if (g_quit_called) return;
     g_quit_called = true;
+
+    // before-quit 알림(idempotent guard 안 — 정확히 1회). in-process(백엔드) listener 는
+    // 동기 실행, 렌더러는 best-effort(quit 진행 전 짧은 윈도). preventDefault(취소)는
+    // IPC 비동기 모델상 미지원 — window:close 렌더러 경계와 동일(정직 경계).
+    if (g_before_quit_fn) |f| f();
 
     cef_devtools.closeMappedDevToolsBeforeQuit();
 

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -151,6 +151,8 @@ pub const run = cef_message_loop.run;
 pub const shutdown = cef_message_loop.shutdown;
 pub const quit = cef_message_loop.quit;
 pub const quitAfterNextResponse = cef_message_loop.quitAfterNextResponse;
+pub const BeforeQuitFn = cef_message_loop.BeforeQuitFn;
+pub const setBeforeQuitHandler = cef_message_loop.setBeforeQuitHandler;
 
 pub const MAX_TITLE_BYTES = cef_window_display.MAX_TITLE_BYTES;
 pub const WindowReadyToShowHandler = cef_window_display.WindowReadyToShowHandler;

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -2475,6 +2475,29 @@ test "session.setDownloadPath + will-download IPC + CEF download handler wire" {
     }
 }
 
+test "app.before-quit 이벤트 — quit chokepoint 훅 wired" {
+    const main_src = try readMainSource();
+    defer std.testing.allocator.free(main_src);
+    inline for (.{
+        "fn beforeQuitHandler",
+        "cef.setBeforeQuitHandler(&beforeQuitHandler)",
+        "\"app:before-quit\"",
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, main_src, needle) != null);
+    }
+
+    // cef_message_loop.zig: quit() 직전 1회 호출되는 BeforeQuitFn 훅(idempotent guard 안).
+    const cef_src = try readCefSource();
+    defer std.testing.allocator.free(cef_src);
+    inline for (.{
+        "pub fn setBeforeQuitHandler",
+        "g_before_quit_fn",
+        "if (g_before_quit_fn) |f| f();",
+    }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, cef_src, needle) != null);
+    }
+}
+
 test "app.getName/getVersion + screen.getDisplayNearestPoint IPC" {
     const main_src = try readMainSource();
     defer std.testing.allocator.free(main_src);


### PR DESCRIPTION
## 요약

Electron `app.on('before-quit')` 패리티 (audit 94):

- 모든 quit 경로(Cmd+Q / `suji.quit()` / window:all-closed 자동 quit / IPC quit)가 거치는 **`cef.quit()` 단일 chokepoint** 에서 `app:before-quit` 이벤트를 **idempotent 1회** 발신(`g_quit_called` guard 안). 종료 직전 정리/상태 저장 훅.
- `BeforeQuitFn` 훅(cef_message_loop) ← main `beforeQuitHandler`(emitBusRaw) 주입. 다른 emit-handler 주입(setWebRequestEmitHandler 등)과 동형. in-process(백엔드) listener 는 동기 실행, 렌더러는 best-effort(browsers close 이전 발신).

이벤트 전용 — SDK 는 기존 `suji.on('app:before-quit')` 구독으로 수신, API 변경 없음.

## 검증

- `zig build test` **949/951 (2 skip)** — `cef_ipc` 소스 계약 가드(beforeQuitHandler / setBeforeQuitHandler / g_before_quit_fn / app:before-quit)
- quit 은 프로세스 종료라 자동 e2e 불가 → source-contract guard + chokepoint(앱 teardown 마다 실행)으로 검증

## 정직 경계

`event.preventDefault()`(종료 취소)는 **IPC 비동기 모델상 미지원** — 렌더러 listener 는 quit 을 동기적으로 막을 수 없다(`window:close` 렌더러 경계와 동일). 백엔드 quit-veto 경로 + `app:will-quit` 사후 이벤트는 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)