### PR TITLE
test(sdk): 백엔드 SDK wire-contract 보강 — Node behavioral + cross-SDK drift 가드

### DIFF
--- a/packages/suji-node/src/index.test.ts
+++ b/packages/suji-node/src/index.test.ts
@@ -20,7 +20,7 @@ const bridge = {
 (globalThis as any).suji = bridge;
 
 // bridge가 globalThis에 세팅된 뒤에 import
-import { handle, invoke, invokeSync, send, sendTo, tray, menu, fs as sujiFs, globalShortcut, screen, desktopCapturer, powerSaveBlocker, safeStorage, app, shell, webRequest, crashReporter, autoUpdater, type InvokeEvent } from './index';
+import { handle, invoke, invokeSync, send, sendTo, tray, menu, fs as sujiFs, globalShortcut, screen, desktopCapturer, powerSaveBlocker, safeStorage, app, shell, webRequest, crashReporter, autoUpdater, windows, session, type InvokeEvent } from './index';
 
 beforeEach(() => {
   registered = {};
@@ -529,5 +529,50 @@ describe('app', () => {
   it('dock.getBadge returns text', async () => {
     bridge.invoke.mockResolvedValueOnce('{"text":"9"}');
     expect(await app.dock.getBadge()).toBe('9');
+  });
+});
+
+// 신규 코어 메서드 wire-contract — bridge.invoke('__core__', '<exact JSON>') 검증.
+// frontend e2e 가 코어 핸들러를 검증하지만, 백엔드 SDK 가 보내는 cmd/필드명 drift 는
+// 이 behavioral 테스트가 잡는다(필드명 오타 = 빌드 통과 + e2e 못잡음).
+describe('webContents wire-contract (stop/insertCSS/setWindowOpenHandler)', () => {
+  it('windows.stop', async () => {
+    await windows.stop(2);
+    expect(bridge.invoke).toHaveBeenCalledWith('__core__', '{"cmd":"stop","windowId":2}');
+  });
+  it('windows.insertCSS', async () => {
+    await windows.insertCSS(2, 'body{color:red}');
+    expect(bridge.invoke).toHaveBeenCalledWith('__core__', '{"cmd":"insert_css","windowId":2,"css":"body{color:red}"}');
+  });
+  it('windows.removeInsertedCSS', async () => {
+    await windows.removeInsertedCSS(2, 'suji-css-3');
+    expect(bridge.invoke).toHaveBeenCalledWith('__core__', '{"cmd":"remove_inserted_css","windowId":2,"key":"suji-css-3"}');
+  });
+  it('windows.setWindowOpenHandler', async () => {
+    await windows.setWindowOpenHandler('deny');
+    expect(bridge.invoke).toHaveBeenCalledWith('__core__', '{"cmd":"web_contents_set_window_open_handler","action":"deny"}');
+  });
+});
+
+describe('session/webRequest/app wire-contract (신규 코어 메서드)', () => {
+  it('session.setDownloadPath', async () => {
+    await session.setDownloadPath('/tmp/dl');
+    expect(bridge.invoke).toHaveBeenCalledWith('__core__', '{"cmd":"session_set_download_path","path":"/tmp/dl"}');
+  });
+  it('webRequest.setRequestHeaders', async () => {
+    await webRequest.setRequestHeaders({ urls: ['https://api.x/*'] }, { Authorization: 'Bearer t' });
+    expect(bridge.invoke).toHaveBeenCalledWith('__core__', '{"cmd":"web_request_set_request_headers","patterns":["https://api.x/*"],"requestHeaders":{"Authorization":"Bearer t"}}');
+  });
+  it('app.setAsDefaultProtocolClient', async () => {
+    await app.setAsDefaultProtocolClient('myapp');
+    expect(bridge.invoke).toHaveBeenCalledWith('__core__', '{"cmd":"app_set_as_default_protocol_client","protocol":"myapp"}');
+  });
+  it('app.isDefaultProtocolClient', async () => {
+    await app.isDefaultProtocolClient('myapp');
+    expect(bridge.invoke).toHaveBeenCalledWith('__core__', '{"cmd":"app_is_default_protocol_client","protocol":"myapp"}');
+  });
+  it('app.removeAsDefaultProtocolClient', async () => {
+    await app.removeAsDefaultProtocolClient('myapp');
+    expect(bridge.invoke).toHaveBeenCalledWith('__core__', '{"cmd":"app_remove_as_default_protocol_client","protocol":"myapp"}');
   });
 });

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -2560,6 +2560,60 @@ test "webContents.setWindowOpenHandler — on_before_popup 정책 + new-window �
     }
 }
 
+// cross-SDK wire-contract 가드 — 이번 세션 신규 코어 메서드의 cmd/필드명이 각 백엔드 SDK
+// (Rust/Go/Zig) 소스 ↔ 코어(main.zig) 에 일관되게 존재하는지 검사. FFI-coupled SDK 는
+// behavioral mock 이 비현실적이라(suji-node 는 별도 behavioral 테스트), 필드명 drift 를
+// 소스 레벨로 잡는 net. cmd 오타/필드명 불일치 = 빌드 통과하지만 런타임 무동작 → 여기서 차단.
+test "cross-SDK wire-contract — 신규 코어 cmd/필드 가 Rust/Go/Zig SDK 에 일관" {
+    const a = std.testing.allocator;
+    const main_src = try readMainSource();
+    defer a.free(main_src);
+    const rust = try readProjectFile("crates/suji-rs/src/lib.rs", 2 * 1024 * 1024);
+    defer a.free(rust);
+    const zig_sdk = try readProjectFile("src/core/app.zig", 1024 * 1024);
+    defer a.free(zig_sdk);
+    const go_win = try readProjectFile("sdks/suji-go/windows/windows.go", 256 * 1024);
+    defer a.free(go_win);
+    const go_sess = try readProjectFile("sdks/suji-go/session/session.go", 64 * 1024);
+    defer a.free(go_sess);
+    const go_wr = try readProjectFile("sdks/suji-go/webrequest/webrequest.go", 64 * 1024);
+    defer a.free(go_wr);
+    const go_app = try readProjectFile("sdks/suji-go/app/app.go", 64 * 1024);
+    defer a.free(go_app);
+
+    // cmd 이름: core(main.zig) + Rust + Zig SDK 모두에 존재해야(drift 차단).
+    inline for (.{
+        "stop",
+        "insert_css",
+        "remove_inserted_css",
+        "web_contents_set_window_open_handler",
+        "session_set_download_path",
+        "web_request_set_request_headers",
+        "app_set_as_default_protocol_client",
+        "app_is_default_protocol_client",
+        "app_remove_as_default_protocol_client",
+    }) |cmd| {
+        try std.testing.expect(std.mem.indexOf(u8, main_src, cmd) != null);
+        try std.testing.expect(std.mem.indexOf(u8, rust, cmd) != null);
+        try std.testing.expect(std.mem.indexOf(u8, zig_sdk, cmd) != null);
+    }
+
+    // 다중-필드 cmd 의 distinctive 필드명: core + 각 SDK 에 동일.
+    inline for (.{ main_src, rust, zig_sdk }) |src| {
+        try std.testing.expect(std.mem.indexOf(u8, src, "requestHeaders") != null); // setRequestHeaders
+        try std.testing.expect(std.mem.indexOf(u8, src, "protocol") != null); // protocol trio
+    }
+
+    // Go: 패키지별 파일에 해당 cmd 존재(분산 — 패키지 경계).
+    try std.testing.expect(std.mem.indexOf(u8, go_win, "web_contents_set_window_open_handler") != null);
+    try std.testing.expect(std.mem.indexOf(u8, go_win, "insert_css") != null);
+    try std.testing.expect(std.mem.indexOf(u8, go_sess, "session_set_download_path") != null);
+    try std.testing.expect(std.mem.indexOf(u8, go_wr, "web_request_set_request_headers") != null);
+    try std.testing.expect(std.mem.indexOf(u8, go_wr, "requestHeaders") != null);
+    try std.testing.expect(std.mem.indexOf(u8, go_app, "app_set_as_default_protocol_client") != null);
+    try std.testing.expect(std.mem.indexOf(u8, go_app, "protocol") != null);
+}
+
 test "app.getName/getVersion + screen.getDisplayNearestPoint IPC" {
     const main_src = try readMainSource();
     defer std.testing.allocator.free(main_src);


### PR DESCRIPTION
## 배경

이번 세션 신규 코어 메서드(stop/insertCSS/removeInsertedCSS/setWindowOpenHandler/setDownloadPath/setRequestHeaders/protocol trio)의 **백엔드 SDK 커버리지 공백** 보강.

**공백**: frontend e2e 는 코어 핸들러를 검증하지만, 백엔드 SDK(Node/Rust/Go/Zig)가 보내는 cmd/필드명 **drift**(오타 = 빌드 통과 + e2e 가 못 잡음)는 미검증이었음.

## 추가한 것

- **suji-node behavioral wire-contract** (`index.test.ts` +9): mock `invoke` 로 각 메서드가 `__core__` 에 보내는 **정확한 cmd+필드 JSON** 검증 (예: `'{"cmd":"web_request_set_request_headers","patterns":[...],"requestHeaders":{...}}'`). → **60 pass**.
- **cross-SDK source-contract 가드** (`cef_ipc_test.zig`): 신규 cmd 이름 + distinctive 필드명(requestHeaders/protocol)이 core(`main.zig`) ↔ Rust ↔ Go ↔ Zig SDK 에 **일관 존재**하는지 검사. FFI-coupled SDK 는 behavioral mock 이 비현실적이라 소스-레벨 drift net.

## 검증

- `zig build test` **952/954 (2 skip)**
- `suji-node` **60 pass**

## 정직 경계

Rust/Go/Zig 는 source-contract(이름 drift) 수준입니다 — 완전한 builder-behavioral 단위테스트(각 SDK `*_request` 빌더 + assert, 기존 `window_op_request` 패턴)는 추가 하드닝 여지로 남겨둡니다. suji-js 는 frontend e2e 로 behavioral 커버됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)