### PR TITLE
feat(ipc): 큰 IPC 페이로드 무제한화 (청크 분할 + emit 동적 버퍼)

### DIFF
--- a/src/core/events.zig
+++ b/src/core/events.zig
@@ -240,13 +240,16 @@ pub const EventBus = struct {
 
     fn emitToJs(self: *EventBus, event_name: []const u8, data: []const u8, target: ?u32) void {
         if (self.webview_eval) |eval_fn| {
-            var js_buf: [16384]u8 = undefined;
-            const js = std.fmt.bufPrint(&js_buf,
+            // 16KB 고정이면 큰 data(예: 200KB 응답)가 안 들어가 bufPrint 가 실패→이벤트 누락.
+            // event_name+data 길이에 맞춰 동적 alloc(allocPrintZ)으로 잘림 없이 실행.
+            const tmp = std.fmt.allocPrint(self.allocator,
                 "window.__suji__ && window.__suji__.__dispatch__ && window.__suji__.__dispatch__(\"{s}\", {s})",
                 .{ event_name, data },
             ) catch return;
-            js_buf[js.len] = 0;
-            eval_fn(target, js_buf[0..js.len :0]);
+            defer self.allocator.free(tmp);
+            const js = self.allocator.dupeZ(u8, tmp) catch return;
+            defer self.allocator.free(js);
+            eval_fn(target, js);
         }
     }
 };

--- a/src/platform/cef_browser_ipc.zig
+++ b/src/platform/cef_browser_ipc.zig
@@ -228,13 +228,14 @@ fn handleBrowserInvoke(
     g_current_call_ctx = .{ .browser = browser, .frame = frame, .seq_id = seq_id, .browser_handle = sender_handle, .deferred = false };
     defer g_current_call_ctx = null;
 
-    // 백엔드 호출
-    var response_buf: [16384]u8 = undefined;
+    // 백엔드 호출 — 재사용 큰 힙(4MB)으로 받아 큰 응답을 안 자른다. 송신은 sendInvokeResponse
+    // 가 32KB 청크로 분할(작은 건 단일). 콜백 시그니처·핸들러는 전부 그대로.
+    const response_buf = responseBuf() orelse return 0;
     var success: bool = false;
     var result: []const u8 = "\"no handler\"";
 
     if (g_invoke_callback) |cb| {
-        if (cb(channel, data_to_backend, &response_buf)) |resp| {
+        if (cb(channel, data_to_backend, response_buf)) |resp| {
             result = resp;
             success = true;
         } else {
@@ -259,12 +260,46 @@ fn handleBrowserInvoke(
     return 1;
 }
 
+// 단일 CefProcessMessage 가 안전히 싣는 청크 크기. 큰 응답은 N개로 쪼개 보내 무제한 지원.
+const RESP_CHUNK_LEN: usize = 32 * 1024;
+
+// 백엔드 응답 수용 버퍼(재사용). 콜백이 여기 write → 32KB 청크로 송신. 브라우저 IPC 는 단일
+// 스레드라 재사용 안전. lazy alloc(첫 큰 호출 때만). 이 이상(>4MB)은 localhost http 권장.
+const RESP_BUF_LEN: usize = 4 * 1024 * 1024;
+var g_response_buf: ?[]u8 = null;
+fn responseBuf() ?[]u8 {
+    if (g_response_buf) |b| return b;
+    const b = std.heap.c_allocator.alloc(u8, RESP_BUF_LEN) catch return null;
+    g_response_buf = b;
+    return b;
+}
+
 fn sendInvokeResponse(browser: ?*c._cef_browser_t, frame: ?*c._cef_frame_t, seq_id: i32, success: bool, result: []const u8) void {
     const f = frame orelse blk: {
         const br = browser orelse return;
         break :blk asPtr(c.cef_frame_t, br.get_main_frame.?(br)) orelse return;
     };
 
+    // 작은 응답: 기존 단일 suji:response (회귀 없음).
+    if (result.len <= RESP_CHUNK_LEN) {
+        sendResponseSingle(f, seq_id, success, result);
+        return;
+    }
+
+    // 큰 응답: suji:response-chunk ×N → suji:response-complete. JS(_chunks)가 재조립.
+    const total: i32 = @intCast((result.len + RESP_CHUNK_LEN - 1) / RESP_CHUNK_LEN);
+    var idx: i32 = 0;
+    var off: usize = 0;
+    while (off < result.len) {
+        const end = @min(off + RESP_CHUNK_LEN, result.len);
+        sendResponseChunk(f, seq_id, idx, total, result[off..end]);
+        off = end;
+        idx += 1;
+    }
+    sendResponseComplete(f, seq_id, success);
+}
+
+fn sendResponseSingle(f: *c.cef_frame_t, seq_id: i32, success: bool, result: []const u8) void {
     var resp_name: c.cef_string_t = .{};
     setCefString(&resp_name, "suji:response");
     const resp_msg = asPtr(c.cef_process_message_t, c.cef_process_message_create(&resp_name)) orelse return;
@@ -278,6 +313,30 @@ fn sendInvokeResponse(browser: ?*c._cef_browser_t, frame: ?*c._cef_frame_t, seq_
     _ = resp_args.set_string.?(resp_args, 2, &result_str);
 
     f.send_process_message.?(f, c.PID_RENDERER, resp_msg);
+}
+
+fn sendResponseChunk(f: *c.cef_frame_t, seq_id: i32, idx: i32, total: i32, data: []const u8) void {
+    var name: c.cef_string_t = .{};
+    setCefString(&name, "suji:response-chunk");
+    const msg = asPtr(c.cef_process_message_t, c.cef_process_message_create(&name)) orelse return;
+    const args = asPtr(c.cef_list_value_t, msg.get_argument_list.?(msg)) orelse return;
+    _ = args.set_int.?(args, 0, seq_id);
+    _ = args.set_int.?(args, 1, idx);
+    _ = args.set_int.?(args, 2, total);
+    var data_str: c.cef_string_t = .{};
+    setCefString(&data_str, data);
+    _ = args.set_string.?(args, 3, &data_str);
+    f.send_process_message.?(f, c.PID_RENDERER, msg);
+}
+
+fn sendResponseComplete(f: *c.cef_frame_t, seq_id: i32, success: bool) void {
+    var name: c.cef_string_t = .{};
+    setCefString(&name, "suji:response-complete");
+    const msg = asPtr(c.cef_process_message_t, c.cef_process_message_create(&name)) orelse return;
+    const args = asPtr(c.cef_list_value_t, msg.get_argument_list.?(msg)) orelse return;
+    _ = args.set_int.?(args, 0, seq_id);
+    _ = args.set_int.?(args, 1, if (success) 1 else 0);
+    f.send_process_message.?(f, c.PID_RENDERER, msg);
 }
 
 /// 메인 프로세스: emit 처리 → EventBus

--- a/src/platform/cef_render_bootstrap.zig
+++ b/src/platform/cef_render_bootstrap.zig
@@ -47,6 +47,19 @@ pub fn injectJsHelpers(ctx: *c._cef_v8_context_t) void {
         \\    if (p) { delete s._pending[seq]; p.reject(new Error(err)); }
         \\    else s._early[seq] = { ok: false, value: err };
         \\  };
+        \\  s._chunks = {};
+        \\  s._nextChunk = function(seq, idx, total, data) {
+        \\    var st = s._chunks[seq];
+        \\    if (!st) { st = s._chunks[seq] = { parts: new Array(total), got: 0 }; }
+        \\    if (idx >= 0 && idx < total && st.parts[idx] === undefined) { st.parts[idx] = data; st.got++; }
+        \\  };
+        \\  s._chunkComplete = function(seq, success) {
+        \\    var st = s._chunks[seq];
+        \\    var full = st ? st.parts.join('') : '';
+        \\    delete s._chunks[seq];
+        \\    if (success) s._nextResolve(seq, full);
+        \\    else s._nextReject(seq, full);
+        \\  };
         \\  s.invoke = function(channel, data, options) {
         \\    var req = data ? Object.assign({cmd: channel}, data) : {cmd: channel};
         \\    var target = options && options.target;

--- a/src/platform/cef_render_handler.zig
+++ b/src/platform/cef_render_handler.zig
@@ -251,6 +251,10 @@ fn onRendererProcessMessageReceived(
 
     if (std.mem.eql(u8, msg_name, "suji:response")) {
         return cef_render_ipc.handleRendererResponse(msg);
+    } else if (std.mem.eql(u8, msg_name, "suji:response-chunk")) {
+        return cef_render_ipc.handleRendererChunk(msg);
+    } else if (std.mem.eql(u8, msg_name, "suji:response-complete")) {
+        return cef_render_ipc.handleRendererComplete(msg);
     } else if (std.mem.eql(u8, msg_name, "suji:event")) {
         return cef_render_ipc.handleRendererEvent(msg);
     }

--- a/src/platform/cef_render_ipc.zig
+++ b/src/platform/cef_render_ipc.zig
@@ -48,7 +48,7 @@ pub fn handleRendererResponse(msg: *c._cef_process_message_t) i32 {
     const seq_id: u32 = @intCast(args.get_int.?(args, 0));
     const success = args.get_int.?(args, 1) == 1;
 
-    var result_buf: [16384]u8 = undefined;
+    var result_buf: [CEF_IPC_BUF_LEN]u8 = undefined; // 송신과 동일 64KB(16KB 고정이면 큰 응답 잘림)
     const result = getArgString(args, 2, &result_buf);
 
     const slot = seq_id % MAX_PENDING;
@@ -67,6 +67,30 @@ pub fn handleRendererResponse(msg: *c._cef_process_message_t) i32 {
     }
 
     return if (called) 1 else 0;
+}
+
+/// 청크 응답 — JS _nextChunk 로 누적(재조립은 JS 담당, Zig 은 무상태 전달).
+pub fn handleRendererChunk(msg: *c._cef_process_message_t) i32 {
+    const args = asPtr(c.cef_list_value_t, msg.get_argument_list.?(msg)) orelse return 0;
+    const seq_id: u32 = @intCast(args.get_int.?(args, 0));
+    const idx = args.get_int.?(args, 1);
+    const total = args.get_int.?(args, 2);
+    var data_buf: [CEF_IPC_BUF_LEN]u8 = undefined;
+    const data = getArgString(args, 3, &data_buf);
+    const slot = seq_id % MAX_PENDING;
+    const ctx = g_pending_contexts[slot] orelse g_renderer_context orelse return 0;
+    return if (callSujiChunk(ctx, seq_id, idx, total, data)) 1 else 0;
+}
+
+/// 청크 완료 — JS _chunkComplete 가 join → resolve. pending slot 소비.
+pub fn handleRendererComplete(msg: *c._cef_process_message_t) i32 {
+    const args = asPtr(c.cef_list_value_t, msg.get_argument_list.?(msg)) orelse return 0;
+    const seq_id: u32 = @intCast(args.get_int.?(args, 0));
+    const success = args.get_int.?(args, 1) == 1;
+    const slot = seq_id % MAX_PENDING;
+    const ctx = g_pending_contexts[slot] orelse g_renderer_context orelse return 0;
+    g_pending_contexts[slot] = null;
+    return if (callSujiComplete(ctx, seq_id, success)) 1 else 0;
 }
 
 /// 메인에서 푸시된 이벤트 → JS __dispatch__ 호출
@@ -193,6 +217,48 @@ fn callSujiResponseCallback(ctx: *c._cef_v8_context_t, seq_id: u32, success: boo
     };
     if (call_args[0] == null or call_args[1] == null) return false;
 
+    _ = callback.execute_function.?(callback, suji_obj, call_args.len, &call_args);
+    return true;
+}
+
+fn callSujiChunk(ctx: *c._cef_v8_context_t, seq_id: u32, idx: i32, total: i32, data: []const u8) bool {
+    _ = ctx.enter.?(ctx);
+    defer _ = ctx.exit.?(ctx);
+    const global = asPtr(c.cef_v8_value_t, ctx.get_global.?(ctx)) orelse return false;
+    var suji_key: c.cef_string_t = .{};
+    setCefString(&suji_key, "__suji__");
+    const suji_obj = asPtr(c.cef_v8_value_t, global.get_value_bykey.?(global, &suji_key)) orelse return false;
+    var fn_key: c.cef_string_t = .{};
+    setCefString(&fn_key, "_nextChunk");
+    const callback = asPtr(c.cef_v8_value_t, suji_obj.get_value_bykey.?(suji_obj, &fn_key)) orelse return false;
+    var data_str: c.cef_string_t = .{};
+    setCefString(&data_str, data);
+    var call_args = [_][*c]c.cef_v8_value_t{
+        c.cef_v8_value_create_int(@intCast(seq_id)),
+        c.cef_v8_value_create_int(idx),
+        c.cef_v8_value_create_int(total),
+        c.cef_v8_value_create_string(&data_str),
+    };
+    if (call_args[0] == null or call_args[1] == null or call_args[2] == null or call_args[3] == null) return false;
+    _ = callback.execute_function.?(callback, suji_obj, call_args.len, &call_args);
+    return true;
+}
+
+fn callSujiComplete(ctx: *c._cef_v8_context_t, seq_id: u32, success: bool) bool {
+    _ = ctx.enter.?(ctx);
+    defer _ = ctx.exit.?(ctx);
+    const global = asPtr(c.cef_v8_value_t, ctx.get_global.?(ctx)) orelse return false;
+    var suji_key: c.cef_string_t = .{};
+    setCefString(&suji_key, "__suji__");
+    const suji_obj = asPtr(c.cef_v8_value_t, global.get_value_bykey.?(global, &suji_key)) orelse return false;
+    var fn_key: c.cef_string_t = .{};
+    setCefString(&fn_key, "_chunkComplete");
+    const callback = asPtr(c.cef_v8_value_t, suji_obj.get_value_bykey.?(suji_obj, &fn_key)) orelse return false;
+    var call_args = [_][*c]c.cef_v8_value_t{
+        c.cef_v8_value_create_int(@intCast(seq_id)),
+        c.cef_v8_value_create_int(if (success) 1 else 0),
+    };
+    if (call_args[0] == null or call_args[1] == null) return false;
     _ = callback.execute_function.?(callback, suji_obj, call_args.len, &call_args);
     return true;
 }


### PR DESCRIPTION
## 원인
고정 스택 버퍼 한계로 큰 IPC 응답이 잘리거나 누락 — 두 경로가 별개.
1. invoke 응답(suji:response) 버퍼가 16KB→64KB 고정이라 천장 존재
2. **실효 병목**: emit 은 CEF 프로세스 메시지가 아니라 `execute_java_script` 로 가는데, `EventBus.emitToJs` 의 js_buf 가 16KB 고정 → 200KB data 는 bufPrint 실패로 이벤트 자체가 누락(화면 빈칸)

## 수정
- **invoke 응답**: `sendInvokeResponse` 를 32KB 청크 분할(`suji:response-chunk`/`-complete`) + 응답 버퍼를 4MB 재사용 힙으로. renderer `handleRendererChunk`/`Complete` + JS `_chunks` 재조립 추가
- **emit**: `emitToJs` 의 js_buf 16KB 고정 → 동적 alloc(allocPrint+dupeZ)

## 검증
- 200KB code 페이로드 IPC 왕복 — 잘림 없이 수신 확인
- 작은 응답 단일 경로 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)