### PR TITLE
feat(platform): macOS-only 네이티브 기능 4종 → Windows/Linux 확장

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,10 +207,13 @@ fn onAllClosed(_: suji.Event) void {
 // suji.tray.createWithIcon("App", "tooltip", "/tmp/tray.png")
 //   / setMenuRaw(id, "...items with submenu/checkbox...") / destroy(id)
 //   / setToolTip(id, tip) (setTooltip Electron 별칭) / getBounds(id) → {x,y,width,height}
-//     (getBounds=macOS NSStatusItem.button window frame, Win/Linux 0 rect)
+//     (getBounds=macOS NSStatusItem.button window frame / Windows Shell_NotifyIconGetRect /
+//      Linux gtk_status_icon_get_geometry(X11; Wayland 0 rect))
 //                                                                       (macOS NSStatusItem / Linux GTK StatusIcon / Windows Shell_NotifyIconW)
 // suji.notification.show("Title", "Body", false) / requestPermission() / close(id)
-//   / removeAll() / removeGroup(groupId)  — groupId=macOS threadIdentifier (Win/Linux false)
+//   / removeAll() / removeGroup(groupId)  — groupId: macOS threadIdentifier(스택 그룹화),
+//     Windows group 추적 후 removeGroup 이 그룹 전체 tray icon 닫음, Linux freedesktop
+//     replaces_id 갱신(근사 — 정직 경계)
 //   NotificationOptions {id?, groupId?} — caller-id + 그룹화. Notification 클래스(JS/Node):
 //   new Notification(opts); await n.show(); n.id (readonly) / n.close()
 //                                       (macOS UNUserNotificationCenter, .app 번들 필수 / Linux D-Bus / Windows Shell_NotifyIcon balloon)
@@ -231,9 +234,11 @@ fn onAllClosed(_: suji.Event) void {
 //   systemDefined 모니터 분기(신규 API 0, 동일 register IPC). ⚠️ 글로벌
 //   수신은 Accessibility(TCC) 필요(헤드리스 미발화 — globalShortcut 동급 경계)
 // suji.screen.getAllDisplays()                — Display 배열 raw JSON (macOS NSScreen / Linux X11 screen)
-//   display 변경 이벤트(macOS, NSApplicationDidChangeScreenParameters 옵저버, count-diff):
+//   display 변경 이벤트(macOS NSApplicationDidChangeScreenParameters / Windows WM_DISPLAYCHANGE /
+//   Linux X11 RandR RRScreenChangeNotify 스레드 — 모두 count-diff):
 //   suji.on("screen:display-added"|"screen:display-removed"|"screen:display-metrics-changed", cb)
-//   → 페이로드 후 getAllDisplays 로 상세 조회. 정직 경계: macOS only, 동시 add+remove 는 metrics
+//   → 페이로드 후 getAllDisplays 로 상세 조회. 정직 경계: 동시 add+remove(수 동일)는 metrics,
+//   Linux 는 libXrandr dlopen(미설치/Wayland 는 no-op)
 // suji.desktopCapturer.getSources("screen,window")  — 화면/창 소스
 //   {id,name,type,x,y,width,height,displayId?} (CGGetActiveDisplayList +
 //   CGWindowListCopyWindowInfo)
@@ -273,9 +278,11 @@ fn onAllClosed(_: suji.Event) void {
 // powerMonitor 이벤트 — 자동 install (macOS NSWorkspace, Linux logind/ScreenSaver DBus,
 //   Windows WM_POWERBROADCAST/WTS), 채널 발신:
 //   `power:suspend` / `power:resume` / `power:lock-screen` / `power:unlock-screen`
-//   + macOS: `power:shutdown`(NSWorkspaceWillPowerOff) / `power:on-battery` /
-//   `power:on-ac`(IOPS run-loop source, AC↔배터리 전환) → suji.on("power:shutdown", cb)
-//   → 다른 SDK도 동일 채널명으로 listen. (shutdown/배터리 이벤트는 macOS 한정)
+//   + `power:shutdown`(macOS NSWorkspaceWillPowerOff / Linux login1 PrepareForShutdown) /
+//   `power:on-battery` / `power:on-ac`(macOS IOPS run-loop / Windows WM_POWERBROADCAST
+//   PBT_APMPOWERSTATUSCHANGE+GetSystemPowerStatus) → suji.on("power:shutdown", cb)
+//   → 다른 SDK도 동일 채널명으로 listen. 정직 경계: Windows shutdown 은 message-only
+//   window 가 WM_ENDSESSION broadcast 미수신이라 미지원, Linux 배터리는 UPower dict 파싱 후속
 // suji.process.run(allocator, suji.io(), &.{ "echo", "hi" })  — std.process.run wrap (백엔드 only)
 //   → RunResult { code, stdout, stderr }, caller가 stdout/stderr free
 // suji.http.fetch(allocator, suji.io(), "https://...", null)   — std.http.Client.fetch wrap

--- a/src/platform/cef_notification.zig
+++ b/src/platform/cef_notification.zig
@@ -68,9 +68,10 @@ pub fn notificationRequestPermission() bool {
 /// 알림 표시. id는 caller-controlled 식별자 (close에 사용). 한도: 64 byte.
 /// title/body는 4KB stack-alloc 한도.
 pub fn notificationShow(id: []const u8, title: []const u8, body: []const u8, silent: bool, group: []const u8) bool {
-    // group(threadIdentifier)은 macOS 전용 — Win/Linux 는 무시(개별 알림으로 표시).
-    if (comptime builtin.os.tag == .windows) return notification_windows.win_notify.show(id, title, body, silent);
-    if (comptime is_linux) return notification_linux.show(id, title, body, silent);
+    // group(suji 확장 = macOS threadIdentifier): macOS=스택 그룹화, Windows=같은 group
+    // tray icon 재사용, Linux=freedesktop replaces_id 갱신(근사 — 정직 경계, 각 backend 주석).
+    if (comptime builtin.os.tag == .windows) return notification_windows.win_notify.show(id, title, body, silent, group);
+    if (comptime is_linux) return notification_linux.show(id, title, body, silent, group);
     if (!comptime is_macos) return false;
     var id_buf: [64]u8 = undefined;
     var t_buf: [4096]u8 = undefined;
@@ -83,9 +84,12 @@ pub fn notificationShow(id: []const u8, title: []const u8, body: []const u8, sil
     return suji_notification_show(id_cstr, t_cstr, b_cstr, if (silent) 1 else 0, g_cstr) != 0;
 }
 
-/// Electron `Notification.removeGroup(groupId)` — threadIdentifier 가 일치하는 표시된 알림 제거.
-/// macOS only(UNUserNotificationCenter threadIdentifier). Win/Linux 는 그룹 개념 미지원 → false.
+/// Electron `Notification.removeGroup(groupId)` — group 이 일치하는 표시된 알림 제거.
+/// macOS: UNUserNotificationCenter threadIdentifier. Windows: 같은 group tray icon NIM_DELETE.
+/// Linux: 같은 group 의 표시 알림 CloseNotification. 미일치/그룹 없으면 false.
 pub fn notificationRemoveGroup(group: []const u8) bool {
+    if (comptime builtin.os.tag == .windows) return notification_windows.win_notify.removeGroup(group);
+    if (comptime is_linux) return notification_linux.removeGroup(group);
     if (!comptime is_macos) return false;
     var g_buf: [512]u8 = undefined;
     const g_cstr = writeCStr(group, &g_buf) orelse return false;

--- a/src/platform/cef_notification_linux.zig
+++ b/src/platform/cef_notification_linux.zig
@@ -17,14 +17,19 @@ pub fn requestPermission() bool {
     return linux_notify.requestPermission();
 }
 
-pub fn show(id: []const u8, title: []const u8, body: []const u8, silent: bool) bool {
+pub fn show(id: []const u8, title: []const u8, body: []const u8, silent: bool, group: []const u8) bool {
     if (comptime !is_linux) return false;
-    return linux_notify.show(id, title, body, silent);
+    return linux_notify.show(id, title, body, silent, group);
 }
 
 pub fn close(id: []const u8) bool {
     if (comptime !is_linux) return false;
     return linux_notify.close(id);
+}
+
+pub fn removeGroup(group: []const u8) bool {
+    if (comptime !is_linux) return false;
+    return linux_notify.removeGroup(group);
 }
 
 const linux_notify = if (is_linux) struct {
@@ -56,6 +61,8 @@ const linux_notify = if (is_linux) struct {
         id_len: usize = 0,
         id: [64]u8 = [_]u8{0} ** 64,
         dbus_id: u32 = 0,
+        group_len: usize = 0,
+        group: [64]u8 = [_]u8{0} ** 64,
     };
     var entries: [64]Entry = [_]Entry{.{}} ** 64;
 
@@ -107,10 +114,20 @@ const linux_notify = if (is_linux) struct {
         return null;
     }
 
-    fn remember(id: []const u8, dbus_id: u32) bool {
+    fn setGroup(entry: *Entry, group: []const u8) void {
+        if (group.len > 0 and group.len <= entry.group.len) {
+            entry.group_len = group.len;
+            @memcpy(entry.group[0..group.len], group);
+        } else {
+            entry.group_len = 0;
+        }
+    }
+
+    fn remember(id: []const u8, dbus_id: u32, group: []const u8) bool {
         if (id.len == 0 or id.len > 63) return false;
         if (findEntry(id)) |entry| {
             entry.dbus_id = dbus_id;
+            setGroup(entry, group);
             return true;
         }
 
@@ -124,7 +141,22 @@ const linux_notify = if (is_linux) struct {
         @memcpy(slot.id[0..id.len], id);
         slot.id[id.len] = 0;
         slot.dbus_id = dbus_id;
+        setGroup(slot, group);
         return true;
+    }
+
+    /// 같은 group 의 마지막으로 알려진 dbus_id (freedesktop replaces_id 로 사용 → 갱신).
+    /// 없으면 0(새 알림). group 미지정(빈) 시 0.
+    fn lastDbusIdForGroup(group: []const u8) u32 {
+        if (group.len == 0 or group.len > 64) return 0;
+        for (&entries) |*entry| {
+            if (entry.used and entry.group_len == group.len and
+                std.mem.eql(u8, entry.group[0..entry.group_len], group))
+            {
+                return entry.dbus_id;
+            }
+        }
+        return 0;
     }
 
     fn makeHints(silent: bool, hint_entry_type: ?*anyopaque) ?*anyopaque {
@@ -155,13 +187,18 @@ const linux_notify = if (is_linux) struct {
         return arr;
     }
 
-    fn show(id: []const u8, title: []const u8, body: []const u8, silent: bool) bool {
+    fn show(id: []const u8, title: []const u8, body: []const u8, silent: bool, group: []const u8) bool {
         var id_buf: [64]u8 = undefined;
         var title_buf: [4096]u8 = undefined;
         var body_buf: [4096]u8 = undefined;
         _ = writeCStr(id, &id_buf) orelse return false;
         const title_z = writeCStr(title, &title_buf) orelse return false;
         const body_z = writeCStr(body, &body_buf) orelse return false;
+
+        // groupId(suji 확장 = macOS threadIdentifier) → freedesktop replaces_id 매핑:
+        // 같은 group 의 이전 알림을 교체(갱신). macOS 의 스택 그룹화와 의미는 다른
+        // 근사(교체) — daemon 이 같은 슬롯에 갱신 표시. 정직 경계.
+        const replaces_id = lastDbusIdForGroup(group);
 
         const hint_entry_type = g_variant_type_new("{sv}") orelse return false;
         defer g_variant_type_free(hint_entry_type);
@@ -184,7 +221,7 @@ const linux_notify = if (is_linux) struct {
             return false;
         };
         n += 1;
-        collected[n] = g_variant_new_uint32(0) orelse {
+        collected[n] = g_variant_new_uint32(replaces_id) orelse {
             cleanupOnFail(&collected, n);
             return false;
         };
@@ -230,12 +267,11 @@ const linux_notify = if (is_linux) struct {
         const child = g_variant_get_child_value(reply, 0) orelse return false;
         defer g_variant_unref(child);
         const dbus_id = g_variant_get_uint32(child);
-        return remember(id, dbus_id);
+        return remember(id, dbus_id, group);
     }
 
-    fn close(id: []const u8) bool {
-        const entry = findEntry(id) orelse return false;
-        const dbus_id = entry.dbus_id;
+    /// CloseNotification(dbus_id) D-Bus 호출. close/removeGroup 공용.
+    fn closeDbusId(dbus_id: u32) bool {
         const child = g_variant_new_uint32(dbus_id) orelse return false;
         const children = [_]?*anyopaque{child};
         const parameters = g_variant_new_tuple(&children, children.len) orelse {
@@ -244,7 +280,28 @@ const linux_notify = if (is_linux) struct {
         };
         const reply = call("CloseNotification", parameters, NOTIFY_TIMEOUT_MS) orelse return false;
         g_variant_unref(reply);
+        return true;
+    }
+
+    fn close(id: []const u8) bool {
+        const entry = findEntry(id) orelse return false;
+        if (!closeDbusId(entry.dbus_id)) return false;
         entry.used = false;
         return true;
+    }
+
+    /// Electron Notification.removeGroup — 같은 group 의 모든 표시 알림 CloseNotification.
+    fn removeGroup(group: []const u8) bool {
+        if (group.len == 0 or group.len > 64) return false;
+        var any = false;
+        for (&entries) |*entry| {
+            if (entry.used and entry.group_len == group.len and
+                std.mem.eql(u8, entry.group[0..entry.group_len], group))
+            {
+                if (closeDbusId(entry.dbus_id)) any = true;
+                entry.* = .{};
+            }
+        }
+        return any;
     }
 } else struct {};

--- a/src/platform/cef_notification_windows.zig
+++ b/src/platform/cef_notification_windows.zig
@@ -17,6 +17,8 @@ pub const win_notify = if (builtin.os.tag == .windows) struct {
         id_len: usize = 0,
         id: [64]u8 = [_]u8{0} ** 64,
         tray_id: u32 = 0,
+        group_len: usize = 0,
+        group: [64]u8 = [_]u8{0} ** 64,
     };
     // 64-slot — Linux notify entries 와 동일 cap. main 스레드(show/close) 와
     // pump 스레드(handleTrayCallback NIN_BALLOONUSERCLICK/TIMEOUT) 가 동시 접근
@@ -31,13 +33,23 @@ pub const win_notify = if (builtin.os.tag == .windows) struct {
         id_map_lock_flag.store(false, .release);
     }
 
-    fn rememberMapping(id: []const u8, tray_id: u32) void {
+    fn storeGroup(m: *MapEntry, group: []const u8) void {
+        if (group.len > 0 and group.len <= m.group.len) {
+            m.group_len = group.len;
+            @memcpy(m.group[0..group.len], group);
+        } else {
+            m.group_len = 0;
+        }
+    }
+
+    fn rememberMapping(id: []const u8, tray_id: u32, group: []const u8) void {
         if (id.len == 0 or id.len > 64) return;
         lockIdMap();
         defer unlockIdMap();
         for (&id_map) |*m| {
             if (m.used and m.id_len == id.len and std.mem.eql(u8, m.id[0..m.id_len], id)) {
                 m.tray_id = tray_id;
+                storeGroup(m, group);
                 return;
             }
         }
@@ -47,6 +59,7 @@ pub const win_notify = if (builtin.os.tag == .windows) struct {
                 m.id_len = id.len;
                 @memcpy(m.id[0..id.len], id);
                 m.tray_id = tray_id;
+                storeGroup(m, group);
                 return;
             }
         }
@@ -99,8 +112,12 @@ pub const win_notify = if (builtin.os.tag == .windows) struct {
 
     /// id 별 tray icon 생성 → balloon (NIM_MODIFY + NIF_INFO). show 후
     /// auto-timeout (10초). close 시 NIM_DELETE.
-    /// caller 가 같은 id 로 여러 번 show 하면 새 icon 추가 (기존 안 지움).
-    pub fn show(id: []const u8, title: []const u8, body: []const u8, silent: bool) bool {
+    /// group(suji 확장 = macOS threadIdentifier): 매핑에 저장만 — removeGroup 이 같은
+    /// group 의 tray icon 들을 한꺼번에 닫는 용도. Shell_NotifyIcon balloon 은 macOS
+    /// 처럼 스택 그룹화가 없고, icon 재사용은 OS auto-timeout(~10s) 후 stale handle
+    /// 위험(NIM_MODIFY 실패)이라 하지 않는다 — 알림마다 새 icon(정직 경계). caller 가
+    /// 같은 id 로 여러 번 show 하면 새 icon 추가 (기존 안 지움).
+    pub fn show(id: []const u8, title: []const u8, body: []const u8, silent: bool, group: []const u8) bool {
         // 빈 tooltip 으로 tray icon 생성 (notification 전용 — 사용자에게 visible 한 icon
         // 짧게 표시 후 destroy 됨, 실제로는 toast UI 가 주로 보임).
         const tray_id = cef_tray.win_tray.createIcon("", "");
@@ -136,7 +153,7 @@ pub const win_notify = if (builtin.os.tag == .windows) struct {
             _ = cef_tray.win_tray.destroyIcon(tray_id);
             return false;
         }
-        rememberMapping(id, tray_id);
+        rememberMapping(id, tray_id, group);
         return true;
     }
 
@@ -144,5 +161,37 @@ pub const win_notify = if (builtin.os.tag == .windows) struct {
     pub fn close(id: []const u8) bool {
         const tray_id = lookupAndForget(id) orelse return false;
         return cef_tray.win_tray.destroyIcon(tray_id);
+    }
+
+    /// Electron Notification.removeGroup — 같은 group 의 tray icon 들을 NIM_DELETE +
+    /// 매핑 정리. tray_id 는 lock 안에서 수집(dedup)하고 destroyIcon(submitSync 경유)은
+    /// lock 밖에서 — idMap lock 과 pump 요청 데드락 회피.
+    pub fn removeGroup(group: []const u8) bool {
+        if (group.len == 0 or group.len > 64) return false;
+        var tids: [64]u32 = undefined;
+        var cnt: usize = 0;
+        lockIdMap();
+        for (&id_map) |*m| {
+            if (m.used and m.group_len == group.len and std.mem.eql(u8, m.group[0..m.group_len], group)) {
+                var dup = false;
+                for (tids[0..cnt]) |t| {
+                    if (t == m.tray_id) {
+                        dup = true;
+                        break;
+                    }
+                }
+                if (!dup and cnt < tids.len) {
+                    tids[cnt] = m.tray_id;
+                    cnt += 1;
+                }
+                m.* = .{};
+            }
+        }
+        unlockIdMap();
+        var any = false;
+        for (tids[0..cnt]) |tid| {
+            if (cef_tray.win_tray.destroyIcon(tid)) any = true;
+        }
+        return any;
     }
 } else struct {};

--- a/src/platform/cef_screen.zig
+++ b/src/platform/cef_screen.zig
@@ -6,6 +6,7 @@ const linux_screen = @import("cef_screen_linux.zig");
 const windows_screen = @import("cef_screen_windows.zig");
 const screen_model = @import("screen_model.zig");
 const cef = @import("cef.zig");
+const win_pump = @import("cef_win_pump.zig").win_pump;
 
 const is_macos = builtin.os.tag == .macos;
 const is_linux = builtin.os.tag == .linux;
@@ -171,8 +172,11 @@ pub const ScreenEmitHandler = *const fn (event: [*:0]const u8) void;
 var g_screen_emit: ?ScreenEmitHandler = null;
 var g_prev_display_count: i32 = -1;
 
-/// 현재 연결된 디스플레이 수 (macOS NSScreen.screens.count). 비-macOS 0.
+/// 현재 연결된 디스플레이 수. macOS NSScreen.screens.count / Windows EnumDisplayMonitors /
+/// Linux RandR XRRGetMonitors(fallback XScreenCount).
 fn screenDisplayCount() i32 {
+    if (comptime builtin.os.tag == .windows) return windows_screen.displayCount();
+    if (comptime is_linux) return linux_screen.displayCount();
     if (!comptime is_macos) return 0;
     const NSScreen = getClass("NSScreen") orelse return 0;
     const screens = msgSend(NSScreen, "screens") orelse return 0;
@@ -195,16 +199,39 @@ fn screenChangedC() callconv(.c) void {
     }
 }
 
-/// screen display 변경 옵저버 설치. macOS only(Linux/Win 후속).
+// Windows screen 변경 콜백 — win_pump WM_DISPLAYCHANGE 가 호출(nativeTheme 패턴 동형).
+pub var g_screen_cb_windows: ?*const fn () callconv(.c) void = null;
+
+/// screen display 변경 옵저버 설치. macOS: NSApplicationDidChangeScreenParameters(screen.m).
+/// Windows: win_pump WM_DISPLAYCHANGE. Linux: X11 RandR RRScreenChangeNotify 스레드.
 /// 정직 경계: count-based diff — 동시 add+remove(수 동일)는 metrics-changed 로 보고.
 pub fn screenInstall(handler: ScreenEmitHandler) void {
-    if (!comptime is_macos) return;
     g_screen_emit = handler;
     g_prev_display_count = screenDisplayCount(); // baseline (옵저버 활성 전).
+    if (comptime builtin.os.tag == .windows) {
+        g_screen_cb_windows = &screenChangedC;
+        win_pump.ensureRunning();
+        return;
+    }
+    if (comptime is_linux) {
+        linux_screen.installChangeListener(&screenChangedC);
+        return;
+    }
+    if (!comptime is_macos) return;
     suji_screen_install(&screenChangedC);
 }
 
 pub fn screenUninstall() void {
+    if (comptime builtin.os.tag == .windows) {
+        g_screen_cb_windows = null;
+        g_screen_emit = null;
+        return;
+    }
+    if (comptime is_linux) {
+        linux_screen.uninstallChangeListener();
+        g_screen_emit = null;
+        return;
+    }
     if (!comptime is_macos) return;
     suji_screen_uninstall();
     g_screen_emit = null;

--- a/src/platform/cef_screen_linux.zig
+++ b/src/platform/cef_screen_linux.zig
@@ -23,6 +23,23 @@ const impl = if (builtin.os.tag == .linux) struct {
         win_y_return: *c_int,
         mask_return: *c_uint,
     ) callconv(.c) c_int;
+    extern "c" fn XNextEvent(display: ?*anyopaque, event: *anyopaque) callconv(.c) c_int;
+    extern "c" fn dlopen(name: ?[*:0]const u8, flag: c_int) callconv(.c) ?*anyopaque;
+    extern "c" fn dlsym(handle: ?*anyopaque, name: [*:0]const u8) callconv(.c) ?*anyopaque;
+
+    // X11 RandR (libXrandr) — dlopen 으로 동적 로드(build 링크 불요, 미설치 시 graceful no-op).
+    const XRRQueryExtensionFn = *const fn (?*anyopaque, *c_int, *c_int) callconv(.c) c_int;
+    const XRRSelectInputFn = *const fn (?*anyopaque, c_ulong, c_int) callconv(.c) void;
+    const XRRGetMonitorsFn = *const fn (?*anyopaque, c_ulong, c_int, *c_int) callconv(.c) ?*anyopaque;
+    const XRRFreeMonitorsFn = *const fn (?*anyopaque) callconv(.c) void;
+    const RR_SCREEN_CHANGE_NOTIFY_MASK: c_int = 1; // RRScreenChangeNotifyMask = 1<<0
+    const RTLD_NOW: c_int = 2;
+
+    var g_rr_lib: ?*anyopaque = null;
+    var g_rr_get_monitors: ?XRRGetMonitorsFn = null;
+    var g_rr_free_monitors: ?XRRFreeMonitorsFn = null;
+    var g_screen_thread_spawned: std.atomic.Value(bool) = .init(false);
+    var g_screen_cb: ?*const fn () callconv(.c) void = null;
 
     fn writeEmptyJsonArray(out_buf: []u8) []const u8 {
         const empty = "[]";
@@ -125,6 +142,83 @@ const impl = if (builtin.os.tag == .linux) struct {
         }
         return screen_model.matchingDisplayIndex(displays[0..len], x, y, w, h);
     }
+
+    // ── display 변경 이벤트 (Electron screen display-added/removed/metrics-changed) ──
+    // X11 RandR RRScreenChangeNotify 를 별도 connection + 스레드에서 select. 깨어나면
+    // 무조건 cef_screen.screenChangedC 콜백 호출 → cef_screen 이 displayCount() count-diff
+    // 로 add/removed/metrics 구분(macOS observer 와 동일 로직 재사용). event-type 디코드
+    // 불요(RRScreenChangeNotifyMask 만 select → 거의 그 이벤트만 옴) → 견고.
+
+    fn ensureRandr(display: ?*anyopaque) bool {
+        if (g_rr_lib == null) {
+            g_rr_lib = dlopen("libXrandr.so.2", RTLD_NOW) orelse return false;
+            g_rr_get_monitors = @ptrCast(dlsym(g_rr_lib, "XRRGetMonitors"));
+            g_rr_free_monitors = @ptrCast(dlsym(g_rr_lib, "XRRFreeMonitors"));
+        }
+        const query: XRRQueryExtensionFn = @ptrCast(dlsym(g_rr_lib, "XRRQueryExtension") orelse return false);
+        var ev_base: c_int = 0;
+        var err_base: c_int = 0;
+        return query(display, &ev_base, &err_base) != 0;
+    }
+
+    /// 활성 모니터 수 (RandR XRRGetMonitors). RandR 1.5 부재 시 XScreenCount fallback.
+    pub fn displayCount() i32 {
+        const display = XOpenDisplay(null) orelse return 0;
+        defer _ = XCloseDisplay(display);
+        return monitorCount(display);
+    }
+
+    fn monitorCount(display: ?*anyopaque) i32 {
+        if (g_rr_get_monitors) |get| {
+            const screen = XDefaultScreen(display);
+            const root = XRootWindow(display, screen);
+            var n: c_int = 0;
+            const mons = get(display, root, 1, &n); // get_active=1
+            if (mons != null) {
+                if (g_rr_free_monitors) |free_fn| free_fn(mons);
+                if (n > 0) return @intCast(n);
+            }
+        }
+        const sc = XScreenCount(display);
+        return if (sc > 0) @intCast(sc) else 0;
+    }
+
+    fn screenThreadMain() void {
+        const display = XOpenDisplay(null) orelse return;
+        defer _ = XCloseDisplay(display);
+        if (!ensureRandr(display)) return; // RandR 미지원 → graceful no-op
+        const select: XRRSelectInputFn = @ptrCast(dlsym(g_rr_lib, "XRRSelectInput") orelse return);
+        const screen = XDefaultScreen(display);
+        const root = XRootWindow(display, screen);
+        select(display, root, RR_SCREEN_CHANGE_NOTIFY_MASK);
+
+        // XEvent union — 64-bit 에서 최대 24 longs(192B). 넉넉히 잡아 stack 디코드 불요.
+        // daemon 루프(앱 수명) — XNextEvent 블로킹은 self-event 로 깨우지 않으므로
+        // uninstall 은 g_screen_cb 만 null 로 게이트한다(thread 는 살아있되 no-op).
+        var ev: [24]c_long = undefined;
+        while (true) {
+            _ = XNextEvent(display, @ptrCast(&ev)); // blocking until RandR notify
+            if (g_screen_cb) |cb| cb();
+        }
+    }
+
+    /// cef_screen.screenChangedC 를 콜백으로 받아 RandR 변경 시 호출. thread 는 **1회만**
+    /// spawn(detached daemon, 앱 수명) — 재install 은 g_screen_cb 만 갱신하고 thread 를
+    /// 재spawn 하지 않는다(XNextEvent 블로킹이라 옛 thread 가 안 죽어 중복 방지). uninstall
+    /// 은 g_screen_cb 만 null 로 게이트(프로세스 종료 시 정리. 정직 경계).
+    pub fn installChangeListener(cb: *const fn () callconv(.c) void) void {
+        g_screen_cb = cb; // 콜백 갱신(재install 포함)
+        if (g_screen_thread_spawned.swap(true, .acq_rel)) return; // thread 는 1회만
+        const t = std.Thread.spawn(.{}, screenThreadMain, .{}) catch {
+            g_screen_thread_spawned.store(false, .release);
+            return;
+        };
+        t.detach();
+    }
+
+    pub fn uninstallChangeListener() void {
+        g_screen_cb = null; // daemon thread 는 유지, 콜백만 게이트
+    }
 } else struct {
     pub fn getAllDisplays(out_buf: []u8) []const u8 {
         const empty = "[]";
@@ -144,9 +238,19 @@ const impl = if (builtin.os.tag == .linux) struct {
     pub fn displayMatching(_: f64, _: f64, _: f64, _: f64) i32 {
         return -1;
     }
+
+    pub fn displayCount() i32 {
+        return 0;
+    }
+
+    pub fn installChangeListener(_: *const fn () callconv(.c) void) void {}
+    pub fn uninstallChangeListener() void {}
 };
 
 pub const getAllDisplays = impl.getAllDisplays;
 pub const cursorPoint = impl.cursorPoint;
 pub const displayNearestPoint = impl.displayNearestPoint;
 pub const displayMatching = impl.displayMatching;
+pub const displayCount = impl.displayCount;
+pub const installChangeListener = impl.installChangeListener;
+pub const uninstallChangeListener = impl.uninstallChangeListener;

--- a/src/platform/cef_screen_windows.zig
+++ b/src/platform/cef_screen_windows.zig
@@ -78,6 +78,21 @@ const impl = if (builtin.os.tag == .windows) struct {
         return .{ @floatFromInt(p.x), @floatFromInt(p.y) };
     }
 
+    /// 연결된 모니터 수 (EnumDisplayMonitors). screen 변경 이벤트의 count-diff 용.
+    pub fn displayCount() i32 {
+        const CountCtx = struct { n: i32 = 0 };
+        const proc = struct {
+            fn cb(_: ?*anyopaque, _: ?*anyopaque, _: *RECT, lp: isize) callconv(.winapi) i32 {
+                const ctx: *CountCtx = @ptrFromInt(@as(usize, @intCast(lp)));
+                ctx.n += 1;
+                return 1;
+            }
+        }.cb;
+        var ctx: CountCtx = .{};
+        _ = EnumDisplayMonitors(null, null, &proc, @intCast(@intFromPtr(&ctx)));
+        return ctx.n;
+    }
+
     pub fn displayNearestPoint(x: f64, y: f64) i32 {
         const p: POINT = .{ .x = @intFromFloat(x), .y = @intFromFloat(y) };
         // macOS `screenGetDisplayNearestPoint` 는 contained-only (못 찾으면 -1).
@@ -152,9 +167,14 @@ const impl = if (builtin.os.tag == .windows) struct {
     pub fn displayMatching(_: f64, _: f64, _: f64, _: f64) i32 {
         return -1;
     }
+
+    pub fn displayCount() i32 {
+        return 0;
+    }
 };
 
 pub const getAllDisplays = impl.getAllDisplays;
 pub const cursorPoint = impl.cursorPoint;
 pub const displayNearestPoint = impl.displayNearestPoint;
 pub const displayMatching = impl.displayMatching;
+pub const displayCount = impl.displayCount;

--- a/src/platform/cef_tray.zig
+++ b/src/platform/cef_tray.zig
@@ -178,12 +178,18 @@ pub fn setTrayTooltip(tray_id: u32, tooltip: []const u8) bool {
     return true;
 }
 
-/// Electron `tray.getBounds()` — 트레이 아이콘 화면 좌표 rect. macOS: NSStatusItem.button.
-/// window.frame 을 **top-left origin** 으로 변환(Electron/getMacWindowBounds 동일 — Cocoa
-/// bottom-left → top-left: y = screenH - frame.y - frame.height). 미존재/비-macOS 는 0 rect.
-/// 정직 경계: macOS only(Win/Linux 는 0 — Shell_NotifyIconGetRect/GTK geometry 후속).
+/// Electron `tray.getBounds()` — 트레이 아이콘 화면 좌표 rect (top-left origin).
+/// macOS: NSStatusItem.button.window.frame 을 Cocoa bottom-left → top-left 변환
+/// (y = screenH - frame.y - frame.height). Windows: Shell_NotifyIconGetRect.
+/// Linux: gtk_status_icon_get_geometry(X11). 미존재/실패/Wayland 는 0 rect.
+fn boundsToNSRect(b: tray_types.Bounds) cef.NSRect {
+    return .{ .x = b.x, .y = b.y, .width = b.width, .height = b.height };
+}
+
 pub fn trayGetBounds(tray_id: u32) cef.NSRect {
     const empty = cef.NSRect{ .x = 0, .y = 0, .width = 0, .height = 0 };
+    if (comptime builtin.os.tag == .windows) return boundsToNSRect(win_tray.getBounds(tray_id) orelse return empty);
+    if (comptime is_linux) return boundsToNSRect(cef_tray_linux.getBounds(tray_id) orelse return empty);
     if (!comptime is_macos) return empty;
     if (!g_trays_initialized) return empty;
     const entry = g_trays.get(tray_id) orelse return empty;

--- a/src/platform/cef_tray_linux.zig
+++ b/src/platform/cef_tray_linux.zig
@@ -40,6 +40,11 @@ pub fn destroy(tray_id: u32) bool {
     return linux_tray.destroy(tray_id);
 }
 
+pub fn getBounds(tray_id: u32) ?tray_types.Bounds {
+    if (!comptime is_linux) return null;
+    return linux_tray.getBounds(tray_id);
+}
+
 const linux_tray = if (is_linux) struct {
     const MAX_TRAYS: usize = 16;
     const MAX_MENU_ITEMS: usize = 64;
@@ -99,6 +104,10 @@ const linux_tray = if (is_linux) struct {
         connect_flags: c_int,
     ) callconv(.c) usize;
     extern "c" fn g_object_unref(object: ?*anyopaque) callconv(.c) void;
+
+    // tray.getBounds() — GdkRectangle{x,y,width,height} (i32), screen-space top-left.
+    const GdkRectangle = extern struct { x: c_int = 0, y: c_int = 0, width: c_int = 0, height: c_int = 0 };
+    extern "c" fn gtk_status_icon_get_geometry(status_icon: ?*anyopaque, screen: ?*?*anyopaque, area: *GdkRectangle, orientation: ?*c_int) callconv(.c) c_int;
 
     fn gtkAvailable() bool {
         return suji_gtk_init_check() != 0;
@@ -280,6 +289,21 @@ const linux_tray = if (is_linux) struct {
         gtk_widget_set_sensitive(menu_item, if (enabled) 1 else 0);
         _ = g_signal_connect_data(menu_item, "activate", @ptrCast(&menuItemActivateC), cb, null, 0);
         gtk_menu_shell_append(menu, menu_item);
+    }
+
+    /// tray.getBounds() — gtk_status_icon_get_geometry 로 X11 트레이 아이콘 화면 rect.
+    /// GdkRectangle 은 이미 top-left origin → 좌표 변환 불요. 실패/Wayland 는 null
+    /// (gtk_status_icon_get_geometry 가 FALSE 반환 — X11 전용, 정직 경계).
+    fn getBounds(tray_id: u32) ?tray_types.Bounds {
+        const entry = findEntry(tray_id) orelse return null;
+        var area: GdkRectangle = .{};
+        if (gtk_status_icon_get_geometry(entry.status_icon, null, &area, null) == 0) return null;
+        return .{
+            .x = @floatFromInt(area.x),
+            .y = @floatFromInt(area.y),
+            .width = @floatFromInt(area.width),
+            .height = @floatFromInt(area.height),
+        };
     }
 
     fn destroy(tray_id: u32) bool {

--- a/src/platform/cef_tray_types.zig
+++ b/src/platform/cef_tray_types.zig
@@ -1,5 +1,9 @@
 //! Shared Tray API types.
 
+/// tray.getBounds() 결과 — top-left origin 화면 좌표 rect (cef.NSRect 동형).
+/// 플랫폼 backend(Windows/Linux)가 cef 순환 import 없이 반환하는 공용 타입.
+pub const Bounds = struct { x: f64, y: f64, width: f64, height: f64 };
+
 pub const TrayMenuItem = union(enum) {
     item: struct {
         label: []const u8,

--- a/src/platform/cef_tray_windows.zig
+++ b/src/platform/cef_tray_windows.zig
@@ -38,6 +38,16 @@ pub const win_tray = if (builtin.os.tag == .windows) struct {
     extern "user32" fn LoadIconW(hInstance: ?*anyopaque, lpIconName: usize) callconv(.winapi) ?*anyopaque;
     const IDI_APPLICATION: usize = 32512;
 
+    // tray.getBounds() — Shell_NotifyIconGetRect(NOTIFYICONIDENTIFIER, RECT*).
+    const RECT = extern struct { left: i32 = 0, top: i32 = 0, right: i32 = 0, bottom: i32 = 0 };
+    const NOTIFYICONIDENTIFIER = extern struct {
+        cbSize: u32 = 0,
+        hWnd: ?*anyopaque = null,
+        uID: u32 = 0,
+        guidItem: [16]u8 = std.mem.zeroes([16]u8),
+    };
+    extern "shell32" fn Shell_NotifyIconGetRect(identifier: *const NOTIFYICONIDENTIFIER, iconLocation: *RECT) callconv(.winapi) i32;
+
     /// id 별 entry — pump hwnd 가 모든 콜백을 받으므로 hwnd 동일. hmenu 는
     /// 옵션(setMenu 호출 후 set, destroyIcon/setMenu rebuild 시 DestroyMenu).
     pub const Entry = struct {
@@ -119,6 +129,29 @@ pub const win_tray = if (builtin.os.tag == .windows) struct {
             }
         }
         return false;
+    }
+
+    /// tray.getBounds() — Shell_NotifyIconGetRect 로 taskbar 아이콘 화면 rect 조회.
+    /// RECT(left/top/right/bottom) → top-left origin {x,y,w,h}. 미존재/실패 시 null.
+    /// (read-only system query — pump proxy 불요, main 스레드 직접 호출 안전.)
+    pub fn getBounds(tray_id: u32) ?tray_types.Bounds {
+        for (&entries) |*e| {
+            if (e.used and e.id == tray_id) {
+                var idf: NOTIFYICONIDENTIFIER = .{};
+                idf.cbSize = @sizeOf(NOTIFYICONIDENTIFIER);
+                idf.hWnd = e.hwnd;
+                idf.uID = tray_id;
+                var rect: RECT = .{};
+                if (Shell_NotifyIconGetRect(&idf, &rect) != 0) return null; // S_OK == 0
+                return .{
+                    .x = @floatFromInt(rect.left),
+                    .y = @floatFromInt(rect.top),
+                    .width = @floatFromInt(rect.right - rect.left),
+                    .height = @floatFromInt(rect.bottom - rect.top),
+                };
+            }
+        }
+        return null;
     }
 
     /// caller (main thread) 가 호출 → pump 스레드로 proxy. pump executeReq 가

--- a/src/platform/cef_win_pump.zig
+++ b/src/platform/cef_win_pump.zig
@@ -12,6 +12,7 @@ const builtin = @import("builtin");
 pub const win_pump = if (builtin.os.tag == .windows) struct {
     const cef_global_shortcut = @import("cef_global_shortcut.zig");
     const cef_native_theme = @import("cef_native_theme.zig");
+    const cef_screen = @import("cef_screen.zig");
     const notification_state = @import("cef_notification_state.zig");
     const notification_windows = @import("cef_notification_windows.zig");
     const cef_tray = @import("cef_tray.zig");
@@ -23,6 +24,7 @@ pub const win_pump = if (builtin.os.tag == .windows) struct {
     const WM_TRAY: u32 = 0x0400 + 1; // WM_USER + 1
     const WM_COMMAND: u32 = 0x0111;
     const WM_SETTINGCHANGE: u32 = 0x001A;
+    const WM_DISPLAYCHANGE: u32 = 0x007E;
     const WM_LBUTTONUP: u32 = 0x0202;
     const WM_RBUTTONUP: u32 = 0x0205;
     const WM_LBUTTONDBLCLK: u32 = 0x0203;
@@ -194,6 +196,12 @@ pub const win_pump = if (builtin.os.tag == .windows) struct {
                         }
                     }
                 }
+                return 0;
+            },
+            WM_DISPLAYCHANGE => {
+                // 모니터 추가/제거/해상도 변경 — cef_screen 이 displayCount count-diff 로
+                // add/removed/metrics 구분(WM_SETTINGCHANGE 와 동일 broadcast 메커니즘).
+                if (cef_screen.g_screen_cb_windows) |cb| cb();
                 return 0;
             },
             else => return DefWindowProcW(hwnd, msg, wparam, lparam),

--- a/src/platform/power_monitor_linux.c
+++ b/src/platform/power_monitor_linux.c
@@ -3,9 +3,13 @@
 // Runtime sources:
 //   - org.freedesktop.login1.Manager.PrepareForSleep(bool) on the system bus
 //     true -> suspend, false -> resume
+//   - org.freedesktop.login1.Manager.PrepareForShutdown(bool) -> shutdown (start=true)
 //   - org.freedesktop.ScreenSaver / org.gnome.ScreenSaver ActiveChanged(bool)
 //     true -> lock-screen, false -> unlock-screen
 //   - org.freedesktop.login1.Session Lock/Unlock as an additional lock source
+//
+// on-battery/on-ac(macOS 패리티)는 UPower PropertiesChanged a{sv} dict 파싱이 필요해
+// (현재 boolean-only D-Bus 헬퍼로는 불가) 정직 경계로 미지원 — 후속.
 //
 // libdbus is loaded with dlopen so the core keeps building on systems that only
 // have the runtime library available, and gracefully becomes a no-op otherwise.
@@ -161,6 +165,10 @@ static void process_message(SujiDbus *d, DBusMessage *msg) {
     if (d->message_is_signal(msg, "org.freedesktop.login1.Manager", "PrepareForSleep")) {
         int sleeping = 0;
         if (get_bool_arg(d, msg, &sleeping)) emit_event(sleeping ? "suspend" : "resume");
+    } else if (d->message_is_signal(msg, "org.freedesktop.login1.Manager", "PrepareForShutdown")) {
+        // start=true 일 때만 — 종료가 시작되는 시점(macOS power:shutdown 패리티).
+        int shutting = 0;
+        if (get_bool_arg(d, msg, &shutting) && shutting) emit_event("shutdown");
     } else if (d->message_is_signal(msg, "org.freedesktop.ScreenSaver", "ActiveChanged") ||
                d->message_is_signal(msg, "org.gnome.ScreenSaver", "ActiveChanged")) {
         int active = 0;
@@ -204,6 +212,9 @@ static void *power_thread_main(void *unused) {
     add_match(&d, system,
         "type='signal',interface='org.freedesktop.login1.Manager',"
         "member='PrepareForSleep',path='/org/freedesktop/login1'");
+    add_match(&d, system,
+        "type='signal',interface='org.freedesktop.login1.Manager',"
+        "member='PrepareForShutdown',path='/org/freedesktop/login1'");
     add_match(&d, system,
         "type='signal',interface='org.freedesktop.login1.Session',member='Lock'");
     add_match(&d, system,

--- a/src/platform/power_monitor_win.c
+++ b/src/platform/power_monitor_win.c
@@ -3,8 +3,13 @@
 // A message-only window receives:
 //   - WM_POWERBROADCAST/PBT_APMSUSPEND -> suspend
 //   - WM_POWERBROADCAST/PBT_APMRESUMEAUTOMATIC or PBT_APMRESUMESUSPEND -> resume
+//   - WM_POWERBROADCAST/PBT_APMPOWERSTATUSCHANGE -> on-battery / on-ac (GetSystemPowerStatus)
 //   - WM_WTSSESSION_CHANGE/WTS_SESSION_LOCK -> lock-screen
 //   - WM_WTSSESSION_CHANGE/WTS_SESSION_UNLOCK -> unlock-screen
+//
+// shutdown 이벤트(macOS power:shutdown 패리티)는 message-only window 가
+// WM_QUERYENDSESSION/WM_ENDSESSION broadcast 를 수신하지 못해(top-level window 필요)
+// 정직 경계로 미지원 — 기존 power monitor 의 message-only 설계를 깨지 않기 위함.
 
 #if defined(_WIN32)
 
@@ -35,6 +40,15 @@ static LRESULT CALLBACK suji_power_wndproc(HWND hwnd, UINT msg, WPARAM wparam, L
             }
             if (wparam == PBT_APMRESUMEAUTOMATIC || wparam == PBT_APMRESUMESUSPEND) {
                 emit_event("resume");
+                return TRUE;
+            }
+            if (wparam == PBT_APMPOWERSTATUSCHANGE) {
+                SYSTEM_POWER_STATUS sps;
+                if (GetSystemPowerStatus(&sps)) {
+                    // ACLineStatus: 0=offline(배터리), 1=online(AC), 255=unknown.
+                    if (sps.ACLineStatus == 0) emit_event("on-battery");
+                    else if (sps.ACLineStatus == 1) emit_event("on-ac");
+                }
                 return TRUE;
             }
             break;


### PR DESCRIPTION
## 요약

백로그 정리 작업의 **PR 1 (플랫폼 확장)** — macOS만 구현돼 있던 네이티브 기능 4종을 Windows/Linux로 확장.

| 기능 | macOS | Windows | Linux |
|------|-------|---------|-------|
| **tray.getBounds()** | NSStatusItem.button frame | `Shell_NotifyIconGetRect` | `gtk_status_icon_get_geometry`(X11) |
| **screen display 이벤트** | NSApplicationDidChangeScreenParameters | `WM_DISPLAYCHANGE`(win_pump) | X11 RandR `RRScreenChangeNotify` 스레드 |
| **notification.groupId** | threadIdentifier(스택) | group 추적 후 removeGroup 일괄 닫기 | freedesktop `replaces_id` 갱신 |
| **powerMonitor** | shutdown/배터리 | 배터리(`PBT_APMPOWERSTATUSCHANGE`) | shutdown(`PrepareForShutdown`) |

- screen count-diff 로직은 `cef_screen.screenChangedC`로 3-OS 공유, Linux RandR은 `libXrandr` dlopen(미설치/Wayland no-op).
- notification.groupId는 macOS threadIdentifier와 의미가 다른 **근사**(Windows=그룹 일괄 닫기, Linux=교체 갱신).

## 정직 경계 (사용자 합의)

- **menu icon/accelerator**: Linux엔 application menu(`setApplicationMenu` macOS only) 자체가 없어 확장 대상 없음 → 스킵.
- **Windows shutdown**: message-only window가 `WM_ENDSESSION` broadcast 미수신(top-level window 필요) → 미지원.
- **Linux 배터리(on-battery/on-ac)**: UPower `a{sv}` dict 파싱 필요(현재 boolean-only D-Bus 헬퍼로 불가) → 후속.

## 검증

- host build (macOS) + Windows/Linux **cross-compile 강제참조**(메모리 규칙: comptime 분기 prune 회피)
- `zig build test` — 952/954 pass (2 skipped)
- `/simplify` + `/code-review max` 반영: Windows notification은 icon 재사용 대신 group 추적만(OS auto-timeout stale handle 회피), Linux RandR 스레드는 1회만 spawn(재install 중복 thread 방지)
- ⚠️ 실 디바이스 검증은 천장(이 머신 macOS) — Windows/Linux 런타임 동작은 CI/실환경 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)