### PR TITLE
feat(webRequest): setRequestHeaders (declarative onBeforeSendHeaders) — 전 5 SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,6 +549,10 @@ suji.platform                                                // "macos" | "linux
 //     responseHeaders={헤더명:값} 객체(Electron onHeadersReceived 패리티, cef_response_t.get_header_map iterate)
 // await webRequest.onBeforeRequest({urls:["https://*.tracker/*"]}, (details, cb) => cb({cancel:true}))
 //   → RV_CONTINUE_ASYNC + listener round-trip cancel/allow (e2e 13 pass)
+// await webRequest.setRequestHeaders({urls:["https://api.x/*"]}, {Authorization:"Bearer …"})
+//   — Electron onBeforeSendHeaders (declarative). URL glob 매칭 요청에 헤더를 동기 주입(덮어쓰기).
+//     빈 urls=해제. echo-server e2e 로 wire 도달 실증. ⚠️ per-request JS 콜백(요청마다 동적
+//     헤더 계산)은 CEF 제약상 불가(RV_CONTINUE_ASYNC 후 request 수정 무시) — 선언적 규칙만
 ```
 
 ## Suji 설정

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2770,6 +2770,23 @@ pub mod web_request {
     pub fn resolve(id: u64, cancel: bool) -> Option<String> {
         invoke("__core__", &resolve_request(id, cancel))
     }
+
+    /// Electron `session.webRequest.onBeforeSendHeaders` 의 declarative 변형 — urls glob 매칭
+    /// 요청에 (name, value) 헤더를 동기 주입(덮어쓰기). 빈 patterns = 해제. 응답 `{"count":N}`.
+    /// ⚠️ per-request JS 콜백은 CEF 제약상 미지원(async resolve 후 request 수정 무시) — 선언만.
+    pub fn set_request_headers(patterns: &[&str], request_headers: &[(&str, &str)]) -> Option<String> {
+        let mut map = serde_json::Map::new();
+        for (k, v) in request_headers {
+            map.insert((*k).to_string(), serde_json::Value::String((*v).to_string()));
+        }
+        let req = serde_json::json!({
+            "cmd": "web_request_set_request_headers",
+            "patterns": patterns,
+            "requestHeaders": serde_json::Value::Object(map),
+        })
+        .to_string();
+        invoke("__core__", &req)
+    }
 }
 
 pub mod crash_reporter {

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -186,7 +186,7 @@
 
 ### webRequest
 
-- **[medium]** `webRequest.onBeforeSendHeaders` — Extend WebRequestDecision interface to include optional requestHeaders field (Record<string, string | string[]>), matching Electron's callback signature. Update the native handler to respect the retur
+- ~~**[medium]** `webRequest.onBeforeSendHeaders`~~ ✅ (PR #131 — **declarative** `webRequest.setRequestHeaders({urls}, headers)`, 전 5 SDK. URL glob 매칭 요청에 헤더를 `OnBeforeResourceLoad` **동기** 구간에서 `set_header_by_name` 으로 주입(덮어쓰기). echo-server e2e 로 실제 wire 도달 실증(주입 헤더가 CORS preflight 유발 → 실 GET 에 도달). 🔒 정직 경계: Electron 의 **per-request JS 콜백**(요청마다 헤더 동적 계산)은 CEF 제약상 불가 — CEF 는 `RV_CONTINUE_ASYNC` 반환 후의 request 수정을 무시하므로 async listener resolve 로는 헤더 수정 불가(echo-server e2e 로 실증). 동기 declarative 규칙(인증 토큰/커스텀 UA 등 대다수 use-case)만 가능) — Extend WebRequestDecision interface to include optional requestHeaders field (Record<string, string | string[]>), matching Electron's callback signature. Update the native handler to respect the retur
 - ~~**[medium]** `webRequest.onHeadersReceived`~~ ✅ (PR #128 — `webRequest:completed` 이벤트에 `responseHeaders`(헤더맵 객체) + `statusText` 추가. cef_response_t.get_header_map 을 cef_string_multimap 으로 iterate→escape→JSON, graceful truncation. e2e 실 응답 헤더 검증) — Add responseHeaders to webRequest:completed event (array of header objects), optionally implement onHeadersReceived listener method. Minimum: extend event payload to include headers captured from CEF 
 
 ### BrowserWindow

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -1188,6 +1188,18 @@ export declare const webRequest: {
     /** blocklist 패턴 list 갱신 (전체 교체). 빈 list = 모든 요청 통과. 최대 32개, 256자/패턴. */
     setBlockedUrls(patterns: string[]): Promise<number>;
     /**
+     * Electron `session.webRequest.onBeforeSendHeaders` 의 **declarative 변형** —
+     * `filter.urls` glob 매칭 요청에 `headers`(이름→값)를 **동기** 주입(덮어쓰기). 빈 urls = 해제.
+     *
+     * ⚠️ Electron 의 per-request JS 콜백(요청마다 헤더를 동적 계산)은 **CEF 제약상 미지원**:
+     * CEF 는 `OnBeforeResourceLoad` 의 동기 구간에서만 request 수정을 반영하고 async
+     * resolve 후 수정은 무시한다(echo-server e2e 로 실증). 따라서 선언적 규칙만 가능 —
+     * 헤더 추가/덮어쓰기(인증 토큰, 커스텀 UA 등 대다수 use-case)는 충족한다.
+     */
+    setRequestHeaders(filter: {
+        urls: string[];
+    }, headers: Record<string, string>): Promise<number>;
+    /**
      * Electron `session.webRequest.onBeforeRequest({urls}, listener)` 동등.
      * filter.urls glob 매칭 시 listener가 비동기 결정 — `callback({ cancel: true })`로 차단,
      * `callback({})`로 통과.

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -1630,6 +1630,23 @@ export const webRequest = {
         return r.count;
     },
     /**
+     * Electron `session.webRequest.onBeforeSendHeaders` 의 **declarative 변형** —
+     * `filter.urls` glob 매칭 요청에 `headers`(이름→값)를 **동기** 주입(덮어쓰기). 빈 urls = 해제.
+     *
+     * ⚠️ Electron 의 per-request JS 콜백(요청마다 헤더를 동적 계산)은 **CEF 제약상 미지원**:
+     * CEF 는 `OnBeforeResourceLoad` 의 동기 구간에서만 request 수정을 반영하고 async
+     * resolve 후 수정은 무시한다(echo-server e2e 로 실증). 따라서 선언적 규칙만 가능 —
+     * 헤더 추가/덮어쓰기(인증 토큰, 커스텀 UA 등 대다수 use-case)는 충족한다.
+     */
+    async setRequestHeaders(filter, headers) {
+        const r = await coreCall({
+            cmd: "web_request_set_request_headers",
+            patterns: filter.urls,
+            requestHeaders: headers,
+        });
+        return r.count;
+    },
+    /**
      * Electron `session.webRequest.onBeforeRequest({urls}, listener)` 동등.
      * filter.urls glob 매칭 시 listener가 비동기 결정 — `callback({ cancel: true })`로 차단,
      * `callback({})`로 통과.

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -2435,6 +2435,24 @@ export const webRequest = {
   },
 
   /**
+   * Electron `session.webRequest.onBeforeSendHeaders` 의 **declarative 변형** —
+   * `filter.urls` glob 매칭 요청에 `headers`(이름→값)를 **동기** 주입(덮어쓰기). 빈 urls = 해제.
+   *
+   * ⚠️ Electron 의 per-request JS 콜백(요청마다 헤더를 동적 계산)은 **CEF 제약상 미지원**:
+   * CEF 는 `OnBeforeResourceLoad` 의 동기 구간에서만 request 수정을 반영하고 async
+   * resolve 후 수정은 무시한다(echo-server e2e 로 실증). 따라서 선언적 규칙만 가능 —
+   * 헤더 추가/덮어쓰기(인증 토큰, 커스텀 UA 등 대다수 use-case)는 충족한다.
+   */
+  async setRequestHeaders(filter: { urls: string[] }, headers: Record<string, string>): Promise<number> {
+    const r = await coreCall<{ count: number }>({
+      cmd: "web_request_set_request_headers",
+      patterns: filter.urls,
+      requestHeaders: headers,
+    });
+    return r.count;
+  },
+
+  /**
    * Electron `session.webRequest.onBeforeRequest({urls}, listener)` 동등.
    * filter.urls glob 매칭 시 listener가 비동기 결정 — `callback({ cancel: true })`로 차단,
    * `callback({})`로 통과.

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -2497,6 +2497,20 @@ export const webRequest = {
     const r = await invoke<{ success: boolean }>('__core__', { cmd: 'web_request_resolve', id, cancel });
     return r.success === true;
   },
+
+  /**
+   * Electron `session.webRequest.onBeforeSendHeaders` 의 declarative 변형 — urls glob 매칭
+   * 요청에 headers 를 동기 주입(덮어쓰기). 빈 urls = 해제. ⚠️ per-request JS 콜백은
+   * CEF 제약상 미지원(async resolve 후 request 수정 무시) — 선언적 규칙만(정직 경계).
+   */
+  async setRequestHeaders(filter: { urls: string[] }, headers: Record<string, string>): Promise<number> {
+    const r = await invoke<{ count: number }>('__core__', {
+      cmd: 'web_request_set_request_headers',
+      patterns: filter.urls,
+      requestHeaders: headers,
+    });
+    return r.count;
+  },
 };
 
 export type PowerSaveBlockerType = 'prevent_app_suspension' | 'prevent_display_sleep';

--- a/sdks/suji-go/webrequest/webrequest.go
+++ b/sdks/suji-go/webrequest/webrequest.go
@@ -30,6 +30,22 @@ func Resolve(id uint64, cancel bool) string {
 	return suji.Invoke("__core__", string(body))
 }
 
+// SetRequestHeaders injects headers into requests matching the URL globs (Electron
+// session.webRequest.onBeforeSendHeaders, declarative variant). Empty patterns clears.
+// Response: `{"count":N}`. ⚠️ per-request JS callback is unsupported (CEF ignores request
+// edits after async resolve) — declarative rule only.
+func SetRequestHeaders(patterns []string, requestHeaders map[string]string) string {
+	if patterns == nil {
+		patterns = []string{}
+	}
+	body, _ := json.Marshal(map[string]any{
+		"cmd":            "web_request_set_request_headers",
+		"patterns":       patterns,
+		"requestHeaders": requestHeaders,
+	})
+	return suji.Invoke("__core__", string(body))
+}
+
 func buildPatternsRequest(cmd string, patterns []string) string {
 	if patterns == nil {
 		patterns = []string{}
@@ -43,4 +59,3 @@ func buildPatternsRequest(cmd string, patterns []string) string {
 	}
 	return string(body)
 }
-

--- a/src/core/app.zig
+++ b/src/core/app.zig
@@ -1833,6 +1833,26 @@ pub const webRequest = struct {
         return coreCmd("web_request_resolve", fields);
     }
 
+    /// Electron `session.webRequest.onBeforeSendHeaders` 의 declarative 변형 — patterns glob
+    /// 매칭 요청에 request_headers_json `{"k":"v",...}`(raw 컨벤션, caller JSON-safe) 동기 주입.
+    /// ⚠️ per-request JS 콜백은 CEF 제약상 미지원(async resolve 후 request 수정 무시) — 선언만.
+    pub fn setRequestHeaders(patterns: []const []const u8, request_headers_json: []const u8) ?[]const u8 {
+        var fields_buf: [16384]u8 = undefined;
+        var w: std.Io.Writer = .fixed(&fields_buf);
+        w.writeAll("\"patterns\":[") catch return null;
+        for (patterns, 0..) |p, i| {
+            if (i > 0) w.writeAll(",") catch return null;
+            w.writeAll("\"") catch return null;
+            var p_buf: [512]u8 = undefined;
+            const p_n = util.escapeJsonStrFull(p, &p_buf) orelse return null;
+            w.writeAll(p_buf[0..p_n]) catch return null;
+            w.writeAll("\"") catch return null;
+        }
+        w.writeAll("],\"requestHeaders\":") catch return null;
+        w.writeAll(request_headers_json) catch return null;
+        return coreCmd("web_request_set_request_headers", w.buffered());
+    }
+
     fn setUrlPatternsCmd(cmd: []const u8, patterns: []const []const u8) ?[]const u8 {
         var fields_buf: [8192]u8 = undefined;
         var w: std.Io.Writer = .fixed(&fields_buf);

--- a/src/core/util.zig
+++ b/src/core/util.zig
@@ -257,6 +257,56 @@ pub fn extractJsonArrayRaw(json: []const u8, key: []const u8) ?[]const u8 {
     return null;
 }
 
+/// `"key":{...}` 의 균형 잡힌 JSON 객체 raw 슬라이스(문자열/이스케이프 인지) 추출.
+/// 없거나 객체가 아니면 null. webRequest requestHeaders 같은 임의-키 객체 추출에 사용.
+pub fn extractJsonObjectRaw(json: []const u8, key: []const u8) ?[]const u8 {
+    const after_colon = findKey(json, key) orelse return null;
+    var i = after_colon;
+    while (i < json.len and std.ascii.isWhitespace(json[i])) : (i += 1) {}
+    if (i >= json.len or json[i] != '{') return null;
+    const start = i;
+    var depth: i32 = 0;
+    var in_str = false;
+    var esc = false;
+    while (i < json.len) : (i += 1) {
+        const c = json[i];
+        if (in_str) {
+            if (esc) {
+                esc = false;
+            } else if (c == '\\') {
+                esc = true;
+            } else if (c == '"') {
+                in_str = false;
+            }
+            continue;
+        }
+        switch (c) {
+            '"' => in_str = true,
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if (depth == 0) return json[start .. i + 1];
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+test "extractJsonObjectRaw: 균형 객체 + 중첩/문자열 내 brace" {
+    try std.testing.expectEqualStrings(
+        "{\"a\":\"b\"}",
+        extractJsonObjectRaw("{\"h\":{\"a\":\"b\"},\"x\":5}", "h").?,
+    );
+    // 문자열 안의 `}` 무시 + 중첩.
+    try std.testing.expectEqualStrings(
+        "{\"a\":\"x}y\",\"n\":{\"k\":1}}",
+        extractJsonObjectRaw("{\"h\":{\"a\":\"x}y\",\"n\":{\"k\":1}}}", "h").?,
+    );
+    try std.testing.expect(extractJsonObjectRaw("{\"h\":5}", "h") == null); // 객체 아님
+    try std.testing.expect(extractJsonObjectRaw("{\"x\":{}}", "h") == null); // 키 없음
+}
+
 test "extractJsonArrayRaw: 균형 배열 + 중첩/문자열 내 bracket" {
     try std.testing.expectEqualStrings(
         "[1,2,3]",

--- a/src/main.zig
+++ b/src/main.zig
@@ -2912,6 +2912,9 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
             .{ok},
         ) catch null;
     }
+    if (std.mem.eql(u8, cmd, "web_request_set_request_headers")) {
+        return handleWebRequestSetRequestHeaders(req_clean, response_buf);
+    }
 
     if (std.mem.eql(u8, cmd, "app_attention_cancel")) {
         const id_n = util.extractJsonInt(req_clean, "id") orelse 0;
@@ -4510,6 +4513,33 @@ fn handleWebRequestSetListenerFilter(req_clean: []const u8, response_buf: []u8) 
     return std.fmt.bufPrint(
         response_buf,
         "{{\"from\":\"zig-core\",\"cmd\":\"web_request_set_listener_filter\",\"count\":{d}}}",
+        .{n},
+    ) catch null;
+}
+
+/// Electron onBeforeSendHeaders (declarative) — urls glob + requestHeaders 객체.
+/// patterns 는 std.json 파싱, requestHeaders 는 임의-키라 raw object 추출(네이티브가 unescape).
+fn handleWebRequestSetRequestHeaders(req_clean: []const u8, response_buf: []u8) ?[]const u8 {
+    var arena_buf: [DIALOG_PARSE_ARENA]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&arena_buf);
+    const arena = fba.allocator();
+
+    const parsed = std.json.parseFromSlice(WebRequestSetBlockedUrlsJson, arena, req_clean, .{
+        .ignore_unknown_fields = true,
+    }) catch {
+        return std.fmt.bufPrint(
+            response_buf,
+            "{{\"from\":\"zig-core\",\"cmd\":\"web_request_set_request_headers\",\"success\":false,\"error\":\"parse\"}}",
+            .{},
+        ) catch null;
+    };
+    defer parsed.deinit();
+
+    const headers = util.extractJsonObjectRaw(req_clean, "requestHeaders") orelse "{}";
+    const n = cef.webRequestSetRequestHeaders(parsed.value.patterns, headers);
+    return std.fmt.bufPrint(
+        response_buf,
+        "{{\"from\":\"zig-core\",\"cmd\":\"web_request_set_request_headers\",\"count\":{d}}}",
         .{n},
     ) catch null;
 }

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -315,6 +315,7 @@ pub const setWebRequestEmitHandler = cef_public_api.setWebRequestEmitHandler;
 pub const emitWebRequestPayload = cef_public_api.emitWebRequestPayload;
 pub const webRequestSetBlockedUrls = cef_public_api.webRequestSetBlockedUrls;
 pub const webRequestSetListenerFilter = cef_public_api.webRequestSetListenerFilter;
+pub const webRequestSetRequestHeaders = cef_public_api.webRequestSetRequestHeaders;
 pub const webRequestPendingDrops = cef_public_api.webRequestPendingDrops;
 pub const webRequestResolve = cef_public_api.webRequestResolve;
 

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -167,6 +167,7 @@ pub const setWebRequestEmitHandler = cef_web_request.setWebRequestEmitHandler;
 pub const emitWebRequestPayload = cef_web_request.emitWebRequestPayload;
 pub const webRequestSetBlockedUrls = cef_web_request.webRequestSetBlockedUrls;
 pub const webRequestSetListenerFilter = cef_web_request.webRequestSetListenerFilter;
+pub const webRequestSetRequestHeaders = cef_web_request.webRequestSetRequestHeaders;
 pub const webRequestPendingDrops = cef_web_request.webRequestPendingDrops;
 pub const webRequestResolve = cef_web_request.webRequestResolve;
 

--- a/src/platform/cef_web_request.zig
+++ b/src/platform/cef_web_request.zig
@@ -164,7 +164,54 @@ fn pendingTake(id: u64) ?*c._cef_callback_t {
     return null;
 }
 
-/// listener 응답 — id로 pending callback 찾아 cont/cancel 호출. 없는 id면 false.
+/// json[from..] 에서 다음 `"..."`(escape 인지)의 inner raw slice + 닫는 따옴표 다음 위치.
+const StrTok = struct { raw: []const u8, end: usize };
+fn nextJsonString(json: []const u8, from: usize) ?StrTok {
+    var i = from;
+    while (i < json.len and json[i] != '"') : (i += 1) {}
+    if (i >= json.len) return null;
+    const start = i + 1;
+    var j = start;
+    while (j < json.len) : (j += 1) {
+        if (json[j] == '\\') {
+            j += 1;
+            continue;
+        }
+        if (json[j] == '"') return .{ .raw = json[start..j], .end = j + 1 };
+    }
+    return null;
+}
+
+/// Electron onBeforeSendHeaders — requestHeaders `{"k":"v",...}` 를 request 에 적용(overwrite).
+/// 평면 string→string 객체라 따옴표 토큰을 key/value 교대로 스캔(`:`/`,`/`{}` 무시). 키/값은
+/// unescape. 최대 64개, 키 256/값 4096 초과는 skip. cef_request_t.set_header_by_name.
+/// **반드시 OnBeforeResourceLoad 동기 구간에서 호출** — CEF 는 RV_CONTINUE_ASYNC 반환 후의
+/// request 수정을 무시한다(echo-server e2e 로 실증). 그래서 declarative(set_request_headers)
+/// 경로에서만 사용하고, async listener resolve 경로에서는 헤더 수정 불가(정직 경계).
+fn applyRequestHeaders(request: *c._cef_request_t, json: []const u8) void {
+    const set_header = request.set_header_by_name orelse return;
+    var pos: usize = 0;
+    var applied: usize = 0;
+    while (applied < 64) : (applied += 1) {
+        const key_tok = nextJsonString(json, pos) orelse break;
+        const val_tok = nextJsonString(json, key_tok.end) orelse break;
+        pos = val_tok.end;
+        var key_buf: [256]u8 = undefined;
+        var val_buf: [4096]u8 = undefined;
+        const kn = util.unescapeJsonStr(key_tok.raw, &key_buf) orelse continue;
+        const vn = util.unescapeJsonStr(val_tok.raw, &val_buf) orelse continue;
+        if (kn == 0) continue;
+        var key_cs: c.cef_string_t = .{};
+        var val_cs: c.cef_string_t = .{};
+        cef.setCefString(&key_cs, key_buf[0..kn]);
+        cef.setCefString(&val_cs, val_buf[0..vn]);
+        set_header(request, &key_cs, &val_cs, 1); // overwrite=1
+        if (key_cs.dtor) |d| d(key_cs.str);
+        if (val_cs.dtor) |d| d(val_cs.str);
+    }
+}
+
+/// listener 응답 — id로 pending callback 찾아 cont/cancel. 없는 id면 false.
 pub fn webRequestResolve(id: u64, cancel_request: bool) bool {
     const cb = pendingTake(id) orelse return false;
     if (cancel_request) {
@@ -174,6 +221,28 @@ pub fn webRequestResolve(id: u64, cancel_request: bool) bool {
     }
     if (cb.base.release) |rel| _ = rel(&cb.base);
     return true;
+}
+
+// ============================================
+// onBeforeSendHeaders — declarative 요청 헤더 주입(동기, OnBeforeResourceLoad).
+// ============================================
+// CEF 가 async resolve 후 request 수정을 무시하므로(echo e2e 실증), per-request JS 콜백
+// 대신 선언적: setRequestHeaders(urls, headers) 로 URL glob 매칭 요청에 동기 적용.
+var g_request_headers_url_pool: UrlGlobPool = .{};
+var g_request_headers_buf: [8192]u8 = undefined;
+var g_request_headers_len: usize = 0;
+var g_request_headers_lock: std.atomic.Value(bool) = .init(false);
+
+/// Electron `session.webRequest.onBeforeSendHeaders` 의 declarative 변형 — urls glob 매칭
+/// 요청에 headers_json `{"k":"v",...}` 를 동기 적용(overwrite). 빈 patterns = 해제.
+/// 반환값은 등록된 patterns 개수. headers_json 은 8KB 초과 시 truncate(정상 헤더엔 충분).
+pub fn webRequestSetRequestHeaders(patterns: []const []const u8, headers_json: []const u8) usize {
+    while (g_request_headers_lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
+    defer g_request_headers_lock.store(false, .release);
+    const n = @min(headers_json.len, g_request_headers_buf.len);
+    @memcpy(g_request_headers_buf[0..n], headers_json[0..n]);
+    g_request_headers_len = n;
+    return g_request_headers_url_pool.set(patterns);
 }
 
 var g_resource_request_handler: c.cef_resource_request_handler_t = undefined;
@@ -297,6 +366,14 @@ fn onBeforeResourceLoad(
     if (g_blocked_url_pool.matchesAny(url)) {
         emitWebRequestEvent("webRequest:before-request", url, "");
         return c.RV_CANCEL;
+    }
+
+    // 1b. onBeforeSendHeaders (declarative) — URL 매칭 시 요청 헤더를 **동기** 적용.
+    // CEF 는 RV_CONTINUE_ASYNC 후 수정을 무시하므로 반드시 여기(반환 전)서 적용해야 한다.
+    if (g_request_headers_url_pool.matchesAny(url)) {
+        while (g_request_headers_lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) std.atomic.spinLoopHint();
+        defer g_request_headers_lock.store(false, .release);
+        if (g_request_headers_len > 0) applyRequestHeaders(req, g_request_headers_buf[0..g_request_headers_len]);
     }
 
     // 2. listener filter 매칭 — async pending. add_ref 후 pool에 저장 + JS listener emit.

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -1574,6 +1574,9 @@ test "webRequest — CefRequestHandler wiring + URL glob blocklist + 2 이벤트
         "cef.webRequestSetBlockedUrls",
         "cef.setWebRequestEmitHandler",
         "webRequestEmitHandler",
+        // onBeforeSendHeaders (declarative) — 동기 헤더 주입.
+        "\"web_request_set_request_headers\"",
+        "cef.webRequestSetRequestHeaders",
     }) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, main_src, needle) != null);
     }
@@ -1586,6 +1589,11 @@ test "webRequest — CefRequestHandler wiring + URL glob blocklist + 2 이벤트
         "ensureRequestHandler",
         "ensureResourceRequestHandler",
         "on_before_resource_load",
+        // onBeforeSendHeaders — 동기 set_header_by_name(RV_CONTINUE_ASYNC 전).
+        "pub fn webRequestSetRequestHeaders",
+        "fn applyRequestHeaders",
+        "set_header_by_name",
+        "g_request_headers_url_pool",
         "on_resource_load_complete",
         "client_ptr.get_request_handler",
         "\"webRequest:before-request\"",

--- a/tests/e2e/web-request.test.ts
+++ b/tests/e2e/web-request.test.ts
@@ -412,4 +412,50 @@ describe("webRequest dynamic listener (RV_CONTINUE_ASYNC)", () => {
     });
     expect(fired).toBe(0);
   });
+
+  test("setRequestHeaders (declarative onBeforeSendHeaders) → 주입 헤더가 실제 요청에 도달(echo server)", async () => {
+    // test 프로세스 내 echo 서버가 수신 헤더 기록 → 동기 주입한 헤더가 wire 에 실제 도달 검증.
+    // (async resolve 경로는 CEF 가 request 수정을 무시 — declarative 동기 경로만 동작)
+    let received: Record<string, string> | null = null;
+    const cors = {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    };
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        // 주입된 커스텀 헤더 → 브라우저가 CORS preflight(OPTIONS) 먼저 보냄. 허용 응답해야
+        // 실제 GET(헤더 값 포함)이 도달한다. 실 GET 에서만 헤더 기록.
+        if (req.method === "OPTIONS") return new Response(null, { headers: cors });
+        if (new URL(req.url).searchParams.has("sujihdr")) {
+          received = Object.fromEntries(req.headers.entries());
+        }
+        return new Response("ok", { headers: cors });
+      },
+    });
+    const port = server.port;
+    const echoUrl = `http://127.0.0.1:${port}/?sujihdr=1`;
+    try {
+      const setR = await core<{ count: number }>({
+        cmd: "web_request_set_request_headers",
+        patterns: ["*sujihdr*"],
+        requestHeaders: { "X-Suji-Onbeforesend": "e2e-injected" },
+      });
+      expect(setR.count).toBe(1);
+
+      await page.evaluate((url) => fetch(url).then(() => {}).catch(() => {}), echoUrl);
+
+      const start = Date.now();
+      while (Date.now() - start < 8000 && received === null) {
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(received).not.toBeNull();
+      // 헤더명은 lowercase 정규화. 동기 주입한 값이 실제 요청에 도달.
+      expect((received as any)["x-suji-onbeforesend"]).toBe("e2e-injected");
+    } finally {
+      await core({ cmd: "web_request_set_request_headers", patterns: [], requestHeaders: {} });
+      server.stop(true);
+    }
+  });
 });


### PR DESCRIPTION
## 요약

Electron `webRequest.onBeforeSendHeaders` 패리티 (audit 189) — **declarative 변형**:

- **`webRequest.setRequestHeaders({urls}, headers)`** — URL glob 매칭 요청에 헤더를 `OnBeforeResourceLoad` **동기** 구간에서 `set_header_by_name` 으로 주입(덮어쓰기). 빈 urls = 해제.
- `util.extractJsonObjectRaw`(임의-키 객체 추출) + `applyRequestHeaders`(평면 string→string 토큰 스캔 파서) 신규.

## 핵심 설계 결정 (empirical)

Electron 의 **per-request JS 콜백**(요청마다 헤더를 동적 계산)은 **CEF 제약상 불가** — CEF 는 `RV_CONTINUE_ASYNC` 반환 후의 request 수정을 무시한다. **echo-server e2e 로 실증**: async listener resolve 경로로 주입한 헤더는 wire 에 도달하지 않았다. 따라서 **declarative 동기 규칙**(OnBeforeResourceLoad 반환 전 적용)으로 구현 — 인증 토큰 / 커스텀 UA 등 대다수 use-case 를 충족한다. (async resolve-with-headers 시도는 revert.)

## 검증

- `zig build test` **950/952 (2 skip)** — `util.extractJsonObjectRaw` 단위 테스트 + `cef_ipc` 소스 계약 가드(setRequestHeaders / applyRequestHeaders / set_header_by_name / pool)
- 5 SDK 빌드(tsc/go/cargo) 통과
- e2e `web-request` **15 pass** — **echo-server 로 wire 도달 실증**: 주입 헤더가 CORS preflight 유발(브라우저가 커스텀 헤더 감지) → preflight 허용 후 실 GET 에 헤더 값 도달

## 정직 경계

🔒 per-request 동적 콜백은 CEF 제약(async request-mod 무시)으로 불가 — declarative 규칙만. multi-value 헤더(`Record<string,string[]>`) · 요청별 동적 계산은 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)