### PR TITLE
feat(plugin): positioner — 창을 화면/트레이/커서 위치로 배치

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ zig build test-http     # http 플러그인 (renderer-safe fetch with URL allowl
 zig build test-os-autostart # os-info + autostart 플러그인 (시스템 정보 / 로그인 자동실행)
 zig build test-notification-rich # notification-rich 플러그인 (WinRT/UNUserNotificationCenter/Freedesktop actions)
 zig build test-window-state # window-state 플러그인 (창 bounds/maximized 저장·복원; CEF-free 표면 — file/validate/graceful no-window)
+zig build test-positioner # positioner 플러그인 (창을 화면/트레이/커서 위치로 배치; CEF-free 표면 — graceful no-window/missing-position)
 
 # 임베드 코어 라이브러리 (CEF 무관 — 모바일/임베드용)
 zig build lib                                  # libsuji_core.a (host)
@@ -71,9 +72,10 @@ bash tests/e2e/run-gpu-accel.sh         # GPU 가속 회귀 가드 (#12) — Web
 bash tests/e2e/run-releasesafe-renderer-boot.sh # #60 part2 회귀 가드 — ReleaseSafe 빌드해 렌더러 V8 부트스트랩(window.__suji__ 바인딩) 검증(Windows CI). 디버깅: SUJI_CEF_DEBUG=1
 bash tests/e2e/run-set-user-agent.sh    # set_user_agent CDP override 실효(navigator.userAgent)
 bash tests/e2e/run-context-isolation.sh # window.__suji__ frozen/슬롯봉인/변조차단/기능보존
-bash tests/e2e/run-plugin-wrappers.sh   # 공식 플러그인 (state/sqlite/log/store/http/notification-rich/window-state) × {JS, Node} wrapper wire-contract (mock bridge)
+bash tests/e2e/run-plugin-wrappers.sh   # 공식 플러그인 (state/sqlite/log/store/http/notification-rich/window-state/positioner) × {JS, Node} wrapper wire-contract (mock bridge)
 bash tests/e2e/run-plugin-state-integration.sh # state plugin DLL 라운드트립(__suji__ → DLL → 응답)
 bash tests/e2e/run-plugin-window-state.sh # window-state plugin 실 CEF 창 라운드트립(save 가 라이브 bounds 읽기 → file → get/restore/clear)
+bash tests/e2e/run-plugin-positioner.sh # positioner plugin 실 CEF 창 지오메트리(move 좌표 단조성 top-left<bottom-right, center 사이, at-cursor)
 bash tests/e2e/run-lua-e2e.sh           # Lua 백엔드 (vendored Lua 5.4 + cjson) invoke 왕복/cjson roundtrip/50 concurrent (-Dlua 자동 빌드)
 bash tests/e2e/run-python-e2e.sh        # Python 백엔드 (embedded CPython 3.13 + GIL) invoke 왕복/json roundtrip/50 concurrent/send·on (scripts/stage-python.sh 자동 staging)
 

--- a/build.zig
+++ b/build.zig
@@ -1168,6 +1168,28 @@ pub fn build(b: *std.Build) void {
     const window_state_test_step = b.step("test-window-state", "Run window-state plugin tests (requires built dylib)");
     window_state_test_step.dependOn(&window_state_test_run.step);
 
+    const positioner_test_mod = b.createModule(.{
+        .root_source_file = b.path("tests/positioner_plugin_test.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    const positioner_loader = b.createModule(.{
+        .root_source_file = b.path("src/backends/loader.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    positioner_loader.addImport("events", events_module);
+    positioner_loader.addImport("runtime", runtime_module);
+    positioner_loader.addImport("util", util_module);
+    positioner_test_mod.addImport("loader", positioner_loader);
+    positioner_test_mod.addImport("events", events_module);
+    const positioner_test = b.addTest(.{ .root_module = positioner_test_mod });
+    const positioner_test_run = b.addRunArtifact(positioner_test);
+    positioner_test_run.setCwd(b.path("."));
+    const positioner_test_step = b.step("test-positioner", "Run positioner plugin tests (requires built dylib)");
+    positioner_test_step.dependOn(&positioner_test_run.step);
+
     // HTTP plugin tests (log/state/sqlite/store 와 동형)
     const http_test_mod = b.createModule(.{
         .root_source_file = b.path("tests/http_plugin_test.zig"),

--- a/documents/index.mdx
+++ b/documents/index.mdx
@@ -42,6 +42,8 @@ npm run dev
 | Electron 마이그레이션 | [`electron-migration.mdx`](./electron-migration.mdx) |
 | IPC 와이어 포맷 + `__core__` cmd 표 | [`ipc-wire.mdx`](./ipc-wire.mdx) |
 | state 플러그인 | [`plugin-state.mdx`](./plugin-state.mdx) |
+| window-state 플러그인 | [`plugin-window-state.mdx`](./plugin-window-state.mdx) |
+| positioner 플러그인 | [`plugin-positioner.mdx`](./plugin-positioner.mdx) |
 | 신규 언어 SDK 포팅 가이드 | [`../docs/SDK_PORTING.md`](../docs/SDK_PORTING.md) |
 
 ## 설계 원칙

--- a/documents/plugin-positioner.mdx
+++ b/documents/plugin-positioner.mdx
@@ -1,0 +1,65 @@
+---
+title: positioner 플러그인
+description: 창을 화면/트레이/커서 기준 위치로 배치 (Tauri positioner 동등)
+---
+
+# positioner 플러그인
+
+창을 한 줄로 화면 모서리/중앙, 커서, 트레이 아이콘 아래로 배치한다. 코어 `screen.getAllDisplays`
++ `windows.getBounds/setBounds` (+ `tray.getBounds`/`screen.getCursorScreenPoint`) 조합이라
+**새 네이티브 코드 0**.
+
+## 설치
+
+```json
+{
+  "plugins": ["positioner"]
+}
+```
+
+## 사용 (`@suji/plugin-positioner`)
+
+```ts
+import { positioner } from '@suji/plugin-positioner';
+
+await positioner.move('center');               // 현재 디스플레이 work area 중앙
+await positioner.move('bottom-right');         // 우하단
+await positioner.move('top-center');           // 상단 중앙
+await positioner.move('at-cursor');            // 커서 위치 (창 좌상단)
+await positioner.move('tray-center', { trayId }); // 트레이 아이콘 아래 (menu-bar 앱)
+
+const { x, y } = await positioner.move('center'); // 적용된 좌상단 좌표
+```
+
+호출 창은 코어가 `__window` 를 자동 주입하므로 `windowId` 생략 가능. Node 백엔드
+(`@suji/plugin-positioner-node`)는 창 컨텍스트가 없어 `{ windowId }` 명시 필요.
+
+## position 목록
+
+| 종류 | 값 |
+|---|---|
+| 화면 상대(work area 내) | `center`, `top-left`, `top-right`, `bottom-left`, `bottom-right`, `top-center`, `bottom-center`, `left-center`, `right-center` |
+| 커서 | `at-cursor` |
+| 트레이(`trayId` 필요) | `tray-center` |
+
+모든 위치는 창이 화면 밖으로 나가지 않도록 work area 로 **clamp** 된다.
+
+## 동작 / 좌표계
+
+- 창이 **현재 위치한 디스플레이**의 work area(메뉴바/Dock/taskbar 제외) 안에서 계산한다.
+  multi-display 는 primary 디스플레이 높이 기준 전역 변환으로 정확히 처리.
+- 코어 `screen`/`tray`/`cursor` rect 는 macOS NSScreen **bottom-up** 좌표, 창 bounds 는
+  CEF **top-left** 좌표라, macOS 는 primary 높이로 y-flip 후 계산한다(Win/Linux 는 둘 다
+  top-left 라 flip 없음).
+
+## 정직 경계
+
+- **tray-center 는 macOS 전용** — `tray.getBounds` 가 Win/Linux 에서 0-rect 라
+  `tray bounds unavailable` 에러를 반환한다(잘못된 코너 배치 대신 명시적 실패 →
+  caller 가 화면 상대 위치로 폴백 가능). 화면 상대 위치 + at-cursor 는 전 플랫폼 동작.
+- **multi-display 정확** — at-cursor 는 커서가 있는 디스플레이, tray-center 는 트레이가
+  있는 디스플레이, 화면 위치는 창이 있는 디스플레이의 work area 로 각각 clamp 한다.
+- 잘못된 position 문자열은 `unknown position` 에러. 창 컨텍스트 없음(`windowId` 0)은
+  `no window`. 범위 밖 `windowId`/좌표는 패닉 대신 에러(`std.math.cast`).
+- 단위 테스트는 screen/window API 가 없어 graceful 표면만 커버 — 실 좌표 단조성
+  (top-left < bottom-right, center 사이)은 `bash tests/e2e/run-plugin-positioner.sh`(실 CEF 창)가 검증.

--- a/documents/plugins.mdx
+++ b/documents/plugins.mdx
@@ -16,7 +16,7 @@ JS)에서 일관되게 호출하기 위한 구조. OS native API (clipboard/fs/d
 | 위치 | `src/platform/cef.zig` (코어) | `plugins/<name>/` (외부 디렉토리) |
 | 빌드 | suji 코어와 함께 | 별도 dylib (또는 source 포함) |
 | 5 SDK 노출 | ✅ 자동 (suji core가 책임) | ✅ wrapper 직접 작성 |
-| 예시 | clipboard, fs, dialog, tray, menu, notification, globalShortcut | `state`, `sqlite`, `log`, `store`, `http`, `notification-rich`, `window-state`, 사용자 DB / 인증 / telemetry 등 |
+| 예시 | clipboard, fs, dialog, tray, menu, notification, globalShortcut | `state`, `sqlite`, `log`, `store`, `http`, `notification-rich`, `window-state`, `positioner`, 사용자 DB / 인증 / telemetry 등 |
 | Mac App Sandbox 호환 | ✅ (entitlements + 코어 binary) | 🟡 dylib + entitlements 분리 작업 필요 |
 
 OS native API를 plugin으로 만들지 못하는 이유:

--- a/examples/multi-backend/suji.json
+++ b/examples/multi-backend/suji.json
@@ -14,7 +14,7 @@
       "protocol": "suji"
     }
   ],
-  "plugins": ["state", "window-state"],
+  "plugins": ["state", "window-state", "positioner"],
   "backends": [
     { "name": "zig", "lang": "zig", "entry": "backends/zig" },
     { "name": "rust", "lang": "rust", "entry": "backends/rust" },

--- a/plugins/positioner/js/package.json
+++ b/plugins/positioner/js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@suji/plugin-positioner",
+  "version": "0.1.0",
+  "description": "Suji Positioner Plugin - place window at screen/tray/cursor positions for Renderer",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/plugins/positioner/js/src/index.test.ts
+++ b/plugins/positioner/js/src/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockBridge = {
+  invoke: mock(() => Promise.resolve({})),
+};
+
+(globalThis as any).window = { __suji__: mockBridge };
+
+const { positioner } = await import("./index");
+
+beforeEach(() => {
+  mockBridge.invoke.mockClear();
+});
+
+describe("positioner.move wire", () => {
+  it("position only", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true, x: 10, y: 20 } });
+    const r = await positioner.move("center");
+    expect(mockBridge.invoke).toHaveBeenCalledWith("positioner:move", { position: "center" });
+    expect(r).toEqual({ x: 10, y: 20 });
+  });
+
+  it("passes windowId + trayId through", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true, x: 0, y: 0 } });
+    await positioner.move("tray-center", { windowId: 2, trayId: 5 });
+    expect(mockBridge.invoke).toHaveBeenCalledWith("positioner:move", {
+      position: "tray-center",
+      windowId: 2,
+      trayId: 5,
+    });
+  });
+
+  it("omits undefined opts", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true, x: 1, y: 2 } });
+    await positioner.move("at-cursor", { windowId: 3 });
+    expect(mockBridge.invoke).toHaveBeenCalledWith("positioner:move", { position: "at-cursor", windowId: 3 });
+  });
+
+  it("returns {0,0} when coords missing", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true } });
+    expect(await positioner.move("center")).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("error propagation", () => {
+  it("throws on bridge error", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ error: "unknown position" });
+    await expect(positioner.move("center")).rejects.toThrow("positioner: unknown position");
+  });
+});

--- a/plugins/positioner/js/src/index.ts
+++ b/plugins/positioner/js/src/index.ts
@@ -1,0 +1,65 @@
+/**
+ * @suji/plugin-positioner — 창을 화면/트레이/커서 기준 위치로 배치 (Tauri positioner 동등).
+ *
+ * 코어 screen/windows/tray API 조합 — 호출 창의 work area(현재 창이 있는 디스플레이)
+ * 안에서 위치를 계산해 setBounds. 호출 창은 코어가 `__window` 자동 주입.
+ *
+ * ```ts
+ * import { positioner } from '@suji/plugin-positioner';
+ *
+ * await positioner.move('center');            // 현재 디스플레이 work area 중앙
+ * await positioner.move('bottom-right');      // 우하단
+ * await positioner.move('at-cursor');         // 커서 위치
+ * await positioner.move('tray-center', { trayId }); // 트레이 아이콘 아래 (menu-bar 앱)
+ * ```
+ *
+ * ⚠️ tray-center / at-cursor 의 tray/cursor 좌표는 macOS 기준이 가장 정확하다
+ *   (tray.getBounds 는 macOS only). multi-display 는 primary 높이 기준 전역 변환으로 정확.
+ */
+
+interface SujiBridge {
+  invoke(channel: string, data?: Record<string, unknown>): Promise<any>;
+}
+
+function getBridge(): SujiBridge {
+  const bridge = (window as any).__suji__;
+  if (!bridge) throw new Error("Suji bridge not available.");
+  return bridge;
+}
+
+async function call(channel: string, data: Record<string, unknown>): Promise<any> {
+  const resp = await getBridge().invoke(channel, data);
+  if (resp?.error) throw new Error(`positioner: ${resp.error}`);
+  return resp?.result ?? resp;
+}
+
+export type Position =
+  | "center"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+  | "top-center"
+  | "bottom-center"
+  | "left-center"
+  | "right-center"
+  | "at-cursor"
+  | "tray-center";
+
+export interface MoveOptions {
+  /** 대상 창 id. 생략 시 호출 창(렌더러). Node 백엔드는 창이 없어 명시 필요. */
+  windowId?: number;
+  /** tray-center 위치에 필요한 트레이 id (suji.tray.create 반환값). */
+  trayId?: number;
+}
+
+export const positioner = {
+  /** 창을 position 으로 이동. 적용된 좌상단 좌표 {x, y} 반환. */
+  async move(position: Position, opts?: MoveOptions): Promise<{ x: number; y: number }> {
+    const data: Record<string, unknown> = { position };
+    if (opts?.windowId !== undefined) data.windowId = opts.windowId;
+    if (opts?.trayId !== undefined) data.trayId = opts.trayId;
+    const r = await call("positioner:move", data);
+    return { x: Number(r?.x ?? 0), y: Number(r?.y ?? 0) };
+  },
+};

--- a/plugins/positioner/js/tsconfig.json
+++ b/plugins/positioner/js/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/plugins/positioner/node/package.json
+++ b/plugins/positioner/node/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@suji/plugin-positioner-node",
+  "version": "0.1.0",
+  "description": "Suji Positioner Plugin - place window at screen/tray/cursor positions for Node.js backends",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/plugins/positioner/node/src/index.test.ts
+++ b/plugins/positioner/node/src/index.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockBridge = {
+  invoke: mock(() => Promise.resolve('{"result":{}}')),
+};
+
+(globalThis as any).suji = mockBridge;
+
+const { positioner } = await import("./index");
+
+beforeEach(() => {
+  mockBridge.invoke.mockClear();
+});
+
+function lastCall(): { backend: string; payload: Record<string, unknown> } {
+  const args = mockBridge.invoke.mock.calls.at(-1)!;
+  return { backend: args[0] as string, payload: JSON.parse(args[1] as string) };
+}
+
+describe("positioner Node — routing + wire", () => {
+  it("move routes to 'positioner' backend with cmd", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true,"x":5,"y":7}}');
+    const r = await positioner.move("center", { windowId: 1 });
+    const { backend, payload } = lastCall();
+    expect(backend).toBe("positioner");
+    expect(payload).toEqual({ cmd: "positioner:move", position: "center", windowId: 1 });
+    expect(r).toEqual({ x: 5, y: 7 });
+  });
+
+  it("tray-center passes trayId", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true,"x":0,"y":0}}');
+    await positioner.move("tray-center", { windowId: 2, trayId: 9 });
+    expect(lastCall().payload).toEqual({ cmd: "positioner:move", position: "tray-center", windowId: 2, trayId: 9 });
+  });
+
+  it("omits undefined opts", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true,"x":1,"y":1}}');
+    await positioner.move("bottom-right");
+    expect(lastCall().payload).toEqual({ cmd: "positioner:move", position: "bottom-right" });
+  });
+});
+
+describe("error propagation", () => {
+  it("throws on bridge error", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"error":"no window"}');
+    await expect(positioner.move("center", { windowId: 1 })).rejects.toThrow("positioner: no window");
+  });
+});

--- a/plugins/positioner/node/src/index.ts
+++ b/plugins/positioner/node/src/index.ts
@@ -1,0 +1,67 @@
+/**
+ * @suji/plugin-positioner-node — 창 위치 배치 for Suji Node backends.
+ * Wire contract 은 renderer `@suji/plugin-positioner` 와 동일.
+ *
+ * ⚠️ Node 백엔드는 창 컨텍스트가 없으므로 `windowId` 를 명시해야 한다.
+ *
+ * ```ts
+ * const { positioner } = require('@suji/plugin-positioner-node');
+ * await positioner.move('center', { windowId: 1 });
+ * ```
+ */
+
+interface SujiBridge {
+  invoke(backend: string, request: string): Promise<string>;
+}
+
+function getBridge(): SujiBridge {
+  const bridge = (globalThis as any).suji as SujiBridge | undefined;
+  if (!bridge) {
+    throw new Error(
+      "@suji/plugin-positioner-node: bridge not available. This module must run inside a Suji app (libnode embedding).",
+    );
+  }
+  return bridge;
+}
+
+async function call(cmd: string, payload: Record<string, unknown>): Promise<any> {
+  const raw = await getBridge().invoke("positioner", JSON.stringify({ cmd, ...payload }));
+  let resp: any;
+  try {
+    resp = JSON.parse(raw);
+  } catch {
+    resp = {};
+  }
+  if (resp?.error) throw new Error(`positioner: ${resp.error}`);
+  return resp?.result;
+}
+
+export type Position =
+  | "center"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+  | "top-center"
+  | "bottom-center"
+  | "left-center"
+  | "right-center"
+  | "at-cursor"
+  | "tray-center";
+
+export interface MoveOptions {
+  /** 대상 창 id. Node 백엔드는 창 컨텍스트가 없어 명시 필요. */
+  windowId?: number;
+  /** tray-center 위치에 필요한 트레이 id. */
+  trayId?: number;
+}
+
+export const positioner = {
+  async move(position: Position, opts?: MoveOptions): Promise<{ x: number; y: number }> {
+    const payload: Record<string, unknown> = { position };
+    if (opts?.windowId !== undefined) payload.windowId = opts.windowId;
+    if (opts?.trayId !== undefined) payload.trayId = opts.trayId;
+    const r = await call("positioner:move", payload);
+    return { x: Number(r?.x ?? 0), y: Number(r?.y ?? 0) };
+  },
+};

--- a/plugins/positioner/node/tsconfig.json
+++ b/plugins/positioner/node/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/plugins/positioner/suji-plugin.json
+++ b/plugins/positioner/suji-plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "positioner",
+  "lang": "zig"
+}

--- a/plugins/positioner/zig/app.zig
+++ b/plugins/positioner/zig/app.zig
@@ -1,0 +1,243 @@
+//! @suji/plugin-positioner — 창을 화면/트레이/커서 기준 위치로 배치 (Tauri positioner 동등).
+//!
+//! 새 네이티브 0 — 코어 screen.getAllDisplays / windows.getBounds+setBounds /
+//! tray.getBounds / screen.getCursorScreenPoint 조합.
+//!
+//! 채널:
+//!   positioner:move {position, windowId?, trayId?} → {ok:true, x, y}
+//!
+//! position:
+//!   화면 상대(work area 내): center, top-left, top-right, bottom-left, bottom-right,
+//!                            top-center, bottom-center, left-center, right-center
+//!   커서: at-cursor (창 좌상단을 커서 위치에, work area 로 clamp)
+//!   트레이(trayId 필요): tray-center (트레이 아이콘 아래 가로 중앙)
+//!
+//! ⚠️ 좌표계: 코어 screen 의 Display/cursor/tray rect 는 macOS NSScreen **bottom-up**,
+//!   창 bounds 는 CEF **top-left**. macOS 는 primary 높이로 y-flip(top-left 전환),
+//!   Win/Linux 는 이미 top-left 라 flip 없음. multi-display 는 primary 높이 기준 전역
+//!   변환이라 정확. tray/cursor 는 macOS 한정(tray.getBounds Win/Linux 0 rect).
+
+const std = @import("std");
+const suji = @import("suji");
+const util = @import("util");
+
+pub const app = suji.app()
+    .named("positioner")
+    .handle("positioner:move", positionerMove);
+
+// ============================================
+// 헬퍼
+// ============================================
+
+/// 코어 응답을 arena 로 복사 — 코어 호출은 threadlocal scratch 를 공유하므로 다음
+/// 호출 전에 owned 복사 필수(clobber 방지).
+fn dupeCore(arena: std.mem.Allocator, resp: ?[]const u8) ?[]const u8 {
+    const r = resp orelse return null;
+    return arena.dupe(u8, r) catch null;
+}
+
+/// windowId 명시 우선, 없으면 호출 창. cast 실패 시 0(패닉 방지) — window-state 동형.
+fn resolveWindowId(req: suji.Request, ev: suji.InvokeEvent) u32 {
+    if (req.int("windowId")) |wid| {
+        if (wid <= 0) return 0;
+        return std.math.cast(u32, wid) orelse 0;
+    }
+    return ev.window.id;
+}
+
+/// displays 배열에서 top-level `{...}` 객체를 순회. display JSON 값은 전부 number/bool
+/// (문자열 값 없음) 이라 단순 brace-depth 로 안전.
+fn nextObject(arr: []const u8, idx: *usize) ?[]const u8 {
+    var i = idx.*;
+    while (i < arr.len and arr[i] != '{') i += 1;
+    if (i >= arr.len) return null;
+    const start = i;
+    var depth: i32 = 0;
+    while (i < arr.len) : (i += 1) {
+        if (arr[i] == '{') {
+            depth += 1;
+        } else if (arr[i] == '}') {
+            depth -= 1;
+            if (depth == 0) {
+                idx.* = i + 1;
+                return arr[start .. i + 1];
+            }
+        }
+    }
+    return null;
+}
+
+const WorkArea = struct { x: i64, y: i64, w: i64, h: i64 };
+
+/// bottom-up y(높이 h 인 rect)를 top-left 로. macOS 만 flip, 그 외 그대로.
+/// 전역 primary 높이 기준 변환(macOS/Chromium 관례: 전역 원점=primary 좌하단)이라
+/// 모든 display 에 단일 primary_h 로 정확.
+/// NOTE(altitude): 좌표 변환이 코어 screen API 가 아닌 플러그인에 있다 — 코어가 raw
+/// bottom-up 만 노출(cef_screen "caller 가 필요 시 변환")하기 때문. 두 번째 지오메트리
+/// 플러그인이 생기면 코어 screen 에 top-left/work-area 헬퍼를 추가해 단일 출처로 옮길 것.
+fn toTopLeftY(bu_y: i64, h: i64, primary_h: i64, is_macos: bool) i64 {
+    return if (is_macos) primary_h - (bu_y + h) else bu_y;
+}
+
+/// primary 프레임 높이(전역 bottom-up→top-left flip 기준). primary 부재 시 첫 display.
+fn getPrimaryHeight(dj: []const u8) i64 {
+    const arr = util.extractJsonArrayRaw(dj, "displays") orelse return 0;
+    var primary_h: i64 = 0;
+    var first_h: i64 = 0;
+    var got_first = false;
+    var idx: usize = 0;
+    while (nextObject(arr, &idx)) |obj| {
+        const fh = util.extractJsonInt(obj, "height") orelse continue;
+        if (!got_first) {
+            first_h = fh;
+            got_first = true;
+        }
+        if (util.extractJsonBool(obj, "isPrimary") orelse false) primary_h = fh;
+    }
+    return if (primary_h != 0) primary_h else first_h;
+}
+
+/// (px, py) top-left 점을 포함하는 display 의 work area(top-left)를 해석.
+/// 우선순위: 포함 display > primary > 첫 display. 못 찾으면 false.
+/// ⚠️ 점(px,py)은 **배치 대상** 기준 — screen 위치는 창 중심, at-cursor 는 커서,
+///    tray 는 트레이 중심을 넘겨 "그 점이 있는 디스플레이"의 work area 로 clamp 한다.
+fn selectWorkArea(dj: []const u8, px: i64, py: i64, primary_h: i64, is_macos: bool, out: *WorkArea) bool {
+    const arr = util.extractJsonArrayRaw(dj, "displays") orelse return false;
+    var best_rank: i32 = 0;
+    var idx: usize = 0;
+    while (nextObject(arr, &idx)) |obj| {
+        const fx = util.extractJsonInt(obj, "x") orelse continue;
+        const fy = util.extractJsonInt(obj, "y") orelse continue;
+        const fw = util.extractJsonInt(obj, "width") orelse continue;
+        const fh = util.extractJsonInt(obj, "height") orelse continue;
+        const vx = util.extractJsonInt(obj, "visibleX") orelse continue;
+        const vy = util.extractJsonInt(obj, "visibleY") orelse continue;
+        const vw = util.extractJsonInt(obj, "visibleWidth") orelse continue;
+        const vh = util.extractJsonInt(obj, "visibleHeight") orelse continue;
+        const is_primary = util.extractJsonBool(obj, "isPrimary") orelse false;
+
+        const ftl_y = toTopLeftY(fy, fh, primary_h, is_macos);
+        const contains = px >= fx and px < fx + fw and py >= ftl_y and py < ftl_y + fh;
+
+        var rank: i32 = 1;
+        if (is_primary) rank = 2;
+        if (contains) rank = 3;
+        if (rank > best_rank) {
+            out.* = .{ .x = vx, .y = toTopLeftY(vy, vh, primary_h, is_macos), .w = vw, .h = vh };
+            best_rank = rank;
+        }
+    }
+    return best_rank > 0;
+}
+
+fn clampI64(v: i64, lo: i64, hi: i64) i64 {
+    if (hi < lo) return lo; // 창이 work area 보다 큰 경우 — 좌상단 우선.
+    return std.math.clamp(v, lo, hi);
+}
+
+/// 화면 상대 position → 창 좌상단 (tx, ty). 알 수 없는 position 이면 false.
+/// 각 position 은 x∈{left,center,right} × y∈{top,middle,bottom} 의 조합 → 테이블 dispatch.
+fn screenPosition(pos: []const u8, wa: WorkArea, win_w: i64, win_h: i64, tx: *i64, ty: *i64) bool {
+    const xs = [3]i64{ wa.x, wa.x + @divTrunc(wa.w - win_w, 2), wa.x + wa.w - win_w }; // left, center, right
+    const ys = [3]i64{ wa.y, wa.y + @divTrunc(wa.h - win_h, 2), wa.y + wa.h - win_h }; // top, middle, bottom
+    const Entry = struct { name: []const u8, xi: usize, yi: usize };
+    const table = [_]Entry{
+        .{ .name = "center", .xi = 1, .yi = 1 },
+        .{ .name = "top-left", .xi = 0, .yi = 0 },
+        .{ .name = "top-right", .xi = 2, .yi = 0 },
+        .{ .name = "bottom-left", .xi = 0, .yi = 2 },
+        .{ .name = "bottom-right", .xi = 2, .yi = 2 },
+        .{ .name = "top-center", .xi = 1, .yi = 0 },
+        .{ .name = "bottom-center", .xi = 1, .yi = 2 },
+        .{ .name = "left-center", .xi = 0, .yi = 1 },
+        .{ .name = "right-center", .xi = 2, .yi = 1 },
+    };
+    for (table) |e| {
+        if (std.mem.eql(u8, pos, e.name)) {
+            tx.* = xs[e.xi];
+            ty.* = ys[e.yi];
+            return true;
+        }
+    }
+    return false;
+}
+
+// ============================================
+// 핸들러
+// ============================================
+
+fn positionerMove(req: suji.Request, ev: suji.InvokeEvent) suji.Response {
+    const id = resolveWindowId(req, ev);
+    if (id == 0) return req.err("no window");
+    const pos = req.string("position") orelse return req.err("missing position");
+
+    const wb = dupeCore(req.arena, suji.windows.getBounds(id)) orelse return req.err("get_bounds failed");
+    if (!(util.extractJsonBool(wb, "ok") orelse false)) return req.err("get_bounds not ok");
+    const win_x = util.extractJsonInt(wb, "x") orelse return req.err("bad bounds");
+    const win_y = util.extractJsonInt(wb, "y") orelse return req.err("bad bounds");
+    const win_w = util.extractJsonInt(wb, "width") orelse return req.err("bad bounds");
+    const win_h = util.extractJsonInt(wb, "height") orelse return req.err("bad bounds");
+
+    const is_macos = std.mem.eql(u8, suji.platform(), "macos");
+
+    const dj = dupeCore(req.arena, suji.screen.getAllDisplays()) orelse return req.err("get_displays failed");
+    const primary_h = getPrimaryHeight(dj);
+
+    // 배치 대상 좌표(tx,ty)와 work-area 선택 기준점(anchor)을 position 종류별로 계산.
+    // ⚠️ 좌표계: displays/cursor 는 코어가 bottom-up 으로 반환(→ flip), tray 는 코어가
+    //   이미 top-left 로 변환(cef_tray) 하므로 **flip 하지 않는다**(비대칭 주의).
+    var tx: i64 = 0;
+    var ty: i64 = 0;
+    var anchor_x: i64 = win_x + @divTrunc(win_w, 2);
+    var anchor_y: i64 = win_y + @divTrunc(win_h, 2);
+    var is_screen_pos = false;
+    if (std.mem.eql(u8, pos, "at-cursor")) {
+        const cj = dupeCore(req.arena, suji.screen.getCursorScreenPoint()) orelse return req.err("cursor failed");
+        const cx = util.extractJsonInt(cj, "x") orelse return req.err("bad cursor");
+        const cy = util.extractJsonInt(cj, "y") orelse return req.err("bad cursor");
+        tx = cx;
+        ty = if (is_macos) primary_h - cy else cy; // 커서는 bottom-up point → 단순 반전.
+        anchor_x = tx; // 커서가 있는 디스플레이의 work area 로 clamp.
+        anchor_y = ty;
+    } else if (std.mem.eql(u8, pos, "tray-center")) {
+        const tray_id = req.int("trayId") orelse return req.err("missing trayId");
+        if (tray_id < 0) return req.err("bad trayId");
+        const tj = dupeCore(req.arena, suji.tray.getBounds(std.math.cast(u32, tray_id) orelse return req.err("bad trayId"))) orelse return req.err("tray failed");
+        const trx = util.extractJsonInt(tj, "x") orelse return req.err("bad tray");
+        const trycoord = util.extractJsonInt(tj, "y") orelse return req.err("bad tray");
+        const trw = util.extractJsonInt(tj, "width") orelse return req.err("bad tray");
+        const trh = util.extractJsonInt(tj, "height") orelse return req.err("bad tray");
+        if (trw == 0 and trh == 0) return req.err("tray bounds unavailable"); // Win/Linux 0-rect 등.
+        // tray.getBounds 는 이미 top-left(cef_tray 변환) — flip 금지. 아이콘 바로 아래, 가로 중앙.
+        tx = trx + @divTrunc(trw - win_w, 2);
+        ty = trycoord + trh;
+        anchor_x = trx + @divTrunc(trw, 2); // 트레이가 있는 디스플레이의 work area 로 clamp.
+        anchor_y = trycoord;
+    } else {
+        is_screen_pos = true; // 화면 위치는 work area 가 필요 — 아래에서 계산.
+    }
+
+    var wa: WorkArea = undefined;
+    if (!selectWorkArea(dj, anchor_x, anchor_y, primary_h, is_macos, &wa)) return req.err("no display");
+
+    if (is_screen_pos) {
+        if (!screenPosition(pos, wa, win_w, win_h, &tx, &ty)) return req.err("unknown position");
+    }
+
+    // work area 안으로 clamp (창이 화면 밖으로 나가지 않도록).
+    tx = clampI64(tx, wa.x, wa.x + wa.w - win_w);
+    ty = clampI64(ty, wa.y, wa.y + wa.h - win_h);
+
+    const xi = std.math.cast(i32, tx) orelse return req.err("coord overflow");
+    const yi = std.math.cast(i32, ty) orelse return req.err("coord overflow");
+    const wi = std.math.cast(u32, win_w) orelse return req.err("coord overflow");
+    const hi = std.math.cast(u32, win_h) orelse return req.err("coord overflow");
+    _ = suji.windows.setBounds(id, .{ .x = xi, .y = yi, .width = wi, .height = hi });
+
+    const body = std.fmt.allocPrint(req.arena, "{{\"ok\":true,\"x\":{d},\"y\":{d}}}", .{ tx, ty }) catch return req.err("alloc");
+    return req.okRaw(body);
+}
+
+comptime {
+    _ = suji.exportApp(app);
+}

--- a/plugins/positioner/zig/build.zig
+++ b/plugins/positioner/zig/build.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const util_mod = b.createModule(.{
+        .root_source_file = b.path("../../../src/core/util.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const suji_mod = b.createModule(.{
+        .root_source_file = b.path("../../../src/core/app.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    suji_mod.addImport("util", util_mod);
+
+    const lib = b.addLibrary(.{
+        .name = "backend",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("app.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+        .linkage = .dynamic,
+    });
+    lib.root_module.addImport("suji", suji_mod);
+    lib.root_module.addImport("util", util_mod);
+
+    b.installArtifact(lib);
+}

--- a/tests/e2e/plugin-positioner-integration.test.ts
+++ b/tests/e2e/plugin-positioner-integration.test.ts
@@ -1,0 +1,95 @@
+/**
+ * 공식 positioner 플러그인 통합 e2e (실 CEF 창 + 실 디스플레이 지오메트리).
+ *
+ * 검증 범위:
+ *   1. renderer 가 __suji__.invoke('positioner:move', {position}) → 플러그인이 실
+ *      getBounds + getAllDisplays 로 work area 를 구해 setBounds 까지 라운드트립
+ *   2. 좌표 단조성: top-left < bottom-right(x,y 모두), center 는 그 사이 — 지오메트리 정확
+ *   3. at-cursor / unknown position graceful
+ *
+ * Wrapper wire shape 은 `bun test plugins/positioner/{js,node}/src` 가 별도 검증.
+ * 단위 테스트는 screen/window API 가 없어 graceful-error 표면만 커버 — 실 좌표 계산은
+ * 이 파일이 유일하게 검증한다.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import puppeteer, { type Browser, type Page } from "puppeteer-core";
+import { getMainPage } from "./_page";
+
+let browser: Browser;
+let page: Page;
+
+const sujiInvoke = <T = any>(channel: string, payload?: unknown): Promise<T> =>
+  page.evaluate(
+    (r) => (window as unknown as { __suji__: { invoke: (ch: string, d?: unknown) => unknown } }).__suji__
+      .invoke(r.channel as string, r.payload as unknown),
+    { channel, payload },
+  ) as Promise<T>;
+
+const move = (position: string): Promise<{ result?: { ok?: boolean; x?: number; y?: number }; error?: string }> =>
+  sujiInvoke("positioner:move", { position });
+
+beforeAll(async () => {
+  browser = await puppeteer.connect({
+    browserURL: "http://localhost:9222",
+    protocolTimeout: 30000,
+    defaultViewport: null,
+  });
+  page = await getMainPage(browser);
+  page.setDefaultTimeout(15000);
+  await page.waitForFunction(() => typeof (window as any).__suji__ !== "undefined", { timeout: 10000 });
+  // 창을 work area 보다 확실히 작게 축소 — 그래야 모서리 위치들이 서로 구분돼 단조성이
+  // 성립한다(헤드리스/소형 가상 디스플레이에서 1024x768 창이 화면을 꽉 채워 모두 한
+  // 모서리로 clamp 되는 flake 방지). set_bounds 는 windowId 명시 필요 → getFocusedWindow.
+  const fw = await sujiInvoke<{ windowId?: number }>("get_focused_window");
+  const wid = fw?.windowId;
+  if (typeof wid === "number") {
+    await sujiInvoke("set_bounds", { windowId: wid, x: 80, y: 80, width: 520, height: 380 });
+  }
+});
+
+afterAll(async () => {
+  await browser?.disconnect();
+});
+
+describe("positioner plugin: live geometry", () => {
+  test("screen-relative positions are monotonic (top-left < bottom-right, center between)", async () => {
+    const tl = await move("top-left");
+    expect(tl?.error).toBeUndefined();
+    expect(tl?.result?.ok).toBe(true);
+
+    const br = await move("bottom-right");
+    expect(br?.result?.ok).toBe(true);
+
+    const c = await move("center");
+    expect(c?.result?.ok).toBe(true);
+
+    const tlx = tl!.result!.x!, tly = tl!.result!.y!;
+    const brx = br!.result!.x!, bry = br!.result!.y!;
+    const cx = c!.result!.x!, cy = c!.result!.y!;
+
+    // bottom-right 는 top-left 보다 우/하 (창이 work area 보다 작다는 전제 — 1024x768 창).
+    expect(brx).toBeGreaterThan(tlx);
+    expect(bry).toBeGreaterThan(tly);
+    // center 는 두 극단 사이.
+    expect(cx).toBeGreaterThanOrEqual(tlx);
+    expect(cx).toBeLessThanOrEqual(brx);
+    expect(cy).toBeGreaterThanOrEqual(tly);
+    expect(cy).toBeLessThanOrEqual(bry);
+  });
+
+  test("at-cursor returns coords (graceful)", async () => {
+    const r = await move("at-cursor");
+    expect(r?.error).toBeUndefined();
+    expect(r?.result?.ok).toBe(true);
+    expect(typeof r?.result?.x).toBe("number");
+    expect(typeof r?.result?.y).toBe("number");
+  });
+
+  test("unknown position → error", async () => {
+    const r = await move("nonsense-corner");
+    expect(r?.error ?? r?.result).toBeDefined();
+    // 에러 객체 또는 result.error 둘 중 하나로 거부.
+    const errStr = JSON.stringify(r);
+    expect(errStr).toContain("unknown position");
+  });
+});

--- a/tests/e2e/run-plugin-positioner.sh
+++ b/tests/e2e/run-plugin-positioner.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# positioner plugin 통합 e2e — multi-backend dev 를 띄워 renderer 가 실 CEF 창 +
+# 실 디스플레이 지오메트리로 positioner:move 라운드트립(좌표 단조성) 검증.
+#
+# 사전조건: plugins/positioner/zig 빌드(suji dev 가 dev 모드에서 자동 buildByLang
+#   하지만, 빌드 실패를 e2e 보다 먼저 정확히 진단하기 위해 명시적 pre-build).
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$ROOT/tests/e2e/_common.sh"
+
+( cd "$ROOT/plugins/positioner/zig" && zig build )
+
+e2e_run_test tests/e2e/plugin-positioner-integration.test.ts

--- a/tests/e2e/run-plugin-wrappers.sh
+++ b/tests/e2e/run-plugin-wrappers.sh
@@ -8,4 +8,4 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
-bun test plugins/state/js/src plugins/state/node/src plugins/sqlite/js/src plugins/sqlite/node/src plugins/log/js/src plugins/log/node/src plugins/store/js/src plugins/store/node/src plugins/http/js/src plugins/http/node/src plugins/notification-rich/js/src plugins/notification-rich/node/src plugins/window-state/js/src plugins/window-state/node/src
+bun test plugins/state/js/src plugins/state/node/src plugins/sqlite/js/src plugins/sqlite/node/src plugins/log/js/src plugins/log/node/src plugins/store/js/src plugins/store/node/src plugins/http/js/src plugins/http/node/src plugins/notification-rich/js/src plugins/notification-rich/node/src plugins/window-state/js/src plugins/window-state/node/src plugins/positioner/js/src plugins/positioner/node/src

--- a/tests/positioner_plugin_test.zig
+++ b/tests/positioner_plugin_test.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const loader = @import("loader");
+
+const PLUGIN_PATH = switch (builtin.os.tag) {
+    .macos => "plugins/positioner/zig/zig-out/lib/libbackend.dylib",
+    .linux => "plugins/positioner/zig/zig-out/lib/libbackend.so",
+    .windows => "plugins/positioner/zig/zig-out/bin/backend.dll",
+    else => @compileError("unsupported OS"),
+};
+
+fn loadPos(reg: *loader.BackendRegistry) !void {
+    try reg.register("positioner", PLUGIN_PATH);
+}
+
+fn invokePlugin(reg: *loader.BackendRegistry, request: []const u8) ?[]const u8 {
+    var req_buf: [4096]u8 = undefined;
+    const len = @min(request.len, req_buf.len - 1);
+    @memcpy(req_buf[0..len], request[0..len]);
+    req_buf[len] = 0;
+    return reg.invoke("positioner", req_buf[0..len :0]);
+}
+
+fn freeResp(reg: *const loader.BackendRegistry, resp: ?[]const u8) void {
+    reg.freeResponse("positioner", resp);
+}
+
+test "positioner plugin: load + channel" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadPos(&reg);
+    try std.testing.expect(reg.get("positioner") != null);
+}
+
+test "positioner plugin: missing position → error" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadPos(&reg);
+
+    // windowId 지정(id!=0)이지만 position 누락 → "missing position".
+    const r = invokePlugin(&reg, "{\"cmd\":\"positioner:move\",\"windowId\":1}");
+    defer freeResp(&reg, r);
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "missing position") != null);
+}
+
+test "positioner plugin: no window → error (no @intCast panic on huge windowId)" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadPos(&reg);
+
+    // __window 미주입 + windowId 미지정 → id=0 → "no window".
+    const r1 = invokePlugin(&reg, "{\"cmd\":\"positioner:move\",\"position\":\"center\"}");
+    defer freeResp(&reg, r1);
+    try std.testing.expect(r1 != null);
+    try std.testing.expect(std.mem.indexOf(u8, r1.?, "no window") != null);
+
+    // u32 범위 밖 windowId → cast 실패 시 0 → "no window"(패닉 X).
+    const r2 = invokePlugin(&reg, "{\"cmd\":\"positioner:move\",\"position\":\"center\",\"windowId\":99999999999}");
+    defer freeResp(&reg, r2);
+    try std.testing.expect(r2 != null);
+    try std.testing.expect(std.mem.indexOf(u8, r2.?, "no window") != null);
+}
+
+test "positioner plugin: with windowId but no core window API → graceful error" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadPos(&reg);
+
+    // test registry 엔 window/screen API 가 없어 getBounds 가 null → "get_bounds failed".
+    // 크래시 없이 에러 반환(graceful). 실 좌표 계산은 e2e(실 CEF 창)가 검증.
+    const r = invokePlugin(&reg, "{\"cmd\":\"positioner:move\",\"position\":\"center\",\"windowId\":1}");
+    defer freeResp(&reg, r);
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, "\"error\"") != null);
+}


### PR DESCRIPTION
## 배경

\"부족한 플러그인 + 로우건\"의 2번째. 화면 모서리/중앙·커서·트레이 아이콘 아래로 창을 한 줄로 배치(Tauri positioner 동등). **새 네이티브 코드 0** — 코어 `screen`/`windows`/`tray` API 조합.

## 구성 (zig/js/node 3-wrapper)

- **`plugins/positioner/zig/app.zig`** — `positioner:move {position, windowId?, trayId?}`. 창이 있는 디스플레이의 work area 안에서 위치 계산 후 `setBounds`.
  - position: `center`, `top-left/right`, `bottom-left/right`, `top/bottom/left/right-center` (9) + `at-cursor` + `tray-center`.
- **`@suji/plugin-positioner`** (renderer) + **`@suji/plugin-positioner-node`** (백엔드).

```ts
import { positioner } from '@suji/plugin-positioner';
await positioner.move('center');
await positioner.move('tray-center', { trayId });
```

## 좌표계 (핵심)

코어 screen API 는 **비대칭**이다: `displays`/`cursor` 는 NSScreen **bottom-up**, `tray.getBounds` 는 cef_tray 가 이미 **top-left** 로 변환. 창 bounds 는 CEF top-left.
→ macOS 는 primary 높이로 `displays`/`cursor` 만 y-flip(**tray 는 flip 금지**), multi-display 는 primary 기준 전역 변환으로 정확. Win/Linux 는 둘 다 top-left 라 flip 없음.

## 검증 (3 레이어)

- `zig build test-positioner` — CEF-free 표면 **4**(load/missing-position/graceful no-window/out-of-range windowId).
- `bun test plugins/positioner/{js,node}/src` — wire-contract **9**.
- `bash tests/e2e/run-plugin-positioner.sh` — **실 CEF 창 지오메트리 3**(창을 520×380 축소 후 좌표 단조성 top-left<bottom-right, center 사이, at-cursor). multi-backend 활성.
- `zig build` 무회귀.

## /simplify

`screenPosition` 9-way 분기 → x/y 인덱스 테이블 dispatch.

## code-review max (9-angle) — 좌표 버그 4건 수정

1. **tray-center double-flip** — `tray.getBounds` 가 이미 top-left 인데 또 flip 해 창이 화면 하단에 배치되던 버그. flip 제거(`ty = tray_y + tray_h`).
2. **at-cursor/tray-center work-area 오선택** — 창 디스플레이가 아닌 **커서/트레이가 있는 디스플레이**의 work area 로 clamp 하도록 anchor 분리(multi-display 정확).
3. **tray 0-rect**(Win/Linux) — 코너 배치 대신 `tray bounds unavailable` 명시 에러(caller 폴백 가능).
4. **e2e flake 방지** — 헤드리스 소형 디스플레이에서 1024×768 창이 화면을 꽉 채워 모든 위치가 한 모서리로 clamp 되는 문제 → 창을 520×380 축소 후 단조성 검증.

## 정직 경계

- `tray-center` 는 macOS 전용(Win/Linux 0-rect → 에러). 화면 상대 + at-cursor 는 전 플랫폼.
- 좌표 변환이 플러그인에 있음(코어 screen 이 raw 만 노출) — 후속 지오메트리 플러그인 시 코어 헬퍼로 이전하도록 NOTE 주석 남김.

🤖 Generated with [Claude Code](https://claude.com/claude-code)