### PR TITLE
feat(plugin): upload — multipart 파일 업로드 / 다운로드→디스크

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ zig build test-os-autostart # os-info + autostart 플러그인 (시스템 정보
 zig build test-notification-rich # notification-rich 플러그인 (WinRT/UNUserNotificationCenter/Freedesktop actions)
 zig build test-window-state # window-state 플러그인 (창 bounds/maximized 저장·복원; CEF-free 표면 — file/validate/graceful no-window)
 zig build test-positioner # positioner 플러그인 (창을 화면/트레이/커서 위치로 배치; CEF-free 표면 — graceful no-window/missing-position)
+zig build test-upload   # upload 플러그인 (multipart 파일 업로드 / 다운로드→디스크; network-free 표면 — URL/PATH allowlist deny-by-default, SSRF, traversal)
 
 # 임베드 코어 라이브러리 (CEF 무관 — 모바일/임베드용)
 zig build lib                                  # libsuji_core.a (host)
@@ -72,10 +73,11 @@ bash tests/e2e/run-gpu-accel.sh         # GPU 가속 회귀 가드 (#12) — Web
 bash tests/e2e/run-releasesafe-renderer-boot.sh # #60 part2 회귀 가드 — ReleaseSafe 빌드해 렌더러 V8 부트스트랩(window.__suji__ 바인딩) 검증(Windows CI). 디버깅: SUJI_CEF_DEBUG=1
 bash tests/e2e/run-set-user-agent.sh    # set_user_agent CDP override 실효(navigator.userAgent)
 bash tests/e2e/run-context-isolation.sh # window.__suji__ frozen/슬롯봉인/변조차단/기능보존
-bash tests/e2e/run-plugin-wrappers.sh   # 공식 플러그인 (state/sqlite/log/store/http/notification-rich/window-state/positioner) × {JS, Node} wrapper wire-contract (mock bridge)
+bash tests/e2e/run-plugin-wrappers.sh   # 공식 플러그인 (state/sqlite/log/store/http/notification-rich/window-state/positioner/upload) × {JS, Node} wrapper wire-contract (mock bridge)
 bash tests/e2e/run-plugin-state-integration.sh # state plugin DLL 라운드트립(__suji__ → DLL → 응답)
 bash tests/e2e/run-plugin-window-state.sh # window-state plugin 실 CEF 창 라운드트립(save 가 라이브 bounds 읽기 → file → get/restore/clear)
 bash tests/e2e/run-plugin-positioner.sh # positioner plugin 실 CEF 창 지오메트리(move 좌표 단조성 top-left<bottom-right, center 사이, at-cursor)
+bash tests/e2e/run-plugin-upload.sh     # upload plugin 실 Bun HTTP 서버 + 디스크(multipart 업로드 바이트 일치 / 다운로드→파일 내용 일치 / allowlist deny / progress 이벤트)
 bash tests/e2e/run-lua-e2e.sh           # Lua 백엔드 (vendored Lua 5.4 + cjson) invoke 왕복/cjson roundtrip/50 concurrent (-Dlua 자동 빌드)
 bash tests/e2e/run-python-e2e.sh        # Python 백엔드 (embedded CPython 3.13 + GIL) invoke 왕복/json roundtrip/50 concurrent/send·on (scripts/stage-python.sh 자동 staging)
 

--- a/build.zig
+++ b/build.zig
@@ -1190,6 +1190,28 @@ pub fn build(b: *std.Build) void {
     const positioner_test_step = b.step("test-positioner", "Run positioner plugin tests (requires built dylib)");
     positioner_test_step.dependOn(&positioner_test_run.step);
 
+    const upload_test_mod = b.createModule(.{
+        .root_source_file = b.path("tests/upload_plugin_test.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    const upload_loader = b.createModule(.{
+        .root_source_file = b.path("src/backends/loader.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    upload_loader.addImport("events", events_module);
+    upload_loader.addImport("runtime", runtime_module);
+    upload_loader.addImport("util", util_module);
+    upload_test_mod.addImport("loader", upload_loader);
+    upload_test_mod.addImport("events", events_module);
+    const upload_test = b.addTest(.{ .root_module = upload_test_mod });
+    const upload_test_run = b.addRunArtifact(upload_test);
+    upload_test_run.setCwd(b.path("."));
+    const upload_test_step = b.step("test-upload", "Run upload plugin tests (requires built dylib)");
+    upload_test_step.dependOn(&upload_test_run.step);
+
     // HTTP plugin tests (log/state/sqlite/store 와 동형)
     const http_test_mod = b.createModule(.{
         .root_source_file = b.path("tests/http_plugin_test.zig"),

--- a/documents/index.mdx
+++ b/documents/index.mdx
@@ -44,6 +44,7 @@ npm run dev
 | state 플러그인 | [`plugin-state.mdx`](./plugin-state.mdx) |
 | window-state 플러그인 | [`plugin-window-state.mdx`](./plugin-window-state.mdx) |
 | positioner 플러그인 | [`plugin-positioner.mdx`](./plugin-positioner.mdx) |
+| upload 플러그인 | [`plugin-upload.mdx`](./plugin-upload.mdx) |
 | 신규 언어 SDK 포팅 가이드 | [`../docs/SDK_PORTING.md`](../docs/SDK_PORTING.md) |
 
 ## 설계 원칙

--- a/documents/plugin-upload.mdx
+++ b/documents/plugin-upload.mdx
@@ -1,0 +1,81 @@
+---
+title: upload 플러그인
+description: 파일 업로드(multipart/form-data) / 다운로드(→디스크) (Tauri upload 동등)
+---
+
+# upload 플러그인
+
+디스크 파일을 그대로 서버에 업로드하거나, 서버 응답을 디스크 파일로 내려받는다 —
+바이너리를 JS 메모리에 올리지 않는다. `http` 플러그인이 문자열 body 만 다루는 것과
+대비된다. 코어 `std.http.Client` + 파일 I/O 조합.
+
+## 설치
+
+```json
+{
+  "plugins": ["upload"]
+}
+```
+
+## 사용 (`@suji/plugin-upload`)
+
+```ts
+import { upload } from '@suji/plugin-upload';
+
+// 1) 두 allowlist 를 먼저 설정 (deny-by-default — 안 하면 전부 차단)
+await upload.setAllowedUrls(['https://api.example.com/*']);
+await upload.setAllowedPaths(['~/Documents/myapp']);
+
+// 2) 업로드 — 디스크 파일을 multipart/form-data 로 POST
+const res = await upload.upload(
+  'https://api.example.com/u',
+  '~/Documents/myapp/photo.png',
+  { fieldName: 'file', fileName: 'photo.png', contentType: 'image/png', id: 'job1' },
+);
+// res = { status, body }
+
+// 3) 다운로드 — 서버 body 를 디스크 파일로 저장
+const dl = await upload.download('https://api.example.com/f/1', '~/Documents/myapp/out.bin', { id: 'job2' });
+// dl = { status, bytes }
+
+// 4) 완료 progress 구독
+const unsub = upload.onProgress((p) => console.log(p.id, p.uploaded, '/', p.total, p.done));
+unsub();
+```
+
+## 채널 (저수준)
+
+| 채널 | 요청 | 응답 |
+|---|---|---|
+| `upload:upload` | `{url, filePath, fieldName?, fileName?, contentType?, id?}` | `{status, body}` |
+| `upload:download` | `{url, filePath, id?}` | `{status, bytes}` |
+| `upload:set_allowed_urls` / `get_allowed_urls` | `{urls:[glob,...]}` | `{ok}` / `{urls}` |
+| `upload:set_allowed_paths` / `get_allowed_paths` | `{paths:[prefix,...]}` | `{ok}` / `{paths}` |
+
+완료 시 `suji.send("upload:progress", {id, uploaded, total, done:true})` 발화.
+
+## 보안 (2중 deny-by-default)
+
+`http` 플러그인의 URL allowlist + `fs` sandbox 의 path allowlist 를 **둘 다** 적용한다.
+
+- **URL allowlist** — 비어 있으면 모든 요청 차단. scheme `http`/`https` 만, `user@host`
+  userinfo bypass 차단, CRLF 차단, redirect 미추적(`.not_allowed`) → SSRF 방지.
+- **PATH allowlist** — 비어 있으면 모든 파일 접근 차단. 없으면 렌더러가 임의 파일을 읽어
+  업로드(유출)하거나 임의 경로로 다운로드(덮어쓰기)할 수 있다. `..` 항상 차단,
+  prefix + separator boundary(`/foo` 허용 시 `/fooX` 통과 X), `*`=escape hatch.
+
+`~` prefix 는 `$HOME`/`%USERPROFILE%` 로 확장된다(allowlist 패턴·filePath 모두 — 그래야 `~/Documents` 허용이 확장된 경로와 매치된다).
+
+> ⚠️ path 검증은 **lexical**(문자열 prefix)이다 — 코어 fs sandbox 와 동일하게 symlink 를
+> realpath 로 해석하지 않는다. allowlist 디렉토리 안의 symlink 가 밖을 가리키면 우회 가능
+> (fs sandbox 와 동일 신뢰 경계). 신뢰할 수 없는 symlink 가 있는 디렉토리는 allowlist 에 넣지 말 것.
+
+## 정직 경계
+
+- **bounded in-memory** — 파일 ≤ 64MB, 응답 ≤ 16MB. 코어가 `std.http.Client.fetch`
+  (payload 일괄)만 쓰고 low-level streaming request 는 미사용이라, **mid-stream(청크)
+  progress 는 불가** — 시작/완료 이벤트만 발화한다(`done:true`). 진짜 청크 단위 진행률은
+  std.http low-level API 도입 후속.
+- multipart boundary 가 파일에 우연히 포함되면 `boundary collision` 에러(손상 방지).
+- 단위 테스트는 network 없이 allowlist/SSRF/traversal 표면만 — 실 업/다운로드 라운드트립은
+  `bash tests/e2e/run-plugin-upload.sh`(실 Bun HTTP 서버 + 디스크)가 검증.

--- a/documents/plugins.mdx
+++ b/documents/plugins.mdx
@@ -16,7 +16,7 @@ JS)에서 일관되게 호출하기 위한 구조. OS native API (clipboard/fs/d
 | 위치 | `src/platform/cef.zig` (코어) | `plugins/<name>/` (외부 디렉토리) |
 | 빌드 | suji 코어와 함께 | 별도 dylib (또는 source 포함) |
 | 5 SDK 노출 | ✅ 자동 (suji core가 책임) | ✅ wrapper 직접 작성 |
-| 예시 | clipboard, fs, dialog, tray, menu, notification, globalShortcut | `state`, `sqlite`, `log`, `store`, `http`, `notification-rich`, `window-state`, `positioner`, 사용자 DB / 인증 / telemetry 등 |
+| 예시 | clipboard, fs, dialog, tray, menu, notification, globalShortcut | `state`, `sqlite`, `log`, `store`, `http`, `notification-rich`, `window-state`, `positioner`, `upload`, 사용자 DB / 인증 / telemetry 등 |
 | Mac App Sandbox 호환 | ✅ (entitlements + 코어 binary) | 🟡 dylib + entitlements 분리 작업 필요 |
 
 OS native API를 plugin으로 만들지 못하는 이유:

--- a/examples/multi-backend/suji.json
+++ b/examples/multi-backend/suji.json
@@ -14,7 +14,7 @@
       "protocol": "suji"
     }
   ],
-  "plugins": ["state", "window-state", "positioner"],
+  "plugins": ["state", "window-state", "positioner", "upload"],
   "backends": [
     { "name": "zig", "lang": "zig", "entry": "backends/zig" },
     { "name": "rust", "lang": "rust", "entry": "backends/rust" },

--- a/plugins/upload/js/package.json
+++ b/plugins/upload/js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@suji/plugin-upload",
+  "version": "0.1.0",
+  "description": "Suji Upload Plugin - multipart file upload / download-to-disk for Renderer",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/plugins/upload/js/src/index.test.ts
+++ b/plugins/upload/js/src/index.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockBridge = {
+  invoke: mock(() => Promise.resolve({})),
+  on: mock((_event: string, _cb: (d: unknown) => void) => () => {}),
+};
+
+(globalThis as any).window = { __suji__: mockBridge };
+
+const { upload } = await import("./index");
+
+beforeEach(() => {
+  mockBridge.invoke.mockClear();
+  mockBridge.on.mockClear();
+});
+
+describe("upload.upload wire", () => {
+  it("url + filePath + opts pass through", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { status: 200, body: "ok" } });
+    const r = await upload.upload("https://x/u", "~/a.png", {
+      fieldName: "f",
+      fileName: "a.png",
+      contentType: "image/png",
+      id: "j1",
+    });
+    expect(mockBridge.invoke).toHaveBeenCalledWith("upload:upload", {
+      url: "https://x/u",
+      filePath: "~/a.png",
+      fieldName: "f",
+      fileName: "a.png",
+      contentType: "image/png",
+      id: "j1",
+    });
+    expect(r).toEqual({ status: 200, body: "ok" });
+  });
+
+  it("omits undefined opts", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { status: 201, body: "" } });
+    await upload.upload("https://x/u", "/tmp/a");
+    expect(mockBridge.invoke).toHaveBeenCalledWith("upload:upload", { url: "https://x/u", filePath: "/tmp/a" });
+  });
+});
+
+describe("upload.download wire", () => {
+  it("returns status + bytes", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { status: 200, bytes: 4096 } });
+    const r = await upload.download("https://x/f", "/tmp/out", { id: "j2" });
+    expect(mockBridge.invoke).toHaveBeenCalledWith("upload:download", { url: "https://x/f", filePath: "/tmp/out", id: "j2" });
+    expect(r).toEqual({ status: 200, bytes: 4096 });
+  });
+});
+
+describe("allowlists", () => {
+  it("setAllowedUrls / getAllowedUrls", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true } });
+    await upload.setAllowedUrls(["https://x/*"]);
+    expect(mockBridge.invoke).toHaveBeenCalledWith("upload:set_allowed_urls", { urls: ["https://x/*"] });
+
+    mockBridge.invoke.mockResolvedValueOnce({ result: { urls: ["https://x/*"] } });
+    expect(await upload.getAllowedUrls()).toEqual(["https://x/*"]);
+  });
+
+  it("setAllowedPaths / getAllowedPaths", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ result: { ok: true } });
+    await upload.setAllowedPaths(["~/Documents"]);
+    expect(mockBridge.invoke).toHaveBeenCalledWith("upload:set_allowed_paths", { paths: ["~/Documents"] });
+
+    mockBridge.invoke.mockResolvedValueOnce({ result: { paths: ["~/Documents"] } });
+    expect(await upload.getAllowedPaths()).toEqual(["~/Documents"]);
+  });
+});
+
+describe("onProgress", () => {
+  it("subscribes to upload:progress and forwards payload", () => {
+    let received: any = null;
+    const unsub = upload.onProgress((p) => {
+      received = p;
+    });
+    expect(mockBridge.on).toHaveBeenCalledWith("upload:progress", expect.any(Function));
+    // 브리지가 호출하는 콜백을 직접 실행해 forward 확인.
+    const cb = mockBridge.on.mock.calls.at(-1)![1] as (d: unknown) => void;
+    cb({ id: "j1", uploaded: 10, total: 10, done: true });
+    expect(received).toEqual({ id: "j1", uploaded: 10, total: 10, done: true });
+    expect(typeof unsub).toBe("function");
+  });
+});
+
+describe("error propagation", () => {
+  it("throws on bridge error", async () => {
+    mockBridge.invoke.mockResolvedValueOnce({ error: "forbidden url" });
+    await expect(upload.upload("https://x/u", "/tmp/a")).rejects.toThrow("upload: forbidden url");
+  });
+});

--- a/plugins/upload/js/src/index.ts
+++ b/plugins/upload/js/src/index.ts
@@ -1,0 +1,105 @@
+/**
+ * @suji/plugin-upload — 파일 업로드(multipart/form-data) / 다운로드(→디스크).
+ *
+ * http 플러그인이 문자열 body 만 다루는 것과 달리, 디스크 파일을 직접 전송/수신한다
+ * (바이너리를 JS 메모리에 올리지 않음). URL + 파일경로 둘 다 deny-by-default allowlist.
+ *
+ * ```ts
+ * import { upload } from '@suji/plugin-upload';
+ *
+ * await upload.setAllowedUrls(['https://api.example.com/*']);
+ * await upload.setAllowedPaths(['~/Documents/myapp']);
+ *
+ * const unsub = upload.onProgress((p) => console.log(p.uploaded, '/', p.total));
+ * const res = await upload.upload('https://api.example.com/u', '~/Documents/myapp/a.png',
+ *   { fieldName: 'file', fileName: 'a.png', contentType: 'image/png', id: 'job1' });
+ * await upload.download('https://api.example.com/f/1', '~/Documents/myapp/out.bin', { id: 'job2' });
+ * unsub();
+ * ```
+ *
+ * 정직 경계: 전송은 bounded(파일 ≤ 64MB) in-memory — 코어가 std.http.Client.fetch 만
+ *   쓰고 low-level streaming 미사용이라 mid-stream progress 불가. 완료 이벤트만 발화.
+ */
+
+interface SujiBridge {
+  invoke(channel: string, data?: Record<string, unknown>): Promise<any>;
+  on(event: string, cb: (data: unknown) => void): () => void;
+}
+
+function getBridge(): SujiBridge {
+  const bridge = (window as any).__suji__;
+  if (!bridge) throw new Error("Suji bridge not available.");
+  return bridge;
+}
+
+async function call(channel: string, data: Record<string, unknown>): Promise<any> {
+  const resp = await getBridge().invoke(channel, data);
+  if (resp?.error) throw new Error(`upload: ${resp.error}`);
+  return resp?.result ?? resp;
+}
+
+export interface UploadOptions {
+  /** multipart 폼 필드명. 기본 "file". */
+  fieldName?: string;
+  /** 서버에 전달할 파일명. 기본 "upload". */
+  fileName?: string;
+  /** 파일 MIME. 기본 "application/octet-stream". */
+  contentType?: string;
+  /** progress 이벤트 상관용 id. */
+  id?: string;
+}
+
+export interface UploadProgress {
+  id: string;
+  uploaded: number;
+  total: number;
+  done: boolean;
+}
+
+export interface UploadResult {
+  status: number;
+  body: string;
+}
+
+export interface DownloadResult {
+  status: number;
+  bytes: number;
+}
+
+export const upload = {
+  /** 디스크 파일을 multipart/form-data 로 POST. */
+  async upload(url: string, filePath: string, opts?: UploadOptions): Promise<UploadResult> {
+    const data: Record<string, unknown> = { url, filePath };
+    if (opts?.fieldName !== undefined) data.fieldName = opts.fieldName;
+    if (opts?.fileName !== undefined) data.fileName = opts.fileName;
+    if (opts?.contentType !== undefined) data.contentType = opts.contentType;
+    if (opts?.id !== undefined) data.id = opts.id;
+    const r = await call("upload:upload", data);
+    return { status: Number(r?.status ?? 0), body: String(r?.body ?? "") };
+  },
+  /** URL 을 GET 해 디스크 파일로 저장. */
+  async download(url: string, filePath: string, opts?: Pick<UploadOptions, "id">): Promise<DownloadResult> {
+    const data: Record<string, unknown> = { url, filePath };
+    if (opts?.id !== undefined) data.id = opts.id;
+    const r = await call("upload:download", data);
+    return { status: Number(r?.status ?? 0), bytes: Number(r?.bytes ?? 0) };
+  },
+  /** 완료 progress 이벤트 구독. 반환 함수로 해제. */
+  onProgress(cb: (p: UploadProgress) => void): () => void {
+    return getBridge().on("upload:progress", (data) => cb(data as UploadProgress));
+  },
+  async setAllowedUrls(urls: string[]): Promise<void> {
+    await call("upload:set_allowed_urls", { urls });
+  },
+  async getAllowedUrls(): Promise<string[]> {
+    const r = await call("upload:get_allowed_urls", {});
+    return (r?.urls ?? []) as string[];
+  },
+  async setAllowedPaths(paths: string[]): Promise<void> {
+    await call("upload:set_allowed_paths", { paths });
+  },
+  async getAllowedPaths(): Promise<string[]> {
+    const r = await call("upload:get_allowed_paths", {});
+    return (r?.paths ?? []) as string[];
+  },
+};

--- a/plugins/upload/js/tsconfig.json
+++ b/plugins/upload/js/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/plugins/upload/node/package.json
+++ b/plugins/upload/node/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@suji/plugin-upload-node",
+  "version": "0.1.0",
+  "description": "Suji Upload Plugin - multipart file upload / download-to-disk for Node.js backends",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/plugins/upload/node/src/index.test.ts
+++ b/plugins/upload/node/src/index.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockBridge = {
+  invoke: mock(() => Promise.resolve('{"result":{}}')),
+  on: mock((_ch: string, _fn: (c: string, d: string) => void) => 7),
+  off: mock((_id: number) => {}),
+};
+
+(globalThis as any).suji = mockBridge;
+
+const { upload } = await import("./index");
+
+beforeEach(() => {
+  mockBridge.invoke.mockClear();
+  mockBridge.on.mockClear();
+  mockBridge.off.mockClear();
+});
+
+function lastCall(): { backend: string; payload: Record<string, unknown> } {
+  const args = mockBridge.invoke.mock.calls.at(-1)!;
+  return { backend: args[0] as string, payload: JSON.parse(args[1] as string) };
+}
+
+describe("upload Node — routing + wire", () => {
+  it("upload routes to 'upload' backend with cmd", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"status":200,"body":"ok"}}');
+    const r = await upload.upload("https://x/u", "/srv/a.png", { contentType: "image/png", id: "j1" });
+    const { backend, payload } = lastCall();
+    expect(backend).toBe("upload");
+    expect(payload).toEqual({ cmd: "upload:upload", url: "https://x/u", filePath: "/srv/a.png", contentType: "image/png", id: "j1" });
+    expect(r).toEqual({ status: 200, body: "ok" });
+  });
+
+  it("download returns status + bytes", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"status":200,"bytes":2048}}');
+    const r = await upload.download("https://x/f", "/srv/out");
+    expect(lastCall().payload).toEqual({ cmd: "upload:download", url: "https://x/f", filePath: "/srv/out" });
+    expect(r).toEqual({ status: 200, bytes: 2048 });
+  });
+
+  it("allowlist setters route", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"result":{"ok":true}}');
+    await upload.setAllowedPaths(["/srv/data"]);
+    expect(lastCall().payload).toEqual({ cmd: "upload:set_allowed_paths", paths: ["/srv/data"] });
+  });
+});
+
+describe("onProgress (node bridge on/off)", () => {
+  it("subscribes, parses raw, returns off()", () => {
+    let received: any = null;
+    const unsub = upload.onProgress((p) => {
+      received = p;
+    });
+    expect(mockBridge.on).toHaveBeenCalledWith("upload:progress", expect.any(Function));
+    const fn = mockBridge.on.mock.calls.at(-1)![1] as (c: string, d: string) => void;
+    fn("upload:progress", '{"id":"j1","uploaded":5,"total":5,"done":true}');
+    expect(received).toEqual({ id: "j1", uploaded: 5, total: 5, done: true });
+    unsub();
+    expect(mockBridge.off).toHaveBeenCalledWith(7);
+  });
+});
+
+describe("error propagation", () => {
+  it("throws on bridge error", async () => {
+    mockBridge.invoke.mockResolvedValueOnce('{"error":"forbidden path"}');
+    await expect(upload.download("https://x/f", "/etc/passwd")).rejects.toThrow("upload: forbidden path");
+  });
+});

--- a/plugins/upload/node/src/index.ts
+++ b/plugins/upload/node/src/index.ts
@@ -1,0 +1,106 @@
+/**
+ * @suji/plugin-upload-node — 파일 업로드/다운로드 for Suji Node backends.
+ * Wire contract 은 renderer `@suji/plugin-upload` 와 동일.
+ *
+ * ```ts
+ * const { upload } = require('@suji/plugin-upload-node');
+ * await upload.setAllowedUrls(['https://api.example.com/*']);
+ * await upload.setAllowedPaths(['/srv/data']);
+ * await upload.upload('https://api.example.com/u', '/srv/data/a.png', { contentType: 'image/png' });
+ * ```
+ */
+
+interface SujiBridge {
+  invoke(backend: string, request: string): Promise<string>;
+  on(channel: string, fn: (channel: string, data: string) => void): number;
+  off(subId: number): void;
+}
+
+function getBridge(): SujiBridge {
+  const bridge = (globalThis as any).suji as SujiBridge | undefined;
+  if (!bridge) {
+    throw new Error(
+      "@suji/plugin-upload-node: bridge not available. This module must run inside a Suji app (libnode embedding).",
+    );
+  }
+  return bridge;
+}
+
+async function call(cmd: string, payload: Record<string, unknown>): Promise<any> {
+  const raw = await getBridge().invoke("upload", JSON.stringify({ cmd, ...payload }));
+  let resp: any;
+  try {
+    resp = JSON.parse(raw);
+  } catch {
+    resp = {};
+  }
+  if (resp?.error) throw new Error(`upload: ${resp.error}`);
+  return resp?.result;
+}
+
+export interface UploadOptions {
+  fieldName?: string;
+  fileName?: string;
+  contentType?: string;
+  id?: string;
+}
+
+export interface UploadProgress {
+  id: string;
+  uploaded: number;
+  total: number;
+  done: boolean;
+}
+
+export interface UploadResult {
+  status: number;
+  body: string;
+}
+
+export interface DownloadResult {
+  status: number;
+  bytes: number;
+}
+
+export const upload = {
+  async upload(url: string, filePath: string, opts?: UploadOptions): Promise<UploadResult> {
+    const data: Record<string, unknown> = { url, filePath };
+    if (opts?.fieldName !== undefined) data.fieldName = opts.fieldName;
+    if (opts?.fileName !== undefined) data.fileName = opts.fileName;
+    if (opts?.contentType !== undefined) data.contentType = opts.contentType;
+    if (opts?.id !== undefined) data.id = opts.id;
+    const r = await call("upload:upload", data);
+    return { status: Number(r?.status ?? 0), body: String(r?.body ?? "") };
+  },
+  async download(url: string, filePath: string, opts?: Pick<UploadOptions, "id">): Promise<DownloadResult> {
+    const data: Record<string, unknown> = { url, filePath };
+    if (opts?.id !== undefined) data.id = opts.id;
+    const r = await call("upload:download", data);
+    return { status: Number(r?.status ?? 0), bytes: Number(r?.bytes ?? 0) };
+  },
+  onProgress(cb: (p: UploadProgress) => void): () => void {
+    const bridge = getBridge();
+    const subId = bridge.on("upload:progress", (_ch: string, raw: string) => {
+      try {
+        cb(JSON.parse(raw) as UploadProgress);
+      } catch {
+        /* ignore malformed */
+      }
+    });
+    return () => bridge.off(subId);
+  },
+  async setAllowedUrls(urls: string[]): Promise<void> {
+    await call("upload:set_allowed_urls", { urls });
+  },
+  async getAllowedUrls(): Promise<string[]> {
+    const r = await call("upload:get_allowed_urls", {});
+    return (r?.urls ?? []) as string[];
+  },
+  async setAllowedPaths(paths: string[]): Promise<void> {
+    await call("upload:set_allowed_paths", { paths });
+  },
+  async getAllowedPaths(): Promise<string[]> {
+    const r = await call("upload:get_allowed_paths", {});
+    return (r?.paths ?? []) as string[];
+  },
+};

--- a/plugins/upload/node/tsconfig.json
+++ b/plugins/upload/node/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/plugins/upload/suji-plugin.json
+++ b/plugins/upload/suji-plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "upload",
+  "lang": "zig"
+}

--- a/plugins/upload/zig/app.zig
+++ b/plugins/upload/zig/app.zig
@@ -1,0 +1,384 @@
+//! @suji/plugin-upload — 파일 업로드(multipart/form-data) / 다운로드(→디스크) (Tauri upload 동등).
+//!
+//! http 플러그인이 문자열 body 만 다루는 것과 달리, 디스크 파일을 직접 전송/수신한다
+//! (JS 메모리에 바이너리를 올리지 않음). 코어 std.http.Client + 파일 I/O 조합.
+//!
+//! 채널:
+//!   upload:upload   {url, filePath, fieldName?, fileName?, contentType?, id?} → {status, body}
+//!   upload:download {url, filePath, id?}                                       → {status, bytes}
+//!   upload:set_allowed_urls  {urls:[glob,...]}  / upload:get_allowed_urls  {} → {urls}
+//!   upload:set_allowed_paths {paths:[prefix,...]}/ upload:get_allowed_paths {} → {paths}
+//!   → 완료 시 suji.send("upload:progress", {id, uploaded, total, done:true}).
+//!
+//! 보안(2중 deny-by-default — http 플러그인 패턴 + fs sandbox 패턴):
+//!   - URL allowlist 비어 있으면 모든 요청 차단. scheme http/https 만, userinfo/CRLF 차단,
+//!     redirect 미추적(.not_allowed) — SSRF 방지(http 플러그인 동형).
+//!   - PATH allowlist 비어 있으면 모든 파일 접근 차단(렌더러가 임의 파일 읽어 업로드=유출,
+//!     임의 경로 다운로드=덮어쓰기 방지). `..` 항상 차단, prefix+separator boundary, `*`=escape.
+//!
+//! 정직 경계: 전송은 bounded in-memory(파일 ≤ 64MB) — 코어가 std.http.Client.fetch(payload)
+//!   만 쓰고 low-level streaming request 는 미사용이라 mid-stream progress 불가. 완료
+//!   이벤트만 발화(시작/완료). 진짜 청크 progress 는 std.http low-level API 후속.
+
+const std = @import("std");
+const suji = @import("suji");
+const util = @import("util");
+
+pub const app = suji.app()
+    .named("upload")
+    .handle("upload:upload", uploadFile)
+    .handle("upload:download", downloadFile)
+    .handle("upload:set_allowed_urls", setAllowedUrls)
+    .handle("upload:get_allowed_urls", getAllowedUrls)
+    .handle("upload:set_allowed_paths", setAllowedPaths)
+    .handle("upload:get_allowed_paths", getAllowedPaths);
+
+var gpa: std.heap.DebugAllocator(.{}) = .init;
+const alloc = gpa.allocator();
+
+fn pluginIo() std.Io {
+    return suji.io();
+}
+
+const MAX_FILE_BYTES: usize = 64 * 1024 * 1024; // 64MB 파일 상한
+const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+const MAX_URL_LEN: usize = 4096;
+const MAX_PATH_LEN: usize = 4096;
+const MAX_PATTERN_LEN: usize = 1024;
+const MAX_PATTERNS: usize = 256;
+const BOUNDARY = "----SujiUploadBoundary7MA4YWxkTrZu0gW";
+
+// ============================================
+// Allowlist (URL glob + PATH prefix) — 둘 다 deny-by-default
+// ============================================
+
+var allowed_urls: std.ArrayList([]const u8) = .empty;
+var urls_mutex: std.Io.Mutex = .init;
+var allowed_paths: std.ArrayList([]const u8) = .empty;
+var paths_mutex: std.Io.Mutex = .init;
+
+fn matchGlob(pattern: []const u8, text: []const u8) bool {
+    var pi: usize = 0;
+    var ti: usize = 0;
+    var star_pi: ?usize = null;
+    var star_ti: usize = 0;
+    while (ti < text.len) {
+        if (pi < pattern.len and pattern[pi] == '*') {
+            star_pi = pi;
+            star_ti = ti;
+            pi += 1;
+        } else if (pi < pattern.len and pattern[pi] == '?') {
+            pi += 1;
+            ti += 1;
+        } else if (pi < pattern.len and pattern[pi] == text[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if (star_pi) |sp| {
+            pi = sp + 1;
+            star_ti += 1;
+            ti = star_ti;
+        } else {
+            return false;
+        }
+    }
+    while (pi < pattern.len and pattern[pi] == '*') pi += 1;
+    return pi == pattern.len;
+}
+
+fn isUrlAllowed(url: []const u8) bool {
+    urls_mutex.lockUncancelable(pluginIo());
+    defer urls_mutex.unlock(pluginIo());
+    for (allowed_urls.items) |pat| {
+        if (matchGlob(pat, url)) return true;
+    }
+    return false;
+}
+
+/// fs sandbox 동형: `..` 항상 차단, `*`=escape(단 `..` 여전히 차단), 아니면 prefix +
+/// separator boundary("/foo" 허용 시 "/fooX" 통과 X). 보안 primitive 는 core `util`
+/// 재사용 — fs sandbox(`rendererPathFsGate`)와 단일 출처(util test 가 boundary/`..` 가드).
+fn isPathAllowed(path: []const u8) bool {
+    if (util.hasParentTraversalSegment(path)) return false;
+    paths_mutex.lockUncancelable(pluginIo());
+    defer paths_mutex.unlock(pluginIo());
+    for (allowed_paths.items) |pat| {
+        if (std.mem.eql(u8, pat, "*")) return true;
+        if (util.pathHasRootBoundary(path, pat)) return true;
+    }
+    return false;
+}
+
+// ============================================
+// URL/JSON helpers (http 플러그인 패턴)
+// ============================================
+
+fn validateUrl(req: suji.Request, url: []const u8) ?suji.Response {
+    if (url.len == 0 or url.len > MAX_URL_LEN) return req.err("invalid url");
+    const is_http = std.mem.startsWith(u8, url, "http://");
+    const is_https = std.mem.startsWith(u8, url, "https://");
+    if (!is_http and !is_https) return req.err("scheme not allowed");
+    const scheme_end = std.mem.indexOf(u8, url, "://") orelse return req.err("invalid url");
+    const authority_start = scheme_end + 3;
+    const authority_end = std.mem.indexOfAnyPos(u8, url, authority_start, "/?#") orelse url.len;
+    if (std.mem.indexOfScalarPos(u8, url[0..authority_end], authority_start, '@') != null) {
+        return req.err("userinfo not allowed");
+    }
+    for (url) |c| if (c == '\r' or c == '\n' or c == 0) return req.err("invalid url");
+    if (!isUrlAllowed(url)) return req.err("forbidden url");
+    return null; // ok
+}
+
+fn appendJsonEscaped(buf: *std.ArrayList(u8), a: std.mem.Allocator, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '"' => try buf.appendSlice(a, "\\\""),
+            '\\' => try buf.appendSlice(a, "\\\\"),
+            '\n' => try buf.appendSlice(a, "\\n"),
+            '\r' => try buf.appendSlice(a, "\\r"),
+            '\t' => try buf.appendSlice(a, "\\t"),
+            0...8, 11, 12, 14...31 => {
+                var tmp: [6]u8 = undefined;
+                const out = std.fmt.bufPrint(&tmp, "\\u{x:0>4}", .{c}) catch continue;
+                try buf.appendSlice(a, out);
+            },
+            else => try buf.append(a, c),
+        }
+    }
+}
+
+fn cGetenv(name: [*:0]const u8) ?[]const u8 {
+    const raw = std.c.getenv(name) orelse return null;
+    return std.mem.span(raw);
+}
+
+/// `~` prefix 를 $HOME 으로 확장(arena). 아니면 그대로.
+fn expandHome(arena: std.mem.Allocator, path: []const u8) []const u8 {
+    if (path.len == 0 or path[0] != '~') return path;
+    const home = cGetenv("HOME") orelse cGetenv("USERPROFILE") orelse return path;
+    return std.fmt.allocPrint(arena, "{s}{s}", .{ home, path[1..] }) catch path;
+}
+
+/// multipart 폼 필드 값(파일명/필드명) 안의 `"`/CR/LF 차단 — 헤더 인젝션 방지.
+fn validFormToken(s: []const u8) bool {
+    if (s.len == 0 or s.len > 256) return false;
+    for (s) |c| {
+        if (c == '"' or c == '\r' or c == '\n' or c == 0) return false;
+    }
+    return true;
+}
+
+/// 완료 progress 발화. id 는 렌더러 제어 문자열이라 반드시 JSON-escape(다른 출력과 동일
+/// 포스처) + arena 빌드(고정 버퍼 오버플로 회피).
+fn emitProgress(arena: std.mem.Allocator, id: []const u8, n: u64) void {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(arena);
+    buf.appendSlice(arena, "{\"id\":\"") catch return;
+    appendJsonEscaped(&buf, arena, id) catch return;
+    var tmp: [64]u8 = undefined;
+    const tail = std.fmt.bufPrint(&tmp, "\",\"uploaded\":{d},\"total\":{d},\"done\":true}}", .{ n, n }) catch return;
+    buf.appendSlice(arena, tail) catch return;
+    suji.send("upload:progress", buf.items);
+}
+
+// ============================================
+// Handlers
+// ============================================
+
+fn uploadFile(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    const url = req.string("url") orelse return req.err("missing url");
+    if (validateUrl(req, url)) |e| return e;
+    const raw_path = req.string("filePath") orelse return req.err("missing filePath");
+    if (raw_path.len == 0 or raw_path.len > MAX_PATH_LEN) return req.err("invalid filePath");
+    const file_path = expandHome(req.arena, raw_path);
+    if (!isPathAllowed(file_path)) return req.err("forbidden path");
+
+    const field = req.string("fieldName") orelse "file";
+    const fname = req.string("fileName") orelse "upload";
+    const ctype = req.string("contentType") orelse "application/octet-stream";
+    if (!validFormToken(field) or !validFormToken(fname) or !validFormToken(ctype)) return req.err("invalid form field");
+    const id = req.string("id") orelse "";
+    if (id.len > 256) return req.err("id too long");
+
+    const file_data = std.Io.Dir.cwd().readFileAlloc(pluginIo(), file_path, req.arena, .limited(MAX_FILE_BYTES)) catch return req.err("read failed");
+
+    // boundary 충돌 방지 — 파일에 boundary 가 있으면 multipart 손상.
+    if (std.mem.indexOf(u8, file_data, BOUNDARY) != null) return req.err("boundary collision");
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(req.arena);
+    body.appendSlice(req.arena, "--" ++ BOUNDARY ++ "\r\nContent-Disposition: form-data; name=\"") catch return req.err("alloc");
+    body.appendSlice(req.arena, field) catch return req.err("alloc");
+    body.appendSlice(req.arena, "\"; filename=\"") catch return req.err("alloc");
+    body.appendSlice(req.arena, fname) catch return req.err("alloc");
+    body.appendSlice(req.arena, "\"\r\nContent-Type: ") catch return req.err("alloc");
+    body.appendSlice(req.arena, ctype) catch return req.err("alloc");
+    body.appendSlice(req.arena, "\r\n\r\n") catch return req.err("alloc");
+    body.appendSlice(req.arena, file_data) catch return req.err("alloc");
+    body.appendSlice(req.arena, "\r\n--" ++ BOUNDARY ++ "--\r\n") catch return req.err("alloc");
+
+    var client: std.http.Client = .{ .allocator = alloc, .io = pluginIo() };
+    defer client.deinit();
+
+    const resp_buf = alloc.alloc(u8, MAX_RESPONSE_BYTES) catch return req.err("alloc");
+    defer alloc.free(resp_buf);
+    var resp_writer: std.Io.Writer = .fixed(resp_buf);
+
+    const ct_header = std.http.Header{ .name = "Content-Type", .value = "multipart/form-data; boundary=" ++ BOUNDARY };
+    const r = client.fetch(.{
+        .location = .{ .url = url },
+        .payload = body.items, // payload 존재 → POST (http 플러그인 동형, method 추론)
+        .extra_headers = &.{ct_header},
+        .response_writer = &resp_writer,
+        .redirect_behavior = .not_allowed,
+    }) catch |e| {
+        if (e == error.WriteFailed) return req.err("response too large");
+        return req.err("upload failed");
+    };
+
+    emitProgress(req.arena, id, file_data.len);
+
+    const body_slice = resp_buf[0..resp_writer.end];
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(req.arena);
+    out.appendSlice(req.arena, "{\"status\":") catch return req.err("alloc");
+    var tmp: [16]u8 = undefined;
+    out.appendSlice(req.arena, std.fmt.bufPrint(&tmp, "{d}", .{@intFromEnum(r.status)}) catch return req.err("alloc")) catch return req.err("alloc");
+    out.appendSlice(req.arena, ",\"body\":\"") catch return req.err("alloc");
+    appendJsonEscaped(&out, req.arena, body_slice) catch return req.err("alloc");
+    out.appendSlice(req.arena, "\"}") catch return req.err("alloc");
+    return req.okRaw(out.toOwnedSlice(req.arena) catch return req.err("alloc"));
+}
+
+fn downloadFile(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    const url = req.string("url") orelse return req.err("missing url");
+    if (validateUrl(req, url)) |e| return e;
+    const raw_path = req.string("filePath") orelse return req.err("missing filePath");
+    if (raw_path.len == 0 or raw_path.len > MAX_PATH_LEN) return req.err("invalid filePath");
+    const file_path = expandHome(req.arena, raw_path);
+    if (!isPathAllowed(file_path)) return req.err("forbidden path");
+    const id = req.string("id") orelse "";
+    if (id.len > 256) return req.err("id too long");
+
+    var client: std.http.Client = .{ .allocator = alloc, .io = pluginIo() };
+    defer client.deinit();
+
+    const resp_buf = alloc.alloc(u8, MAX_RESPONSE_BYTES) catch return req.err("alloc");
+    defer alloc.free(resp_buf);
+    var resp_writer: std.Io.Writer = .fixed(resp_buf);
+
+    const r = client.fetch(.{
+        .location = .{ .url = url },
+        .response_writer = &resp_writer,
+        .redirect_behavior = .not_allowed,
+    }) catch |e| {
+        if (e == error.WriteFailed) return req.err("response too large");
+        return req.err("download failed");
+    };
+
+    const data = resp_buf[0..resp_writer.end];
+
+    // atomic write (.tmp → rename) — store/window-state 패턴.
+    const io = pluginIo();
+    if (std.mem.lastIndexOfAny(u8, file_path, "/\\")) |sep| {
+        std.Io.Dir.cwd().createDirPath(io, file_path[0..sep]) catch {};
+    }
+    const tmp_path = std.fmt.allocPrint(req.arena, "{s}.tmp", .{file_path}) catch return req.err("alloc");
+    var f = std.Io.Dir.cwd().createFile(io, tmp_path, .{}) catch return req.err("write failed");
+    f.writePositionalAll(io, data, 0) catch {
+        f.close(io);
+        std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
+        return req.err("write failed");
+    };
+    f.close(io);
+    if (@import("builtin").os.tag == .windows) std.Io.Dir.cwd().deleteFile(io, file_path) catch {};
+    std.Io.Dir.cwd().rename(tmp_path, std.Io.Dir.cwd(), file_path, io) catch {
+        std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
+        return req.err("write failed");
+    };
+
+    emitProgress(req.arena, id, data.len);
+
+    var tmp: [16]u8 = undefined;
+    const body = std.fmt.allocPrint(
+        req.arena,
+        "{{\"status\":{s},\"bytes\":{d}}}",
+        .{ std.fmt.bufPrint(&tmp, "{d}", .{@intFromEnum(r.status)}) catch return req.err("alloc"), data.len },
+    ) catch return req.err("alloc");
+    return req.okRaw(body);
+}
+
+// ── allowlist setters/getters (http 플러그인 동형) ──
+
+fn parseStringArrayInto(req: suji.Request, key: []const u8, mutex: *std.Io.Mutex, list: *std.ArrayList([]const u8), expand_home: bool) ?suji.Response {
+    const raw = suji.extractJsonValue(req.raw, key) orelse return req.err("missing array");
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, raw, .{}) catch return req.err("invalid array");
+    defer parsed.deinit();
+    if (parsed.value != .array) return req.err("must be array");
+    if (parsed.value.array.items.len > MAX_PATTERNS) return req.err("too many patterns");
+
+    var new_list: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (new_list.items) |p| alloc.free(p);
+        new_list.deinit(alloc);
+    }
+    for (parsed.value.array.items) |val| {
+        if (val != .string) return req.err("pattern not string");
+        if (val.string.len == 0 or val.string.len > MAX_PATTERN_LEN) return req.err("invalid pattern");
+        // PATH 패턴은 `~` → $HOME 확장 — filePath 도 expandHome 되므로 양쪽을 맞춘다.
+        // 안 하면 "~/Documents" allowlist 가 확장된 "/Users/x/Documents/..." 와 절대 매치 X.
+        var home_buf: [MAX_PATH_LEN]u8 = undefined;
+        const to_store: []const u8 = if (expand_home and val.string[0] == '~') blk: {
+            const home = cGetenv("HOME") orelse cGetenv("USERPROFILE") orelse break :blk val.string;
+            break :blk std.fmt.bufPrint(&home_buf, "{s}{s}", .{ home, val.string[1..] }) catch break :blk val.string;
+        } else val.string;
+        const owned = alloc.dupe(u8, to_store) catch return req.err("alloc");
+        new_list.append(alloc, owned) catch {
+            alloc.free(owned);
+            return req.err("alloc");
+        };
+    }
+
+    mutex.lockUncancelable(pluginIo());
+    defer mutex.unlock(pluginIo());
+    for (list.items) |p| alloc.free(p);
+    list.deinit(alloc);
+    list.* = new_list;
+    return null;
+}
+
+fn emitStringArray(req: suji.Request, key: []const u8, mutex: *std.Io.Mutex, list: *std.ArrayList([]const u8)) suji.Response {
+    mutex.lockUncancelable(pluginIo());
+    defer mutex.unlock(pluginIo());
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(req.arena);
+    out.appendSlice(req.arena, "{\"") catch return req.err("alloc");
+    out.appendSlice(req.arena, key) catch return req.err("alloc");
+    out.appendSlice(req.arena, "\":[") catch return req.err("alloc");
+    for (list.items, 0..) |item, i| {
+        if (i > 0) out.append(req.arena, ',') catch return req.err("alloc");
+        out.append(req.arena, '"') catch return req.err("alloc");
+        appendJsonEscaped(&out, req.arena, item) catch return req.err("alloc");
+        out.append(req.arena, '"') catch return req.err("alloc");
+    }
+    out.appendSlice(req.arena, "]}") catch return req.err("alloc");
+    return req.okRaw(out.toOwnedSlice(req.arena) catch return req.err("alloc"));
+}
+
+fn setAllowedUrls(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    if (parseStringArrayInto(req, "urls", &urls_mutex, &allowed_urls, false)) |e| return e;
+    return req.okRaw("{\"ok\":true}");
+}
+fn getAllowedUrls(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    return emitStringArray(req, "urls", &urls_mutex, &allowed_urls);
+}
+fn setAllowedPaths(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    if (parseStringArrayInto(req, "paths", &paths_mutex, &allowed_paths, true)) |e| return e;
+    return req.okRaw("{\"ok\":true}");
+}
+fn getAllowedPaths(req: suji.Request, _: suji.InvokeEvent) suji.Response {
+    return emitStringArray(req, "paths", &paths_mutex, &allowed_paths);
+}
+
+comptime {
+    _ = suji.exportApp(app);
+}

--- a/plugins/upload/zig/build.zig
+++ b/plugins/upload/zig/build.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const util_mod = b.createModule(.{
+        .root_source_file = b.path("../../../src/core/util.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const suji_mod = b.createModule(.{
+        .root_source_file = b.path("../../../src/core/app.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    suji_mod.addImport("util", util_mod);
+
+    const lib = b.addLibrary(.{
+        .name = "backend",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("app.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+        .linkage = .dynamic,
+    });
+    lib.root_module.addImport("suji", suji_mod);
+    lib.root_module.addImport("util", util_mod);
+
+    // Windows: std.http.Client TLS deps (http 플러그인과 동일).
+    if (target.result.os.tag == .windows) {
+        lib.root_module.linkSystemLibrary("ws2_32", .{});
+        lib.root_module.linkSystemLibrary("crypt32", .{});
+        lib.root_module.linkSystemLibrary("ncrypt", .{});
+        lib.root_module.linkSystemLibrary("bcrypt", .{});
+    }
+
+    b.installArtifact(lib);
+}

--- a/tests/e2e/plugin-upload-integration.test.ts
+++ b/tests/e2e/plugin-upload-integration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * 공식 upload 플러그인 통합 e2e (실 HTTP 서버 + 실 디스크 파일).
+ *
+ * 검증 범위:
+ *   1. renderer __suji__.invoke('upload:upload') → 플러그인이 디스크 파일을 읽어
+ *      multipart/form-data 로 실 서버에 POST → 서버가 받은 바이트/내용 일치
+ *   2. 'upload:download' → 실 서버 GET → 디스크 파일로 저장 → 내용 일치
+ *   3. URL/PATH allowlist deny-by-default (allowlist 밖 → forbidden)
+ *   4. upload:progress 완료 이벤트 발화
+ *
+ * Wrapper wire shape 은 `bun test plugins/upload/{js,node}/src` 가 별도 검증.
+ * 이 파일은 REAL plugin DLL ↔ std.http ↔ 파일 I/O 통합만 검사(unit 은 network 없이
+ * allowlist/SSRF/traversal 표면만 커버).
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import puppeteer, { type Browser, type Page } from "puppeteer-core";
+import { getMainPage } from "./_page";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let browser: Browser;
+let page: Page;
+let server: ReturnType<typeof Bun.serve>;
+let port = 0;
+let lastUpload: { bytes: number; name: string | null; content: string } | null = null;
+
+let tmpDir = "";
+let srcFile = "";
+let dlFile = "";
+const SRC_CONTENT = "SUJI-UPLOAD-PAYLOAD-" + "x".repeat(500);
+const DL_CONTENT = "SUJI-DOWNLOAD-BODY-" + "y".repeat(300);
+
+const inv = <T = any>(channel: string, payload?: unknown): Promise<T> =>
+  page.evaluate(
+    (r) => (window as unknown as { __suji__: { invoke: (c: string, d?: unknown) => unknown } }).__suji__
+      .invoke(r.channel as string, r.payload as unknown),
+    { channel, payload },
+  ) as Promise<T>;
+
+beforeAll(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "suji-upload-"));
+  srcFile = join(tmpDir, "src.bin");
+  dlFile = join(tmpDir, "out.bin");
+  writeFileSync(srcFile, SRC_CONTENT);
+
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/upload" && req.method === "POST") {
+        const fd = await req.formData();
+        const f = fd.get("file") as File | null;
+        const buf = f ? await f.arrayBuffer() : new ArrayBuffer(0);
+        lastUpload = { bytes: buf.byteLength, name: f?.name ?? null, content: Buffer.from(buf).toString() };
+        return new Response(JSON.stringify({ ok: true, received: buf.byteLength }), { status: 200 });
+      }
+      if (url.pathname === "/file" && req.method === "GET") {
+        return new Response(DL_CONTENT, { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  port = server.port;
+
+  browser = await puppeteer.connect({
+    browserURL: "http://localhost:9222",
+    protocolTimeout: 30000,
+    defaultViewport: null,
+  });
+  page = await getMainPage(browser);
+  page.setDefaultTimeout(15000);
+  await page.waitForFunction(() => typeof (window as any).__suji__ !== "undefined", { timeout: 10000 });
+
+  // allowlist 설정 + progress 수집기 등록.
+  await inv("upload:set_allowed_urls", { urls: [`http://localhost:${port}/*`] });
+  await inv("upload:set_allowed_paths", { paths: [tmpDir] });
+  await page.evaluate(() => {
+    (window as any).__up_progress = [];
+    (window as unknown as { __suji__: { on: (e: string, cb: (d: unknown) => void) => unknown } }).__suji__
+      .on("upload:progress", (d) => (window as any).__up_progress.push(d));
+  });
+});
+
+afterAll(async () => {
+  try {
+    server?.stop(true);
+  } catch {}
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {}
+  await browser?.disconnect();
+});
+
+describe("upload plugin: live HTTP + disk round-trip", () => {
+  test("upload sends the disk file as multipart; server receives exact bytes", async () => {
+    const r = await inv<{ result?: { status?: number; body?: string }; error?: string }>("upload:upload", {
+      url: `http://localhost:${port}/upload`,
+      filePath: srcFile,
+      fieldName: "file",
+      fileName: "src.bin",
+      contentType: "application/octet-stream",
+      id: "j1",
+    });
+    expect(r?.error).toBeUndefined();
+    expect(r?.result?.status).toBe(200);
+    expect(lastUpload).not.toBeNull();
+    expect(lastUpload!.bytes).toBe(SRC_CONTENT.length);
+    expect(lastUpload!.content).toBe(SRC_CONTENT);
+    expect(lastUpload!.name).toBe("src.bin");
+  });
+
+  test("upload:progress completion event fired", async () => {
+    // 이벤트는 invoke 응답 직전 발화 — 짧게 폴링.
+    let events: any[] = [];
+    for (let i = 0; i < 20; i++) {
+      events = await page.evaluate(() => (window as any).__up_progress ?? []);
+      if (events.length > 0) break;
+      await new Promise((res) => setTimeout(res, 100));
+    }
+    const j1 = events.find((e) => e?.id === "j1");
+    expect(j1).toBeDefined();
+    expect(j1.done).toBe(true);
+    expect(j1.total).toBe(SRC_CONTENT.length);
+  });
+
+  test("download writes server body to disk", async () => {
+    const r = await inv<{ result?: { status?: number; bytes?: number }; error?: string }>("upload:download", {
+      url: `http://localhost:${port}/file`,
+      filePath: dlFile,
+      id: "j2",
+    });
+    expect(r?.error).toBeUndefined();
+    expect(r?.result?.status).toBe(200);
+    expect(r?.result?.bytes).toBe(DL_CONTENT.length);
+    expect(existsSync(dlFile)).toBe(true);
+    expect(readFileSync(dlFile, "utf8")).toBe(DL_CONTENT);
+  });
+
+  test("allowlist deny — url outside allowlist is forbidden", async () => {
+    const r = await inv<{ result?: unknown; error?: string }>("upload:download", {
+      url: "http://evil.example/x",
+      filePath: dlFile,
+    });
+    expect(JSON.stringify(r)).toContain("forbidden url");
+  });
+
+  test("allowlist deny — path outside allowlist is forbidden", async () => {
+    const r = await inv<{ result?: unknown; error?: string }>("upload:download", {
+      url: `http://localhost:${port}/file`,
+      filePath: "/etc/suji-should-not-write",
+    });
+    expect(JSON.stringify(r)).toContain("forbidden path");
+  });
+});

--- a/tests/e2e/run-plugin-upload.sh
+++ b/tests/e2e/run-plugin-upload.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# upload plugin 통합 e2e — multi-backend dev 를 띄워 renderer 가 실 Bun HTTP 서버에
+# 디스크 파일을 multipart 업로드 / 서버 body 를 디스크로 다운로드 라운드트립 검증.
+#
+# 사전조건: plugins/upload/zig 빌드(suji dev 가 dev 모드에서 자동 buildByLang 하지만,
+#   빌드 실패를 e2e 보다 먼저 정확히 진단하기 위해 명시적 pre-build).
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$ROOT/tests/e2e/_common.sh"
+
+( cd "$ROOT/plugins/upload/zig" && zig build )
+
+e2e_run_test tests/e2e/plugin-upload-integration.test.ts

--- a/tests/e2e/run-plugin-wrappers.sh
+++ b/tests/e2e/run-plugin-wrappers.sh
@@ -8,4 +8,4 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
-bun test plugins/state/js/src plugins/state/node/src plugins/sqlite/js/src plugins/sqlite/node/src plugins/log/js/src plugins/log/node/src plugins/store/js/src plugins/store/node/src plugins/http/js/src plugins/http/node/src plugins/notification-rich/js/src plugins/notification-rich/node/src plugins/window-state/js/src plugins/window-state/node/src plugins/positioner/js/src plugins/positioner/node/src
+bun test plugins/state/js/src plugins/state/node/src plugins/sqlite/js/src plugins/sqlite/node/src plugins/log/js/src plugins/log/node/src plugins/store/js/src plugins/store/node/src plugins/http/js/src plugins/http/node/src plugins/notification-rich/js/src plugins/notification-rich/node/src plugins/window-state/js/src plugins/window-state/node/src plugins/positioner/js/src plugins/positioner/node/src plugins/upload/js/src plugins/upload/node/src

--- a/tests/upload_plugin_test.zig
+++ b/tests/upload_plugin_test.zig
@@ -1,0 +1,150 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const loader = @import("loader");
+
+const PLUGIN_PATH = switch (builtin.os.tag) {
+    .macos => "plugins/upload/zig/zig-out/lib/libbackend.dylib",
+    .linux => "plugins/upload/zig/zig-out/lib/libbackend.so",
+    .windows => "plugins/upload/zig/zig-out/bin/backend.dll",
+    else => @compileError("unsupported OS"),
+};
+
+fn loadUp(reg: *loader.BackendRegistry) !void {
+    try reg.register("upload", PLUGIN_PATH);
+}
+
+fn invokePlugin(reg: *loader.BackendRegistry, request: []const u8) ?[]const u8 {
+    var req_buf: [4096]u8 = undefined;
+    const len = @min(request.len, req_buf.len - 1);
+    @memcpy(req_buf[0..len], request[0..len]);
+    req_buf[len] = 0;
+    return reg.invoke("upload", req_buf[0..len :0]);
+}
+
+fn freeResp(reg: *const loader.BackendRegistry, resp: ?[]const u8) void {
+    reg.freeResponse("upload", resp);
+}
+
+fn expectContains(r: ?[]const u8, needle: []const u8) !void {
+    try std.testing.expect(r != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.?, needle) != null);
+}
+
+test "upload plugin: load + channels" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadUp(&reg);
+    try std.testing.expect(reg.get("upload") != null);
+}
+
+test "upload plugin: allowlist URL round-trip" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadUp(&reg);
+
+    const s = invokePlugin(&reg, "{\"cmd\":\"upload:set_allowed_urls\",\"urls\":[\"https://ok.example/*\"]}");
+    defer freeResp(&reg, s);
+    try expectContains(s, "\"ok\":true");
+
+    const g = invokePlugin(&reg, "{\"cmd\":\"upload:get_allowed_urls\"}");
+    defer freeResp(&reg, g);
+    try expectContains(g, "https://ok.example/*");
+}
+
+test "upload plugin: allowlist PATH round-trip" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadUp(&reg);
+
+    const s = invokePlugin(&reg, "{\"cmd\":\"upload:set_allowed_paths\",\"paths\":[\"/srv/data\"]}");
+    defer freeResp(&reg, s);
+    try expectContains(s, "\"ok\":true");
+
+    const g = invokePlugin(&reg, "{\"cmd\":\"upload:get_allowed_paths\"}");
+    defer freeResp(&reg, g);
+    try expectContains(g, "/srv/data");
+}
+
+test "upload plugin: deny-by-default URL (empty allowlist → forbidden url)" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadUp(&reg);
+
+    // 명시적으로 빈 allowlist 설정(전역 상태 격리).
+    freeResp(&reg, invokePlugin(&reg, "{\"cmd\":\"upload:set_allowed_urls\",\"urls\":[]}"));
+    const r = invokePlugin(&reg, "{\"cmd\":\"upload:download\",\"url\":\"https://evil.example/x\",\"filePath\":\"/tmp/x\"}");
+    defer freeResp(&reg, r);
+    try expectContains(r, "forbidden url");
+}
+
+test "upload plugin: scheme + userinfo SSRF guards" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadUp(&reg);
+
+    const bad_scheme = invokePlugin(&reg, "{\"cmd\":\"upload:download\",\"url\":\"file:///etc/passwd\",\"filePath\":\"/tmp/x\"}");
+    defer freeResp(&reg, bad_scheme);
+    try expectContains(bad_scheme, "scheme not allowed");
+
+    const userinfo = invokePlugin(&reg, "{\"cmd\":\"upload:download\",\"url\":\"https://ok.example@evil.example/x\",\"filePath\":\"/tmp/x\"}");
+    defer freeResp(&reg, userinfo);
+    try expectContains(userinfo, "userinfo not allowed");
+}
+
+test "upload plugin: PATH deny-by-default + traversal (url allowed, path forbidden)" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadUp(&reg);
+
+    // url 은 허용하되 path allowlist 는 특정 prefix 만 — 그 밖/traversal 은 forbidden path.
+    freeResp(&reg, invokePlugin(&reg, "{\"cmd\":\"upload:set_allowed_urls\",\"urls\":[\"https://ok.example/*\"]}"));
+    freeResp(&reg, invokePlugin(&reg, "{\"cmd\":\"upload:set_allowed_paths\",\"paths\":[\"/srv/data\"]}"));
+
+    // allowlist 밖 경로
+    const outside = invokePlugin(&reg, "{\"cmd\":\"upload:download\",\"url\":\"https://ok.example/x\",\"filePath\":\"/etc/passwd\"}");
+    defer freeResp(&reg, outside);
+    try expectContains(outside, "forbidden path");
+
+    // boundary: /srv/dataX 는 prefix 통과하지만 separator boundary 로 거부
+    const boundary = invokePlugin(&reg, "{\"cmd\":\"upload:download\",\"url\":\"https://ok.example/x\",\"filePath\":\"/srv/dataX/y\"}");
+    defer freeResp(&reg, boundary);
+    try expectContains(boundary, "forbidden path");
+
+    // traversal
+    const traversal = invokePlugin(&reg, "{\"cmd\":\"upload:download\",\"url\":\"https://ok.example/x\",\"filePath\":\"/srv/data/../../etc/passwd\"}");
+    defer freeResp(&reg, traversal);
+    try expectContains(traversal, "forbidden path");
+}
+
+test "upload plugin: ~ in allowed path expands at store time (documented usage works)" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadUp(&reg);
+
+    // "~/suji-up-test" 저장 → get 은 $HOME 으로 확장된 경로를 돌려줘야(raw "~" 잔존 X).
+    // 안 그러면 expandHome 된 filePath 와 절대 매치 안 됨(code-review max 발견 버그).
+    freeResp(&reg, invokePlugin(&reg, "{\"cmd\":\"upload:set_allowed_paths\",\"paths\":[\"~/suji-up-test\"]}"));
+    const g = invokePlugin(&reg, "{\"cmd\":\"upload:get_allowed_paths\"}");
+    defer freeResp(&reg, g);
+    try expectContains(g, "suji-up-test");
+    // raw "~/" 형태가 남아 있으면 확장 실패 — 버그 회귀.
+    try std.testing.expect(std.mem.indexOf(u8, g.?, "~/suji-up-test") == null);
+}
+
+test "upload plugin: missing url/filePath" {
+    var reg = loader.BackendRegistry.init(std.heap.page_allocator, std.testing.io);
+    defer reg.deinit();
+    reg.setGlobal();
+    try loadUp(&reg);
+
+    const no_url = invokePlugin(&reg, "{\"cmd\":\"upload:upload\",\"filePath\":\"/tmp/x\"}");
+    defer freeResp(&reg, no_url);
+    try expectContains(no_url, "missing url");
+}


### PR DESCRIPTION
## 배경

\"부족한 플러그인 + 로우건\"의 3번째이자 가장 복잡한 것. `http` 플러그인이 문자열 body 만 다루는 것과 달리 **디스크 파일을 직접 전송/수신**한다(바이너리를 JS 메모리에 올리지 않음). 코어 `std.http.Client` + 파일 I/O 조합.

## 구성 (zig/js/node 3-wrapper)

- **`plugins/upload/zig/app.zig`** — `upload:upload`(multipart/form-data POST) / `download`(GET→디스크) / `set·get_allowed_urls` / `set·get_allowed_paths`. 완료 시 `suji.send("upload:progress", {id, uploaded, total, done})`.
- **`@suji/plugin-upload`** (renderer, `onProgress` 구독) + **`@suji/plugin-upload-node`**.

```ts
import { upload } from '@suji/plugin-upload';
await upload.setAllowedUrls(['https://api.example.com/*']);
await upload.setAllowedPaths(['~/Documents/myapp']);
const unsub = upload.onProgress((p) => console.log(p.uploaded, '/', p.total));
await upload.upload('https://api.example.com/u', '~/Documents/myapp/a.png', { contentType: 'image/png' });
await upload.download('https://api.example.com/f/1', '~/Documents/myapp/out.bin');
```

## 보안 (2중 deny-by-default)

- **URL allowlist** (http 플러그인 패턴) — scheme `http`/`https`, userinfo bypass·CRLF 차단, redirect 미추적 → SSRF 방지.
- **PATH allowlist** (fs sandbox 패턴, core `util.hasParentTraversalSegment`/`pathHasRootBoundary` 재사용) — `..` 차단, prefix+separator boundary, `*`=escape. 없으면 렌더러가 임의 파일을 읽어 업로드(유출)/임의 경로 다운로드(덮어쓰기) 가능 → deny-by-default.

## 검증 (3 레이어)

- `zig build test-upload` — network-free 표면 **8**(load/allowlist round-trip/deny-by-default/scheme+userinfo SSRF/path traversal+boundary/`~`expansion/missing).
- `bun test plugins/upload/{js,node}/src` — wire-contract **12**(onProgress on/off 포함).
- `bash tests/e2e/run-plugin-upload.sh` — **실 Bun HTTP 서버 + 디스크 5**(multipart 업로드 바이트 일치 / 다운로드→파일 내용 일치 / progress 이벤트 / url·path allowlist deny). multi-backend 활성.
- `zig build` 무회귀.

## /simplify

`isPathAllowed` 의 `..`/boundary 로직을 core `util.hasParentTraversalSegment`/`pathHasRootBoundary` 로 교체(fs sandbox 와 단일 출처). `matchGlob` 은 util 이 semantic superset(동작 변경)이라 로컬 유지(http 동형).

## code-review max (9-angle) — 2 버그 + 문서 보강

1. **`~` allowlist 미확장** — `~` 가 filePath 만 확장되고 allowlist 패턴은 미확장이라, 문서화된 `setAllowedPaths(['~/Documents'])` 가 확장된 filePath 와 절대 매치 안 돼 **전부 deny** 되던 버그 → 패턴도 store 시 확장(회귀 테스트 추가).
2. **`emitProgress` id 미escape + 고정 버퍼** — 렌더러 제어 `id` 를 raw `{s}` 로 박아 `"`/`\`/제어문자 시 JSON 깨짐(Node onProgress 가 조용히 드롭), 긴 id 는 256 버퍼 오버플로 → `appendJsonEscaped` + arena 빌드 + id 길이 cap.
3. symlink/lexical path-gate 한계 문서화(fs sandbox 동일 경계).

## 정직 경계

- **bounded in-memory**(파일 ≤ 64MB, 응답 ≤ 16MB) — 코어가 `std.http.Client.fetch(payload)` 만 쓰고 low-level streaming request 는 미사용이라 **mid-stream progress 불가**, 완료 이벤트만 발화. 진짜 청크 progress 는 후속.
- path 검증은 **lexical**(symlink realpath 미해석 — 코어 fs sandbox 동일 경계).

🤖 Generated with [Claude Code](https://claude.com/claude-code)