### PR TITLE
feat(plugin): window-state — 창 bounds/maximized 저장·복원

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ zig build test-store    # store 플러그인 (file-backed config store, named in
 zig build test-http     # http 플러그인 (renderer-safe fetch with URL allowlist, deny-by-default)
 zig build test-os-autostart # os-info + autostart 플러그인 (시스템 정보 / 로그인 자동실행)
 zig build test-notification-rich # notification-rich 플러그인 (WinRT/UNUserNotificationCenter/Freedesktop actions)
+zig build test-window-state # window-state 플러그인 (창 bounds/maximized 저장·복원; CEF-free 표면 — file/validate/graceful no-window)
 
 # 임베드 코어 라이브러리 (CEF 무관 — 모바일/임베드용)
 zig build lib                                  # libsuji_core.a (host)
@@ -70,8 +71,9 @@ bash tests/e2e/run-gpu-accel.sh         # GPU 가속 회귀 가드 (#12) — Web
 bash tests/e2e/run-releasesafe-renderer-boot.sh # #60 part2 회귀 가드 — ReleaseSafe 빌드해 렌더러 V8 부트스트랩(window.__suji__ 바인딩) 검증(Windows CI). 디버깅: SUJI_CEF_DEBUG=1
 bash tests/e2e/run-set-user-agent.sh    # set_user_agent CDP override 실효(navigator.userAgent)
 bash tests/e2e/run-context-isolation.sh # window.__suji__ frozen/슬롯봉인/변조차단/기능보존
-bash tests/e2e/run-plugin-wrappers.sh   # 공식 플러그인 (state/sqlite/log/store/http/notification-rich) × {JS, Node} wrapper wire-contract (mock bridge)
+bash tests/e2e/run-plugin-wrappers.sh   # 공식 플러그인 (state/sqlite/log/store/http/notification-rich/window-state) × {JS, Node} wrapper wire-contract (mock bridge)
 bash tests/e2e/run-plugin-state-integration.sh # state plugin DLL 라운드트립(__suji__ → DLL → 응답)
+bash tests/e2e/run-plugin-window-state.sh # window-state plugin 실 CEF 창 라운드트립(save 가 라이브 bounds 읽기 → file → get/restore/clear)
 bash tests/e2e/run-lua-e2e.sh           # Lua 백엔드 (vendored Lua 5.4 + cjson) invoke 왕복/cjson roundtrip/50 concurrent (-Dlua 자동 빌드)
 bash tests/e2e/run-python-e2e.sh        # Python 백엔드 (embedded CPython 3.13 + GIL) invoke 왕복/json roundtrip/50 concurrent/send·on (scripts/stage-python.sh 자동 staging)
 

--- a/build.zig
+++ b/build.zig
@@ -1146,6 +1146,28 @@ pub fn build(b: *std.Build) void {
     const store_test_step = b.step("test-store", "Run store plugin tests (requires built dylib)");
     store_test_step.dependOn(&store_test_run.step);
 
+    const window_state_test_mod = b.createModule(.{
+        .root_source_file = b.path("tests/window_state_plugin_test.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    const window_state_loader = b.createModule(.{
+        .root_source_file = b.path("src/backends/loader.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    window_state_loader.addImport("events", events_module);
+    window_state_loader.addImport("runtime", runtime_module);
+    window_state_loader.addImport("util", util_module);
+    window_state_test_mod.addImport("loader", window_state_loader);
+    window_state_test_mod.addImport("events", events_module);
+    const window_state_test = b.addTest(.{ .root_module = window_state_test_mod });
+    const window_state_test_run = b.addRunArtifact(window_state_test);
+    window_state_test_run.setCwd(b.path("."));
+    const window_state_test_step = b.step("test-window-state", "Run window-state plugin tests (requires built dylib)");
+    window_state_test_step.dependOn(&window_state_test_run.step);
+
     // HTTP plugin tests (log/state/sqlite/store 와 동형)
     const http_test_mod = b.createModule(.{
         .root_source_file = b.path("tests/http_plugin_test.zig"),

--- a/documents/plugin-window-state.mdx
+++ b/documents/plugin-window-state.mdx
@@ -1,0 +1,87 @@
+---
+title: window-state 플러그인
+description: 창 위치/크기/최대화 상태 저장·복원 (Electron/Tauri window-state 동등)
+---
+
+# window-state 플러그인
+
+창을 닫았다 다시 열어도 마지막 위치·크기·최대화 상태를 그대로 복원한다. 코어 백엔드
+window API(`getBounds`/`isMaximized`/`setBounds`/`maximize`)를 조합 + 파일 영속이라
+**새 네이티브 코드 0** — `store` 플러그인의 atomic-write 패턴을 재사용한다.
+
+## 설치
+
+`suji.json`에 등록:
+
+```json
+{
+  "plugins": ["window-state"]
+}
+```
+
+## 동작 모델
+
+코어에 window move/resize **이벤트가 없으므로** 자동 추적은 불가능하다(Tauri 도
+디바운스 차이뿐). 따라서 적절한 시점에 `saveState()`를 **명시 호출**하고, 시작 시
+`restoreState()`를 호출한다.
+
+저장 위치: `<appdata>/suji-app/window-state/<key>.json` (key 별 단일 파일).
+`key` 생략 시 **호출 창 name**(있으면) 또는 `"main"` — 멀티 윈도우는 `key`로 구분.
+
+## 프론트 (`@suji/plugin-window-state`)
+
+```ts
+import { windowState } from '@suji/plugin-window-state';
+
+// 1) 앱 시작 — 마지막 상태 복원 (저장값 없으면 false)
+await windowState.restoreState();
+
+// 2) 종료 직전 — 현재 상태 저장 (move/resize 이벤트가 없어 명시 저장)
+suji.on('app:before-quit', () => windowState.saveState());
+
+// 멀티 윈도우 — key 로 슬롯 구분
+await windowState.restoreState({ key: 'settings' });
+await windowState.saveState({ key: 'settings' });
+
+// 조회/삭제
+const s = await windowState.getState({ key: 'main' });
+// s = { x, y, width, height, maximized } | null
+await windowState.clearState({ key: 'main' });
+```
+
+호출 창은 코어가 `__window`를 자동 주입하므로 `windowId`를 줄 필요가 없다.
+
+## 백엔드 (`@suji/plugin-window-state-node`)
+
+Wire contract 은 프론트와 동일. ⚠️ Node 백엔드는 **창 컨텍스트가 없으므로** `windowId`를
+명시해야 한다.
+
+```ts
+const { windowState } = require('@suji/plugin-window-state-node');
+await windowState.restoreState({ key: 'main', windowId: 1 });
+await windowState.saveState({ key: 'main', windowId: 1 });
+```
+
+## 채널 (저수준)
+
+| 채널 | 요청 | 응답 |
+|---|---|---|
+| `window-state:save` | `{key?, windowId?}` | `{ok:true}` |
+| `window-state:restore` | `{key?, windowId?}` | `{ok:true, restored:bool}` |
+| `window-state:get` | `{key?}` | `{state: {x,y,width,height,maximized}|null}` |
+| `window-state:clear` | `{key?}` | `{ok:true}` |
+
+`save`/`restore`는 `windowId`(명시) 우선, 없으면 호출 창. `id=0`(창 컨텍스트 없음)이면
+`"no window"` 에러. `key`는 path traversal 방지 화이트리스트(`store` 와 동일 가드).
+
+## 정직 경계
+
+- **자동 추적 없음** — move/resize 이벤트가 코어에 없어 `saveState`를 명시 호출해야 한다.
+- **bounds 먼저, 그 다음 maximize** — 복원은 항상 `setBounds()`로 저장 위치·크기를 적용한
+  뒤, 저장이 maximized 면 `maximize()`. 코어에 `getNormalBounds`(pre-maximize bounds)가
+  없어 maximized 창의 저장 bounds 는 최대화 bounds 자체다 — unmaximize 시 pre-maximize
+  크기로 복귀하지는 않는다(정직 경계).
+- **잘못된 정수/키 방어** — 디스크 파일이 손상/변조돼 범위 밖 좌표면 패닉 대신
+  `corrupt state` 에러. 자동 파생 key(창 name)가 파일명 부적합(공백 등)이면 `"main"` 으로 폴백.
+- 단위 테스트는 window API 가 없어 file/validate/graceful-no-window 표면만 커버 —
+  실 창 라운드트립은 `bash tests/e2e/run-plugin-window-state.sh`(실 CEF 창)가 검증.

--- a/documents/plugins.mdx
+++ b/documents/plugins.mdx
@@ -16,7 +16,7 @@ JS)에서 일관되게 호출하기 위한 구조. OS native API (clipboard/fs/d
 | 위치 | `src/platform/cef.zig` (코어) | `plugins/<name>/` (외부 디렉토리) |
 | 빌드 | suji 코어와 함께 | 별도 dylib (또는 source 포함) |
 | 5 SDK 노출 | ✅ 자동 (suji core가 책임) | ✅ wrapper 직접 작성 |
-| 예시 | clipboard, fs, dialog, tray, menu, notification, globalShortcut | `state`, `sqlite`, `log`, `store`, `http`, `notification-rich`, 사용자 DB / 인증 / telemetry 등 |
+| 예시 | clipboard, fs, dialog, tray, menu, notification, globalShortcut | `state`, `sqlite`, `log`, `store`, `http`, `notification-rich`, `window-state`, 사용자 DB / 인증 / telemetry 등 |
 | Mac App Sandbox 호환 | ✅ (entitlements + 코어 binary) | 🟡 dylib + entitlements 분리 작업 필요 |
 
 OS native API를 plugin으로 만들지 못하는 이유:

--- a/examples/multi-backend/suji.json
+++ b/examples/multi-backend/suji.json
@@ -14,7 +14,7 @@
       "protocol": "suji"
     }
   ],
-  "plugins": ["state"],
+  "plugins": ["state", "window-state"],
   "backends": [
     { "name": "zig", "lang": "zig", "entry": "backends/zig" },
     { "name": "rust", "lang": "rust", "entry": "backends/rust" },

--- a/plugins/window-state/js/package.json
+++ b/plugins/window-state/js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@suji/plugin-window-state",
+  "version": "0.1.0",
+  "description": "Suji Window State Plugin - persist & restore window bounds/maximized for Renderer",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/plugins/window-state/js/src/index.test.ts
+++ b/plugins/window-state/js/src/index.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockBridge = {
+  invoke: mock(() => Promise.resolve({})),
+};
+
+(globalThis as any).window = { __suji__: mockBridge };
+
+const { windowState } = await import("./index");
+
+beforeEach(() => {
+  mockBridge.invoke.mockClear();
+});
+
+describe("saveState wire", () => {
+  it("no opts → empty payload", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true } });
+    await windowState.saveState();
+    expect(mockBridge.invoke).toHaveBeenCalledWith("window-state:save", {});
+  });
+
+  it("key + windowId pass through", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true } });
+    await windowState.saveState({ key: "settings", windowId: 3 });
+    expect(mockBridge.invoke).toHaveBeenCalledWith("window-state:save", { key: "settings", windowId: 3 });
+  });
+});
+
+describe("restoreState wire + return", () => {
+  it("returns restored bool", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true, restored: true } });
+    expect(await windowState.restoreState({ key: "main" })).toBe(true);
+    expect(mockBridge.invoke).toHaveBeenCalledWith("window-state:restore", { key: "main" });
+  });
+
+  it("returns false when nothing stored", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true, restored: false } });
+    expect(await windowState.restoreState()).toBe(false);
+  });
+});
+
+describe("getState response unwrap", () => {
+  it("returns state object", async () => {
+    const st = { x: 10, y: 20, width: 800, height: 600, maximized: false };
+    mockBridge.invoke.mockResolvedValueOnce({ result: { state: st } });
+    expect(await windowState.getState({ key: "main" })).toEqual(st);
+    // get 은 windowId 를 안 보냄
+    expect(mockBridge.invoke).toHaveBeenCalledWith("window-state:get", { key: "main" });
+  });
+
+  it("returns null when state null", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { state: null } });
+    expect(await windowState.getState()).toBeNull();
+  });
+});
+
+describe("clearState wire", () => {
+  it("sends key only", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true } });
+    await windowState.clearState({ key: "settings" });
+    expect(mockBridge.invoke).toHaveBeenCalledWith("window-state:clear", { key: "settings" });
+  });
+});
+
+describe("error propagation", () => {
+  it("throws when bridge response has error", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ error: "no window" });
+    await expect(windowState.saveState()).rejects.toThrow("window-state: no window");
+  });
+});

--- a/plugins/window-state/js/src/index.ts
+++ b/plugins/window-state/js/src/index.ts
@@ -1,0 +1,82 @@
+/**
+ * @suji/plugin-window-state — 창 위치/크기/최대화 상태 저장·복원 (Electron/Tauri window-state 동등).
+ *
+ * 코어 백엔드 windows API(getBounds/isMaximized/setBounds/maximize) 조합 + 파일 영속.
+ * 호출 창은 자동 감지(코어가 `__window` 주입) — windowId 생략 가능.
+ *
+ * ```ts
+ * import { windowState } from '@suji/plugin-window-state';
+ *
+ * // 시작 시 복원
+ * await windowState.restoreState();              // key 생략 → 창 name 또는 "main"
+ * // 종료 직전 저장 (move/resize 이벤트가 없어 명시 저장)
+ * suji.on('app:before-quit', () => windowState.saveState());
+ *
+ * // 멀티 윈도우 — key 로 구분
+ * await windowState.restoreState({ key: 'settings' });
+ * ```
+ *
+ * 정직 경계: 코어에 window move/resize 이벤트가 없어 자동 추적은 불가 — saveState 를
+ *   적절한 시점(app:before-quit / window:close)에 명시 호출한다.
+ */
+
+interface SujiBridge {
+  invoke(channel: string, data?: Record<string, unknown>): Promise<any>;
+}
+
+function getBridge(): SujiBridge {
+  const bridge = (window as any).__suji__;
+  if (!bridge) throw new Error("Suji bridge not available.");
+  return bridge;
+}
+
+async function call(channel: string, data: Record<string, unknown>): Promise<any> {
+  const resp = await getBridge().invoke(channel, data);
+  if (resp?.error) throw new Error(`window-state: ${resp.error}`);
+  return resp?.result ?? resp;
+}
+
+export interface WindowState {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  maximized: boolean;
+}
+
+export interface SaveOptions {
+  /** 저장 슬롯 키. 생략 시 창 name 또는 "main". 멀티 윈도우 구분용. */
+  key?: string;
+  /** 대상 창 id. 생략 시 호출 창(렌더러). Node 백엔드는 창이 없어 명시 필요. */
+  windowId?: number;
+}
+
+/** key/windowId 가 정의됐을 때만 payload 에 포함 (wire 최소화). get/clear 의 opts 는
+ *  타입이 key-only(Pick) 라 windowId 는 애초에 부재 → 무조건 복사해도 동일. */
+function payload(opts?: SaveOptions): Record<string, unknown> {
+  const p: Record<string, unknown> = {};
+  if (opts?.key !== undefined) p.key = opts.key;
+  if (opts?.windowId !== undefined) p.windowId = opts.windowId;
+  return p;
+}
+
+export const windowState = {
+  /** 현재 창(또는 windowId) bounds+maximized 를 저장. */
+  async saveState(opts?: SaveOptions): Promise<void> {
+    await call("window-state:save", payload(opts));
+  },
+  /** 저장된 state 를 창에 적용. 저장값이 없으면 false. */
+  async restoreState(opts?: SaveOptions): Promise<boolean> {
+    const r = await call("window-state:restore", payload(opts));
+    return Boolean(r?.restored);
+  },
+  /** 저장된 state 조회(적용 X). 없으면 null. */
+  async getState(opts?: Pick<SaveOptions, "key">): Promise<WindowState | null> {
+    const r = await call("window-state:get", payload(opts));
+    return (r?.state ?? null) as WindowState | null;
+  },
+  /** 저장된 state 삭제. */
+  async clearState(opts?: Pick<SaveOptions, "key">): Promise<void> {
+    await call("window-state:clear", payload(opts));
+  },
+};

--- a/plugins/window-state/js/tsconfig.json
+++ b/plugins/window-state/js/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/plugins/window-state/node/package.json
+++ b/plugins/window-state/node/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@suji/plugin-window-state-node",
+  "version": "0.1.0",
+  "description": "Suji Window State Plugin - persist & restore window bounds/maximized for Node.js backends",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/plugins/window-state/node/src/index.test.ts
+++ b/plugins/window-state/node/src/index.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockBridge = {
+  invoke: mock(() => Promise.resolve('{"result":{}}')),
+};
+
+(globalThis as any).suji = mockBridge;
+
+const { windowState } = await import("./index");
+
+beforeEach(() => {
+  mockBridge.invoke.mockClear();
+});
+
+function lastCall(): { backend: string; payload: Record<string, unknown> } {
+  const args = mockBridge.invoke.mock.calls.at(-1)!;
+  return { backend: args[0] as string, payload: JSON.parse(args[1] as string) };
+}
+
+describe("window-state Node — routing + wire", () => {
+  it("saveState routes to 'window-state' backend with cmd", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true}}');
+    await windowState.saveState({ key: "main", windowId: 1 });
+    const { backend, payload } = lastCall();
+    expect(backend).toBe("window-state");
+    expect(payload).toEqual({ cmd: "window-state:save", key: "main", windowId: 1 });
+  });
+
+  it("restoreState returns restored bool", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true,"restored":true}}');
+    expect(await windowState.restoreState({ key: "main", windowId: 1 })).toBe(true);
+    expect(lastCall().payload).toEqual({ cmd: "window-state:restore", key: "main", windowId: 1 });
+  });
+
+  it("getState unwraps state, sends key only", async () => {
+    const st = { x: 1, y: 2, width: 3, height: 4, maximized: true };
+    mockBridge.invoke.mockResolvedValueOnce(JSON.stringify({ result: { state: st } }));
+    expect(await windowState.getState({ key: "main" })).toEqual(st);
+    expect(lastCall().payload).toEqual({ cmd: "window-state:get", key: "main" });
+  });
+
+  it("clearState sends key only", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true}}');
+    await windowState.clearState({ key: "main" });
+    expect(lastCall().payload).toEqual({ cmd: "window-state:clear", key: "main" });
+  });
+
+  it("empty opts → bare cmd", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true,"restored":false}}');
+    await windowState.restoreState();
+    expect(lastCall().payload).toEqual({ cmd: "window-state:restore" });
+  });
+});
+
+describe("error propagation", () => {
+  it("throws when bridge response has error", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"error":"no window"}');
+    await expect(windowState.saveState({ windowId: 1 })).rejects.toThrow("window-state: no window");
+  });
+});

--- a/plugins/window-state/node/src/index.ts
+++ b/plugins/window-state/node/src/index.ts
@@ -1,0 +1,78 @@
+/**
+ * @suji/plugin-window-state-node — 창 상태 저장·복원 for Suji Node backends.
+ * Wire contract 은 renderer `@suji/plugin-window-state` 와 동일.
+ *
+ * ⚠️ Node 백엔드는 창 컨텍스트가 없으므로 `windowId` 를 명시해야 한다(렌더러는 자동 감지).
+ *
+ * ```ts
+ * const { windowState } = require('@suji/plugin-window-state-node');
+ * await windowState.restoreState({ key: 'main', windowId: 1 });
+ * await windowState.saveState({ key: 'main', windowId: 1 });
+ * ```
+ */
+
+interface SujiBridge {
+  invoke(backend: string, request: string): Promise<string>;
+}
+
+function getBridge(): SujiBridge {
+  const bridge = (globalThis as any).suji as SujiBridge | undefined;
+  if (!bridge) {
+    throw new Error(
+      "@suji/plugin-window-state-node: bridge not available. This module must run inside a Suji app (libnode embedding).",
+    );
+  }
+  return bridge;
+}
+
+async function call(cmd: string, payload: Record<string, unknown>): Promise<any> {
+  const raw = await getBridge().invoke("window-state", JSON.stringify({ cmd, ...payload }));
+  let resp: any;
+  try {
+    resp = JSON.parse(raw);
+  } catch {
+    resp = {};
+  }
+  if (resp?.error) throw new Error(`window-state: ${resp.error}`);
+  return resp?.result;
+}
+
+export interface WindowState {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  maximized: boolean;
+}
+
+export interface SaveOptions {
+  /** 저장 슬롯 키. 생략 시 "main". 멀티 윈도우 구분용. */
+  key?: string;
+  /** 대상 창 id. Node 백엔드는 창 컨텍스트가 없어 명시 필요. */
+  windowId?: number;
+}
+
+/** get/clear 의 opts 는 타입이 key-only(Pick) 라 windowId 는 부재 → 무조건 복사해도 동일. */
+function payload(opts?: SaveOptions): Record<string, unknown> {
+  const p: Record<string, unknown> = {};
+  if (opts?.key !== undefined) p.key = opts.key;
+  if (opts?.windowId !== undefined) p.windowId = opts.windowId;
+  return p;
+}
+
+export const windowState = {
+  async saveState(opts?: SaveOptions): Promise<void> {
+    await call("window-state:save", payload(opts));
+  },
+  async restoreState(opts?: SaveOptions): Promise<boolean> {
+    const r = await call("window-state:restore", payload(opts));
+    return Boolean(r?.restored);
+  },
+  async getState(opts?: Pick<SaveOptions, "key">): Promise<WindowState | null> {
+    const r = await call("window-state:get", payload(opts));
+    return (r?.state ?? null) as WindowState | null;
+  },
+  async clearState(opts?: Pick<SaveOptions, "key">): Promise<void> {
+    await call("window-state:clear", payload(opts));
+  },
+};

--- a/plugins/window-state/node/tsconfig.json
+++ b/plugins/window-state/node/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/plugins/window-state/suji-plugin.json
+++ b/plugins/window-state/suji-plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "window-state",
+  "lang": "zig"
+}

--- a/plugins/window-state/zig/app.zig
+++ b/plugins/window-state/zig/app.zig
@@ -1,0 +1,220 @@
+//! @suji/plugin-window-state — 창 위치/크기/최대화 상태 저장·복원 (Electron/Tauri window-state 동등).
+//!
+//! 새 네이티브 0 — 코어 백엔드 windows SDK(getBounds/isMaximized/setBounds/maximize)
+//! 조합 + 파일 영속. store 플러그인의 atomic-write 패턴 재사용(per-key 단일 파일).
+//!
+//! 채널:
+//!   window-state:save    {key?, windowId?}  → {ok:true}
+//!     호출 창(또는 windowId)의 bounds+maximized 를 <appdata>/suji-app/window-state/<key>.json 에 저장.
+//!   window-state:restore {key?, windowId?}  → {ok:true, restored:bool}
+//!     저장된 state 를 창에 적용(maximized 면 maximize, 아니면 setBounds). 없으면 restored:false.
+//!   window-state:get     {key?}             → {state: {x,y,width,height,maximized}|null}
+//!   window-state:clear   {key?}             → {ok:true}
+//!
+//! key 기본값: 호출 창 name(있으면) 또는 "main". 멀티 윈도우는 key 로 구분.
+//! 정직 경계: 코어에 window move/resize 이벤트가 없어 자동 추적은 불가 — save 를 명시
+//!   호출(app:before-quit/window:close 시점)해야 한다(Tauri 도 디바운스 차이뿐). Node
+//!   백엔드는 창 컨텍스트가 없으므로 windowId 명시 필요(없으면 "no window" 에러).
+
+const std = @import("std");
+const builtin = @import("builtin");
+const suji = @import("suji");
+const util = @import("util");
+
+pub const app = suji.app()
+    .named("window-state")
+    .handle("window-state:save", wsSave)
+    .handle("window-state:restore", wsRestore)
+    .handle("window-state:get", wsGet)
+    .handle("window-state:clear", wsClear);
+
+var gpa: std.heap.DebugAllocator(.{}) = .init;
+const alloc = gpa.allocator();
+
+const MAX_FILE_BYTES: usize = 64 * 1024; // state JSON 은 작음 — 64KB cap
+const MAX_KEY_LEN: usize = 64;
+
+fn pluginIo() std.Io {
+    return suji.io();
+}
+
+// 코어 windows API 응답 파싱은 util.extractJsonInt/extractJsonBool(코어와 동일
+// 캐노니컬 추출기)을 직접 사용 — 부재 bool 은 `orelse false` 로 처리.
+
+// ============================================
+// key 검증 + 파일 경로 (store 플러그인 패턴)
+// ============================================
+
+/// key 문자 화이트리스트 — path traversal 방지(store 와 동일 가드).
+fn validKey(key: []const u8) bool {
+    if (key.len == 0 or key.len > MAX_KEY_LEN) return false;
+    if (std.mem.eql(u8, key, ".") or std.mem.eql(u8, key, "..")) return false;
+    for (key) |c| {
+        if (!std.ascii.isAlphanumeric(c) and c != '-' and c != '_' and c != '.') return false;
+    }
+    return true;
+}
+
+fn cGetenv(name: [*:0]const u8) ?[]const u8 {
+    const raw = std.c.getenv(name) orelse return null;
+    return std.mem.span(raw);
+}
+
+/// <appdata>/suji-app/window-state/<key>.json (store makePath 와 동형 디렉토리 트리).
+fn makePath(key: []const u8) ?[]const u8 {
+    if (builtin.os.tag == .macos) {
+        const home = cGetenv("HOME") orelse return null;
+        return std.fmt.allocPrint(alloc, "{s}/Library/Application Support/suji-app/window-state/{s}.json", .{ home, key }) catch null;
+    } else if (builtin.os.tag == .linux) {
+        if (cGetenv("XDG_DATA_HOME")) |dir| {
+            return std.fmt.allocPrint(alloc, "{s}/suji-app/window-state/{s}.json", .{ dir, key }) catch null;
+        }
+        const home = cGetenv("HOME") orelse return null;
+        return std.fmt.allocPrint(alloc, "{s}/.local/share/suji-app/window-state/{s}.json", .{ home, key }) catch null;
+    } else if (builtin.os.tag == .windows) {
+        const appdata = cGetenv("APPDATA") orelse return null;
+        return std.fmt.allocPrint(alloc, "{s}\\suji-app\\window-state\\{s}.json", .{ appdata, key }) catch null;
+    }
+    return null;
+}
+
+/// state JSON 을 path 에 atomic write(.tmp → rename). store.persistUnlocked 동형.
+fn writeStateFile(path: []const u8, content: []const u8) bool {
+    const io = pluginIo();
+    if (std.mem.lastIndexOfAny(u8, path, "/\\")) |sep| {
+        std.Io.Dir.cwd().createDirPath(io, path[0..sep]) catch {};
+    }
+    const tmp_path = std.fmt.allocPrint(alloc, "{s}.tmp", .{path}) catch return false;
+    defer alloc.free(tmp_path);
+    var file = std.Io.Dir.cwd().createFile(io, tmp_path, .{}) catch return false;
+    file.writePositionalAll(io, content, 0) catch {
+        file.close(io);
+        std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
+        return false;
+    };
+    file.close(io);
+    // Windows rename 은 dst 존재 시 fail → 미리 delete (store 와 동일 trade-off).
+    if (builtin.os.tag == .windows) {
+        std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    }
+    std.Io.Dir.cwd().rename(tmp_path, std.Io.Dir.cwd(), path, io) catch {
+        std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
+        return false;
+    };
+    return true;
+}
+
+/// path 의 state JSON 을 arena 로 읽음. 없으면 null.
+fn readStateFile(path: []const u8, arena: std.mem.Allocator) ?[]const u8 {
+    return std.Io.Dir.cwd().readFileAlloc(pluginIo(), path, arena, .limited(MAX_FILE_BYTES)) catch null;
+}
+
+// ============================================
+// 공통: windowId/key 해석
+// ============================================
+
+/// windowId 명시 우선, 없으면 호출 창(InvokeEvent). 0 이면 창 컨텍스트 없음.
+/// caller-supplied wid 는 u32 범위 밖일 수 있으므로 cast 실패 시 0(패닉 방지).
+fn resolveWindowId(req: suji.Request, ev: suji.InvokeEvent) u32 {
+    if (req.int("windowId")) |wid| {
+        if (wid <= 0) return 0;
+        return std.math.cast(u32, wid) orelse 0;
+    }
+    return ev.window.id;
+}
+
+/// key 해석:
+///   - 명시 key: 검증 실패 시 null(에러) — 사용자가 잘못 준 것이므로 알린다.
+///   - 자동 파생(창 name → "main"): name 이 validKey 를 통과 못 하면(공백/슬래시 등
+///     창 name 은 허용되지만 파일명엔 부적합) "main" 으로 graceful fallback(에러 X).
+fn resolveKey(req: suji.Request, ev: suji.InvokeEvent) ?[]const u8 {
+    if (req.string("key")) |k| {
+        return if (validKey(k)) k else null;
+    }
+    const derived = ev.window.name orelse "main";
+    return if (validKey(derived)) derived else "main";
+}
+
+// ============================================
+// 핸들러
+// ============================================
+
+fn wsSave(req: suji.Request, ev: suji.InvokeEvent) suji.Response {
+    const id = resolveWindowId(req, ev);
+    if (id == 0) return req.err("no window");
+    const key = resolveKey(req, ev) orelse return req.err("invalid key");
+
+    // ⚠️ getBounds/isMaximized 응답은 동일 threadlocal scratch 를 공유 →
+    // 두 번째 호출 전에 첫 응답을 i64 로 복사 완료해야 한다(순서 의존).
+    const bounds = suji.windows.getBounds(id) orelse return req.err("get_bounds failed");
+    if (!(util.extractJsonBool(bounds, "ok") orelse false)) return req.err("get_bounds not ok");
+    const x = util.extractJsonInt(bounds, "x") orelse return req.err("bad bounds");
+    const y = util.extractJsonInt(bounds, "y") orelse return req.err("bad bounds");
+    const w = util.extractJsonInt(bounds, "width") orelse return req.err("bad bounds");
+    const h = util.extractJsonInt(bounds, "height") orelse return req.err("bad bounds");
+
+    const max_resp = suji.windows.isMaximized(id);
+    const maximized = if (max_resp) |mr| (util.extractJsonBool(mr, "maximized") orelse false) else false;
+
+    const state = std.fmt.allocPrint(
+        req.arena,
+        "{{\"x\":{d},\"y\":{d},\"width\":{d},\"height\":{d},\"maximized\":{}}}",
+        .{ x, y, w, h, maximized },
+    ) catch return req.err("alloc");
+
+    const path = makePath(key) orelse return req.err("path");
+    defer alloc.free(path);
+    if (!writeStateFile(path, state)) return req.err("write failed");
+    return req.okRaw("{\"ok\":true}");
+}
+
+fn wsRestore(req: suji.Request, ev: suji.InvokeEvent) suji.Response {
+    const id = resolveWindowId(req, ev);
+    if (id == 0) return req.err("no window");
+    const key = resolveKey(req, ev) orelse return req.err("invalid key");
+
+    const path = makePath(key) orelse return req.err("path");
+    defer alloc.free(path);
+    const state = readStateFile(path, req.arena) orelse return req.okRaw("{\"ok\":true,\"restored\":false}");
+
+    // 저장값은 사용자가 수정 가능한 디스크 파일 → 범위 밖 정수는 std.math.cast 로
+    // 에러 처리(@intCast 패닉 방지).
+    const x = util.extractJsonInt(state, "x") orelse return req.err("corrupt state");
+    const y = util.extractJsonInt(state, "y") orelse return req.err("corrupt state");
+    const w = util.extractJsonInt(state, "width") orelse return req.err("corrupt state");
+    const h = util.extractJsonInt(state, "height") orelse return req.err("corrupt state");
+    const xi = std.math.cast(i32, x) orelse return req.err("corrupt state");
+    const yi = std.math.cast(i32, y) orelse return req.err("corrupt state");
+    const wi = std.math.cast(u32, w) orelse return req.err("corrupt state");
+    const hi = std.math.cast(u32, h) orelse return req.err("corrupt state");
+
+    // 항상 bounds 를 먼저 적용한 뒤(maximized 여도 — unmaximize 시 복귀할 bounds 보존),
+    // maximized 면 maximize. (정직 경계: 코어에 getNormalBounds 가 없어 maximized 창의
+    // 저장 bounds 는 최대화 bounds 자체 — 저장 시점 pre-maximize bounds 는 캡처 불가.)
+    _ = suji.windows.setBounds(id, .{ .x = xi, .y = yi, .width = wi, .height = hi });
+    if (util.extractJsonBool(state, "maximized") orelse false) {
+        _ = suji.windows.maximize(id);
+    }
+    return req.okRaw("{\"ok\":true,\"restored\":true}");
+}
+
+fn wsGet(req: suji.Request, ev: suji.InvokeEvent) suji.Response {
+    const key = resolveKey(req, ev) orelse return req.err("invalid key");
+    const path = makePath(key) orelse return req.err("path");
+    defer alloc.free(path);
+    const state = readStateFile(path, req.arena) orelse return req.okRaw("{\"state\":null}");
+    const body = std.fmt.allocPrint(req.arena, "{{\"state\":{s}}}", .{state}) catch return req.err("alloc");
+    return req.okRaw(body);
+}
+
+fn wsClear(req: suji.Request, ev: suji.InvokeEvent) suji.Response {
+    const key = resolveKey(req, ev) orelse return req.err("invalid key");
+    const path = makePath(key) orelse return req.err("path");
+    defer alloc.free(path);
+    std.Io.Dir.cwd().deleteFile(pluginIo(), path) catch {};
+    return req.okRaw("{\"ok\":true}");
+}
+
+comptime {
+    _ = suji.exportApp(app);
+}

--- a/plugins/window-state/zig/build.zig
+++ b/plugins/window-state/zig/build.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const util_mod = b.createModule(.{
+        .root_source_file = b.path("../../../src/core/util.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const suji_mod = b.createModule(.{
+        .root_source_file = b.path("../../../src/core/app.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    suji_mod.addImport("util", util_mod);
+
+    const lib = b.addLibrary(.{
+        .name = "backend",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("app.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+        .linkage = .dynamic,
+    });
+    lib.root_module.addImport("suji", suji_mod);
+    lib.root_module.addImport("util", util_mod);
+
+    b.installArtifact(lib);
+}

--- a/src/core/app.zig
+++ b/src/core/app.zig
@@ -844,6 +844,22 @@ pub const windows = struct {
         return windowCoreCmd("set_bounds", fields);
     }
 
+    /// 창 bounds 조회 (Electron BrowserWindow.getBounds). 응답:
+    /// `{...,"ok":bool,"x","y","width","height"}` — caller가 std.json 으로 파싱.
+    /// 프론트/Rust/Go SDK 엔 있던 reader 의 zig 백엔드 패리티(window-state 플러그인 사용).
+    pub fn getBounds(id: u32) ?[]const u8 {
+        return windowIdCmd("get_bounds", id);
+    }
+
+    /// 창 최대화 (Electron BrowserWindow.maximize). 응답 `{...,"ok":bool}`.
+    pub fn maximize(id: u32) ?[]const u8 {
+        return windowIdCmd("maximize", id);
+    }
+    /// 최대화 여부 (Electron BrowserWindow.isMaximized). 응답 `{...,"ok":bool,"maximized":bool}`.
+    pub fn isMaximized(id: u32) ?[]const u8 {
+        return windowIdCmd("is_maximized", id);
+    }
+
     /// JS code escape용 stack 버퍼 — cef.zig executeJavascript와 동일 임계값.
     const JS_CODE_STACK_BUF: usize = 4096;
 };

--- a/tests/e2e/plugin-window-state-integration.test.ts
+++ b/tests/e2e/plugin-window-state-integration.test.ts
@@ -1,0 +1,80 @@
+/**
+ * 공식 window-state 플러그인 통합 e2e (실 CEF 창 라운드트립).
+ *
+ * 검증 범위:
+ *   1. renderer 가 __suji__.invoke('window-state:save') → 플러그인이 **실 창**의
+ *      getBounds/isMaximized 를 코어 window API(getWindowApi)로 읽어 파일에 영속
+ *   2. 'window-state:get' 으로 저장값을 되읽어 라이브 창 bounds 와 일치(width/height>0)
+ *   3. 'window-state:restore' 가 저장값을 창에 적용(restored:true)
+ *   4. 'window-state:clear' 후 get → null, restore → restored:false
+ *
+ * Wrapper wire shape 은 `bun test plugins/window-state/{js,node}/src` 가 별도 검증.
+ * 이 파일은 REAL plugin DLL ↔ 코어 window API ↔ renderer 통합만 검사
+ * (unit test 는 window API 가 없어 file-path 핸들러 + graceful no-window 만 커버).
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import puppeteer, { type Browser, type Page } from "puppeteer-core";
+import { getMainPage } from "./_page";
+
+let browser: Browser;
+let page: Page;
+
+const KEY = "e2e";
+
+const core = <T = unknown>(channel: string, payload?: Record<string, unknown>): Promise<T> =>
+  page.evaluate(
+    (r) => (window as unknown as { __suji__: { invoke: (ch: string, d?: unknown) => unknown } }).__suji__
+      .invoke(r.channel as string, r.payload as Record<string, unknown> | undefined),
+    { channel, payload },
+  ) as Promise<T>;
+
+beforeAll(async () => {
+  browser = await puppeteer.connect({
+    browserURL: "http://localhost:9222",
+    protocolTimeout: 30000,
+    defaultViewport: null,
+  });
+  page = await getMainPage(browser);
+  page.setDefaultTimeout(15000);
+  await page.waitForFunction(() => typeof (window as any).__suji__ !== "undefined", { timeout: 10000 });
+  await core("window-state:clear", { key: KEY });
+});
+
+afterAll(async () => {
+  try {
+    await core("window-state:clear", { key: KEY });
+  } catch {}
+  await browser?.disconnect();
+});
+
+describe("window-state plugin: live window round-trip", () => {
+  test("save reads live bounds and persists", async () => {
+    const r = await core<{ result?: { ok?: boolean }; error?: string }>("window-state:save", { key: KEY });
+    expect(r?.error).toBeUndefined();
+    expect(r?.result?.ok).toBe(true);
+  });
+
+  test("get returns the persisted live bounds", async () => {
+    const r = await core<{ result?: { state?: any } }>("window-state:get", { key: KEY });
+    const s = r?.result?.state;
+    expect(s).not.toBeNull();
+    expect(typeof s.x).toBe("number");
+    expect(typeof s.y).toBe("number");
+    expect(s.width).toBeGreaterThan(0);
+    expect(s.height).toBeGreaterThan(0);
+    expect(typeof s.maximized).toBe("boolean");
+  });
+
+  test("restore applies stored state (restored:true)", async () => {
+    const r = await core<{ result?: { restored?: boolean } }>("window-state:restore", { key: KEY });
+    expect(r?.result?.restored).toBe(true);
+  });
+
+  test("clear removes state → get null, restore false", async () => {
+    await core("window-state:clear", { key: KEY });
+    const g = await core<{ result?: { state?: any } }>("window-state:get", { key: KEY });
+    expect(g?.result?.state ?? null).toBeNull();
+    const r = await core<{ result?: { restored?: boolean } }>("window-state:restore", { key: KEY });
+    expect(r?.result?.restored).toBe(false);
+  });
+});

--- a/tests/e2e/run-plugin-window-state.sh
+++ b/tests/e2e/run-plugin-window-state.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# window-state plugin 통합 e2e — multi-backend dev 를 띄워 renderer 가 실 CEF 창의
+# bounds 를 플러그인 → 코어 window API 로 save/get/restore/clear 라운드트립 검증.
+#
+# 사전조건: plugins/window-state/zig 빌드(suji dev 가 dev 모드에서 자동 buildByLang
+#   하지만, 빌드 실패를 e2e 보다 먼저 정확히 진단하기 위해 명시적 pre-build).
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$ROOT/tests/e2e/_common.sh"
+
+( cd "$ROOT/plugins/window-state/zig" && zig build )
+
+e2e_run_test tests/e2e/plugin-window-state-integration.test.ts

--- a/tests/e2e/run-plugin-wrappers.sh
+++ b/tests/e2e/run-plugin-wrappers.sh
@@ -8,4 +8,4 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
-bun test plugins/state/js/src plugins/state/node/src plugins/sqlite/js/src plugins/sqlite/node/src plugins/log/js/src plugins/log/node/src plugins/store/js/src plugins/store/node/src plugins/http/js/src plugins/http/node/src plugins/notification-rich/js/src plugins/notification-rich/node/src
+bun test plugins/state/js/src plugins/state/node/src plugins/sqlite/js/src plugins/sqlite/node/src plugins/log/js/src plugins/log/node/src plugins/store/js/src plugins/store/node/src plugins/http/js/src plugins/http/node/src plugins/notification-rich/js/src plugins/notification-rich/node/src plugins/window-state/js/src plugins/window-state/node/src

--- a/tests/window_state_plugin_test.zig
+++ b/tests/window_state_plugin_test.zig
@@ -1,0 +1,149 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const loader = @import("loader");
+
+const PLUGIN_PATH = switch (builtin.os.tag) {
+    .macos => "plugins/window-state/zig/zig-out/lib/libbackend.dylib",
+    .linux => "plugins/window-state/zig/zig-out/lib/libbackend.so",
+    .windows => "plugins/window-state/zig/zig-out/bin/backend.dll",
+    else => @compileError("unsupported OS"),
+};
+
+fn loadWs(reg: *loader.BackendRegistry) !void {
+    try reg.register("window-state", PLUGIN_PATH);
+}
+
+fn invokePlugin(reg: *loader.BackendRegistry, request: []const u8) ?[]const u8 {
+    var req_buf: [4096]u8 = undefined;
+    const len = @min(request.len, req_buf.len - 1);
+    @memcpy(req_buf[0..len], request[0..len]);
+    req_buf[len] = 0;
+    return reg.invoke("window-state", req_buf[0..len :0]);
+}
+
+fn freeResp(reg: *const loader.BackendRegistry, resp: ?[]const u8) void {
+    reg.freeResponse("window-state", resp);
+}
+
+var test_counter: u64 = 0;
+fn uniqueKey(buf: []u8) ![]const u8 {
+    test_counter += 1;
+    return std.fmt.bufPrint(buf, "wstest-{d}", .{test_counter});
+}
+
+test "window-state plugin: load + channels" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadWs(&reg);
+    try std.testing.expect(reg.get("window-state") != null);
+}
+
+test "window-state plugin: get fresh key → state null" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadWs(&reg);
+
+    var key_buf: [64]u8 = undefined;
+    const key = try uniqueKey(&key_buf);
+    var b: [256]u8 = undefined;
+    const r = invokePlugin(&reg, try std.fmt.bufPrint(&b, "{{\"cmd\":\"window-state:get\",\"key\":\"{s}\"}}", .{key}));
+    defer freeResp(&reg, r);
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"state\":null") != null);
+}
+
+test "window-state plugin: clear is ok (idempotent)" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadWs(&reg);
+
+    var key_buf: [64]u8 = undefined;
+    const key = try uniqueKey(&key_buf);
+    var b: [256]u8 = undefined;
+    const r = invokePlugin(&reg, try std.fmt.bufPrint(&b, "{{\"cmd\":\"window-state:clear\",\"key\":\"{s}\"}}", .{key}));
+    defer freeResp(&reg, r);
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"ok\":true") != null);
+}
+
+test "window-state plugin: save without window → no window error" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadWs(&reg);
+
+    // __window 미주입 + windowId 미지정 → id=0 → "no window".
+    const r = invokePlugin(&reg, "{\"cmd\":\"window-state:save\",\"key\":\"x\"}");
+    defer freeResp(&reg, r);
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "no window") != null);
+}
+
+test "window-state plugin: save with windowId but no core window API → graceful error" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadWs(&reg);
+
+    // windowId 는 있지만 test registry 엔 window API(get_window_api_fn)/__core__ 백엔드가
+    // 없어 getBounds 가 null → "get_bounds failed". 크래시 없이 에러 반환(graceful).
+    const r = invokePlugin(&reg, "{\"cmd\":\"window-state:save\",\"key\":\"x\",\"windowId\":1}");
+    defer freeResp(&reg, r);
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\"") != null);
+}
+
+test "window-state plugin: restore with no stored state → restored false" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadWs(&reg);
+
+    var key_buf: [64]u8 = undefined;
+    const key = try uniqueKey(&key_buf);
+    var b: [256]u8 = undefined;
+    // windowId 지정(id!=0)이지만 저장값 없음 → restored:false (window API 호출 전 early return).
+    const r = invokePlugin(&reg, try std.fmt.bufPrint(&b, "{{\"cmd\":\"window-state:restore\",\"key\":\"{s}\",\"windowId\":1}}", .{key}));
+    defer freeResp(&reg, r);
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"restored\":false") != null);
+}
+
+test "window-state plugin: out-of-range windowId → graceful (no @intCast panic)" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadWs(&reg);
+
+    // u32 범위 밖 windowId — resolveWindowId 가 cast 실패 시 0 으로(패닉 X) → "no window".
+    const r = invokePlugin(&reg, "{\"cmd\":\"window-state:save\",\"key\":\"x\",\"windowId\":99999999999}");
+    defer freeResp(&reg, r);
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "no window") != null);
+}
+
+test "window-state plugin: invalid key rejected (path traversal)" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadWs(&reg);
+
+    const bad = [_][]const u8{
+        "{\"cmd\":\"window-state:get\",\"key\":\"../evil\"}",
+        "{\"cmd\":\"window-state:get\",\"key\":\"..\"}",
+        "{\"cmd\":\"window-state:get\",\"key\":\".\"}",
+        "{\"cmd\":\"window-state:get\",\"key\":\"\"}",
+        "{\"cmd\":\"window-state:get\",\"key\":\"foo/bar\"}",
+        "{\"cmd\":\"window-state:clear\",\"key\":\"foo bar\"}",
+    };
+    for (bad) |req| {
+        const r = invokePlugin(&reg, req);
+        defer freeResp(&reg, r);
+        try std.testing.expect(r != null);
+        try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\"") != null);
+    }
+}


### PR DESCRIPTION
## 배경

\"부족한 플러그인 + 로우건\" 질문의 1순위 결과물. Tauri/Electron 대비 빠진 플러그인 중 **새 네이티브 코드 0**으로 만들 수 있는 가장 흔한 데스크톱 요구(창 위치/크기/최대화 복원)를 구현한다. 코어 백엔드 `windows` SDK 조합 + 파일 영속(`store` 의 atomic-write 패턴 재사용).

## 구성 (기존 8개 플러그인의 zig/js/node 3-wrapper 패턴 동형)

- **`plugins/window-state/zig/app.zig`** — 채널 `save`/`restore`/`get`/`clear`. 호출 창(또는 `windowId`)의 `getBounds`+`isMaximized` 를 읽어 `<appdata>/suji-app/window-state/<key>.json` 에 **per-key atomic** 저장. `restore` 는 `setBounds` + (maximized 면) `maximize`.
- **`@suji/plugin-window-state`** (renderer) + **`@suji/plugin-window-state-node`** (백엔드). 호출 창은 코어가 `__window` 자동 주입 → 렌더러는 `windowId` 생략. Node 는 창 컨텍스트가 없어 명시.
- **코어 백엔드 `windows` SDK 패리티**: `getBounds`/`maximize`/`isMaximized` 추가 — 프론트/Rust/Go 엔 있던 reader 가 zig 백엔드엔 `setBounds` 만 있던 갭. `windowIdCmd` 한 줄 래퍼.

```ts
import { windowState } from '@suji/plugin-window-state';
await windowState.restoreState();                      // 시작 시 복원
suji.on('app:before-quit', () => windowState.saveState()); // 종료 직전 저장
```

## 검증 (3 레이어)

- `zig build test-window-state` — CEF-free 표면 **8 테스트**(load/get/clear/validate/graceful no-window/out-of-range windowId 가드).
- `bun test plugins/window-state/{js,node}/src` — wire-contract **14**.
- `bash tests/e2e/run-plugin-window-state.sh` — **실 CEF 창 라운드트립 4**(save 가 라이브 bounds 읽기 → file → get/restore/clear). multi-backend 예제에 window-state 활성.
- `zig build test`(790) + 전체 wrapper 스위트(190) 무회귀.

## /simplify

`jsonInt/jsonBool` → `util.extractJsonInt/Bool` 재사용, `payload()` 단일 인자화, 미사용 코어 reader(`unmaximize/minimize/isMinimized`) 제거.

## code-review max (9-angle)

- **`@intCast` 패닉 2건** — 손상/변조 state 파일의 범위 밖 좌표, 범위 밖 `windowId` → `std.math.cast` 로 graceful error(패닉 X). 회귀 테스트 추가.
- 자동 파생 key(창 name 공백/슬래시 등)가 `validKey` 실패 시 `"main"` 폴백(명시 key 는 에러 유지).
- `restore` 가 maximized 여도 `setBounds` 를 먼저 적용(unmaximize 복귀 bounds 보존).

## 정직 경계

- move/resize 이벤트가 코어에 없어 `saveState` 명시 호출 필요(`app:before-quit`/`window:close`) — Tauri 도 디바운스 차이뿐.
- 코어에 `getNormalBounds` 부재 → maximized 창의 pre-maximize bounds 는 캡처 불가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)