### PR TITLE
feat(session): setPermissionRequestHandler 에 camera/mic(media-access) 통합

### DIFF
--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -3058,21 +3058,25 @@ pub mod session {
     /// 렌더러(웹 콘텐츠) 권한 요청 정보 — `set_permission_request_handler` 핸들러 인자.
     #[derive(Debug, Clone)]
     pub struct PermissionRequest {
-        /// 응답 매칭용 CEF prompt id.
+        /// 응답 매칭용 CEF prompt id. getUserMedia(media) 요청은 0.
         pub permission_id: u64,
         /// 요청 origin (file:// 페이지는 빈 문자열 가능).
         pub origin: String,
-        /// 요청된 권한 이름 (예: ["geolocation"]).
+        /// 요청된 권한 이름 (예: ["geolocation"], ["media"]).
         pub permissions: Vec<String>,
+        /// getUserMedia 요청 시 요청된 미디어 타입 (["audio"]/["video"]). 비-media 는 빈 Vec.
+        pub media_types: Vec<String>,
     }
 
     /// Electron `session.setPermissionRequestHandler(handler)` 동등. 렌더러가 geolocation/
     /// notifications/clipboard 등 권한을 요청하면 `handler` 가 호출돼 `true`(허용)/`false`(거부)
-    /// 를 반환한다. 한 번 등록(앱 수명). 정직 경계: camera/mic(getUserMedia)는 별도 CEF
-    /// 경로라 미포함 — on_show_permission_prompt 권한군 대상.
+    /// 를 반환한다. 한 번 등록(앱 수명). camera/mic(getUserMedia)도 이 핸들러가 받는다
+    /// (permissions=["media"], media_types=["audio"]/["video"]; true 면 요청된 타입 grant).
+    /// 정직 경계: media 실 grant 검증은 헤드리스 e2e 불가.
     ///
-    /// `session:permission-request` 이벤트를 구독해 결정 후 `session_permission_response`
-    /// 로 응답한다(JS/Node SDK 와 동일 wire). 핸들러는 leak 되어 앱 수명 동안 유지.
+    /// `session:permission-request`/`session:media-access-request` 를 구독해 결정 후
+    /// `session_permission_response`/`session_media_access_response` 로 응답한다(JS/Node SDK
+    /// 와 동일 wire). 핸들러는 leak 되어 앱 수명 동안 유지(두 trampoline 이 공유).
     pub fn set_permission_request_handler<F>(handler: F)
     where
         F: Fn(PermissionRequest) -> bool + Send + Sync + 'static,
@@ -3080,7 +3084,9 @@ pub mod session {
         type BoxedHandler = Box<dyn Fn(PermissionRequest) -> bool + Send + Sync>;
         let boxed: Box<BoxedHandler> = Box::new(Box::new(handler));
         let arg = Box::into_raw(boxed) as *mut std::os::raw::c_void;
+        // 같은 leaked handler 를 두 이벤트에 등록(빌림만 — arg 소유권 미이전, 앱 수명 유지).
         crate::on("session:permission-request", permission_trampoline, arg);
+        crate::on("session:media-access-request", media_trampoline, arg);
         invoke(
             "__core__",
             r#"{"cmd":"session_set_permission_handler","enabled":true}"#,
@@ -3131,6 +3137,7 @@ pub mod session {
                 permission_id,
                 origin,
                 permissions,
+                media_types: Vec::new(),
             })
         }))
         .unwrap_or(false);
@@ -3138,6 +3145,56 @@ pub mod session {
             "cmd": "session_permission_response",
             "permissionId": permission_id,
             "granted": granted,
+        })
+        .to_string();
+        invoke("__core__", &resp);
+    }
+
+    /// getUserMedia(camera/mic) 트램폴린 — session:media-access-request → handler →
+    /// session_media_access_response. permission_trampoline 과 같은 leaked handler 공유.
+    extern "C" fn media_trampoline(
+        _channel: *const std::os::raw::c_char,
+        data: *const std::os::raw::c_char,
+        arg: *mut std::os::raw::c_void,
+    ) {
+        if arg.is_null() || data.is_null() {
+            return;
+        }
+        let handler =
+            unsafe { &*(arg as *const Box<dyn Fn(PermissionRequest) -> bool + Send + Sync>) };
+        let payload = unsafe { std::ffi::CStr::from_ptr(data) }
+            .to_str()
+            .unwrap_or("");
+        let v: serde_json::Value = serde_json::from_str(payload).unwrap_or(serde_json::Value::Null);
+        let media_request_id = v.get("mediaRequestId").and_then(|x| x.as_u64()).unwrap_or(0);
+        let origin = v
+            .get("origin")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_string();
+        let audio = v.get("audio").and_then(|x| x.as_bool()).unwrap_or(false);
+        let video = v.get("video").and_then(|x| x.as_bool()).unwrap_or(false);
+        let mut media_types: Vec<String> = Vec::new();
+        if audio {
+            media_types.push("audio".to_string());
+        }
+        if video {
+            media_types.push("video".to_string());
+        }
+        let granted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            handler(PermissionRequest {
+                permission_id: 0,
+                origin,
+                permissions: vec!["media".to_string()],
+                media_types,
+            })
+        }))
+        .unwrap_or(false);
+        let resp = json!({
+            "cmd": "session_media_access_response",
+            "mediaRequestId": media_request_id,
+            "audio": granted && audio,
+            "video": granted && video,
         })
         .to_string();
         invoke("__core__", &resp);

--- a/packages/suji-js/dist/index.d.ts
+++ b/packages/suji-js/dist/index.d.ts
@@ -1106,12 +1106,15 @@ export interface CookieFilter {
 }
 /** 렌더러(웹 콘텐츠)가 권한을 요청할 때 핸들러가 받는 정보. */
 export interface PermissionRequestDetails {
-    /** 응답 매칭용 CEF prompt id. */
+    /** 응답 매칭용 CEF prompt id. getUserMedia(media) 요청은 -1(별도 경로). */
     permissionId: number;
     /** 요청 origin (예: "https://example.com"). file:// 페이지는 빈 문자열일 수 있음. */
     origin: string;
-    /** 요청된 권한 이름 배열 (예: ["geolocation"], ["notifications","clipboard"]). */
+    /** 요청된 권한 이름 배열 (예: ["geolocation"], ["notifications","clipboard"], ["media"]). */
     permissions: string[];
+    /** getUserMedia(camera/mic) 요청 시 요청된 미디어 타입 (["audio"], ["video"], 또는 둘 다).
+     *  permissions 에 "media" 가 포함된 경우에만 존재. handler 가 true 면 요청된 타입 모두 grant. */
+    mediaTypes?: string[];
 }
 /** 권한 요청 핸들러 — true 반환 시 허용(grant), false 반환 시 거부(deny).
  *  async 가능(커스텀 UI 등). 한 번에 1 핸들러만 active. */
@@ -1152,8 +1155,9 @@ export declare const session: {
      * `handler` 가 throw 하거나 비-bool 반환 시 **거부**(deny, 안전 기본). `null` 전달 시
      * 핸들러 해제(이후 CEF 기본 처리). 한 번에 1 핸들러만 active — 재등록 시 이전 detach.
      *
-     * 정직 경계: camera/mic(getUserMedia)는 별도 CEF 경로(media access)라 이 핸들러
-     * 미포함 — on_show_permission_prompt 가 덮는 권한군 대상.
+     * camera/mic(getUserMedia)도 이 핸들러가 받는다(permission "media", details.mediaTypes
+     * 에 ["audio"]/["video"]). handler 가 true 면 요청된 미디어 타입을 모두 grant, false 면
+     * deny. 정직 경계: media 실 grant 검증은 실 카메라+권한 다이얼로그라 헤드리스 e2e 불가.
      */
     setPermissionRequestHandler(handler: PermissionRequestHandler | null): Promise<void>;
     /**

--- a/packages/suji-js/dist/index.js
+++ b/packages/suji-js/dist/index.js
@@ -1470,8 +1470,9 @@ export const session = {
      * `handler` 가 throw 하거나 비-bool 반환 시 **거부**(deny, 안전 기본). `null` 전달 시
      * 핸들러 해제(이후 CEF 기본 처리). 한 번에 1 핸들러만 active — 재등록 시 이전 detach.
      *
-     * 정직 경계: camera/mic(getUserMedia)는 별도 CEF 경로(media access)라 이 핸들러
-     * 미포함 — on_show_permission_prompt 가 덮는 권한군 대상.
+     * camera/mic(getUserMedia)도 이 핸들러가 받는다(permission "media", details.mediaTypes
+     * 에 ["audio"]/["video"]). handler 가 true 면 요청된 미디어 타입을 모두 grant, false 면
+     * deny. 정직 경계: media 실 grant 검증은 실 카메라+권한 다이얼로그라 헤드리스 e2e 불가.
      */
     async setPermissionRequestHandler(handler) {
         if (activePermissionOff) {
@@ -1482,7 +1483,7 @@ export const session = {
             await coreCall({ cmd: "session_set_permission_handler", enabled: false });
             return;
         }
-        activePermissionOff = on("session:permission-request", (payload) => {
+        const offPrompt = on("session:permission-request", (payload) => {
             let ev;
             try {
                 ev = typeof payload === "string" ? JSON.parse(payload) : payload;
@@ -1508,6 +1509,48 @@ export const session = {
                 .then((granted) => respond(granted === true))
                 .catch(() => respond(false));
         });
+        // getUserMedia(camera/mic) — 별도 CEF 경로지만 같은 handler 로 통합(Electron 패리티).
+        const offMedia = on("session:media-access-request", (payload) => {
+            let raw;
+            try {
+                raw = typeof payload === "string" ? JSON.parse(payload) : payload;
+            }
+            catch {
+                return;
+            }
+            const mediaTypes = [];
+            if (raw.audio)
+                mediaTypes.push("audio");
+            if (raw.video)
+                mediaTypes.push("video");
+            const ev = {
+                permissionId: -1, // media 는 prompt id 없음
+                origin: raw.origin ?? "",
+                permissions: ["media"],
+                mediaTypes,
+            };
+            let settled = false;
+            const respond = (granted) => {
+                if (settled)
+                    return;
+                settled = true;
+                void coreCall({
+                    cmd: "session_media_access_response",
+                    mediaRequestId: raw.mediaRequestId,
+                    // granted 면 요청된 타입만 grant(allowed 는 requested 의 부분집합이어야 — CEF 계약).
+                    audio: granted && raw.audio === true,
+                    video: granted && raw.video === true,
+                });
+            };
+            Promise.resolve()
+                .then(() => handler(ev))
+                .then((granted) => respond(granted === true))
+                .catch(() => respond(false));
+        });
+        activePermissionOff = () => {
+            offPrompt();
+            offMedia();
+        };
         await coreCall({ cmd: "session_set_permission_handler", enabled: true });
     },
     /**

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -2139,12 +2139,15 @@ export interface CookieFilter {
 
 /** 렌더러(웹 콘텐츠)가 권한을 요청할 때 핸들러가 받는 정보. */
 export interface PermissionRequestDetails {
-  /** 응답 매칭용 CEF prompt id. */
+  /** 응답 매칭용 CEF prompt id. getUserMedia(media) 요청은 -1(별도 경로). */
   permissionId: number;
   /** 요청 origin (예: "https://example.com"). file:// 페이지는 빈 문자열일 수 있음. */
   origin: string;
-  /** 요청된 권한 이름 배열 (예: ["geolocation"], ["notifications","clipboard"]). */
+  /** 요청된 권한 이름 배열 (예: ["geolocation"], ["notifications","clipboard"], ["media"]). */
   permissions: string[];
+  /** getUserMedia(camera/mic) 요청 시 요청된 미디어 타입 (["audio"], ["video"], 또는 둘 다).
+   *  permissions 에 "media" 가 포함된 경우에만 존재. handler 가 true 면 요청된 타입 모두 grant. */
+  mediaTypes?: string[];
 }
 
 /** 권한 요청 핸들러 — true 반환 시 허용(grant), false 반환 시 거부(deny).
@@ -2215,8 +2218,9 @@ export const session = {
    * `handler` 가 throw 하거나 비-bool 반환 시 **거부**(deny, 안전 기본). `null` 전달 시
    * 핸들러 해제(이후 CEF 기본 처리). 한 번에 1 핸들러만 active — 재등록 시 이전 detach.
    *
-   * 정직 경계: camera/mic(getUserMedia)는 별도 CEF 경로(media access)라 이 핸들러
-   * 미포함 — on_show_permission_prompt 가 덮는 권한군 대상.
+   * camera/mic(getUserMedia)도 이 핸들러가 받는다(permission "media", details.mediaTypes
+   * 에 ["audio"]/["video"]). handler 가 true 면 요청된 미디어 타입을 모두 grant, false 면
+   * deny. 정직 경계: media 실 grant 검증은 실 카메라+권한 다이얼로그라 헤드리스 e2e 불가.
    */
   async setPermissionRequestHandler(
     handler: PermissionRequestHandler | null,
@@ -2229,7 +2233,7 @@ export const session = {
       await coreCall({ cmd: "session_set_permission_handler", enabled: false });
       return;
     }
-    activePermissionOff = on("session:permission-request", (payload) => {
+    const offPrompt = on("session:permission-request", (payload) => {
       let ev: PermissionRequestDetails;
       try {
         ev = typeof payload === "string" ? JSON.parse(payload) : payload;
@@ -2253,6 +2257,44 @@ export const session = {
         .then((granted) => respond(granted === true))
         .catch(() => respond(false));
     });
+    // getUserMedia(camera/mic) — 별도 CEF 경로지만 같은 handler 로 통합(Electron 패리티).
+    const offMedia = on("session:media-access-request", (payload) => {
+      let raw: { mediaRequestId: number; origin: string; audio: boolean; video: boolean };
+      try {
+        raw = typeof payload === "string" ? JSON.parse(payload) : payload;
+      } catch {
+        return;
+      }
+      const mediaTypes: string[] = [];
+      if (raw.audio) mediaTypes.push("audio");
+      if (raw.video) mediaTypes.push("video");
+      const ev: PermissionRequestDetails = {
+        permissionId: -1, // media 는 prompt id 없음
+        origin: raw.origin ?? "",
+        permissions: ["media"],
+        mediaTypes,
+      };
+      let settled = false;
+      const respond = (granted: boolean) => {
+        if (settled) return;
+        settled = true;
+        void coreCall({
+          cmd: "session_media_access_response",
+          mediaRequestId: raw.mediaRequestId,
+          // granted 면 요청된 타입만 grant(allowed 는 requested 의 부분집합이어야 — CEF 계약).
+          audio: granted && raw.audio === true,
+          video: granted && raw.video === true,
+        });
+      };
+      Promise.resolve()
+        .then(() => handler(ev))
+        .then((granted) => respond(granted === true))
+        .catch(() => respond(false));
+    });
+    activePermissionOff = () => {
+      offPrompt();
+      offMedia();
+    };
     await coreCall({ cmd: "session_set_permission_handler", enabled: true });
   },
 

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -2604,12 +2604,14 @@ export interface CookieFilter {
 
 /** 렌더러(웹 콘텐츠)가 권한을 요청할 때 핸들러가 받는 정보. */
 export interface PermissionRequestDetails {
-  /** 응답 매칭용 CEF prompt id. */
+  /** 응답 매칭용 CEF prompt id. getUserMedia(media) 요청은 -1. */
   permissionId: number;
   /** 요청 origin. file:// 페이지는 빈 문자열일 수 있음. */
   origin: string;
-  /** 요청된 권한 이름 배열 (예: ["geolocation"]). */
+  /** 요청된 권한 이름 배열 (예: ["geolocation"], ["media"]). */
   permissions: string[];
+  /** getUserMedia 요청 시 요청된 미디어 타입 (["audio"]/["video"]). "media" 포함 시에만 존재. */
+  mediaTypes?: string[];
 }
 
 /** 권한 요청 핸들러 — true 반환 시 허용, false 반환 시 거부. async 가능. 1 핸들러만 active. */
@@ -2670,7 +2672,8 @@ export const session = {
    * Electron `session.setPermissionRequestHandler(handler)` 동등. 렌더러가 geolocation/
    * notifications/clipboard 등 권한을 요청하면 handler 가 호출돼 true(허용)/false(거부) 결정.
    * async 가능(타임아웃 없음). throw/비-bool → 거부(안전 기본). null → 핸들러 해제.
-   * 1 핸들러만 active. 정직 경계: camera/mic(getUserMedia)는 별도 CEF 경로라 미포함.
+   * 1 핸들러만 active. camera/mic(getUserMedia)도 이 핸들러가 받는다(permission "media",
+   * details.mediaTypes). 정직 경계: media 실 grant 검증은 헤드리스 e2e 불가.
    */
   async setPermissionRequestHandler(
     handler: PermissionRequestHandler | null,
@@ -2683,7 +2686,7 @@ export const session = {
       await invoke('__core__', { cmd: 'session_set_permission_handler', enabled: false });
       return;
     }
-    activePermissionOff = on<PermissionRequestDetails>(
+    const offPrompt = on<PermissionRequestDetails>(
       'session:permission-request',
       (ev) => {
         let settled = false;
@@ -2702,6 +2705,40 @@ export const session = {
           .catch(() => respond(false));
       },
     );
+    // getUserMedia(camera/mic) — 별도 CEF 경로지만 같은 handler 로 통합(Electron 패리티).
+    const offMedia = on<{ mediaRequestId: number; origin: string; audio: boolean; video: boolean }>(
+      'session:media-access-request',
+      (raw) => {
+        const mediaTypes: string[] = [];
+        if (raw.audio) mediaTypes.push('audio');
+        if (raw.video) mediaTypes.push('video');
+        const ev: PermissionRequestDetails = {
+          permissionId: -1,
+          origin: raw.origin ?? '',
+          permissions: ['media'],
+          mediaTypes,
+        };
+        let settled = false;
+        const respond = (granted: boolean) => {
+          if (settled) return;
+          settled = true;
+          void invoke('__core__', {
+            cmd: 'session_media_access_response',
+            mediaRequestId: raw.mediaRequestId,
+            audio: granted && raw.audio === true,
+            video: granted && raw.video === true,
+          });
+        };
+        Promise.resolve()
+          .then(() => handler(ev))
+          .then((granted) => respond(granted === true))
+          .catch(() => respond(false));
+      },
+    );
+    activePermissionOff = () => {
+      offPrompt();
+      offMedia();
+    };
     await invoke('__core__', { cmd: 'session_set_permission_handler', enabled: true });
   },
 

--- a/sdks/suji-go/session/session.go
+++ b/sdks/suji-go/session/session.go
@@ -46,32 +46,43 @@ func SetProxy(mode, proxyRules, proxyBypassRules, pacScript string) string {
 // PermissionRequest is the renderer (web content) permission request passed to
 // the handler registered via SetPermissionRequestHandler.
 type PermissionRequest struct {
-	// PermissionID matches the response to the CEF prompt.
+	// PermissionID matches the response to the CEF prompt. getUserMedia(media) → 0.
 	PermissionID uint64 `json:"permissionId"`
 	// Origin of the requester (may be "" for file:// pages).
 	Origin string `json:"origin"`
-	// Permissions requested, e.g. ["geolocation"].
+	// Permissions requested, e.g. ["geolocation"], ["media"].
 	Permissions []string `json:"permissions"`
+	// MediaTypes requested for getUserMedia (["audio"]/["video"]); empty for non-media.
+	MediaTypes []string `json:"mediaTypes,omitempty"`
 }
 
-// activePermissionListener holds the current `session:permission-request`
-// listener id so re-registration detaches the previous one (1 handler active,
-// matching JS/Node). 0 = none.
-var activePermissionListener uint64
+// activePermissionListener / activeMediaListener hold the current
+// `session:permission-request` / `session:media-access-request` listener ids so
+// re-registration detaches the previous ones (1 handler active, matching JS/Node).
+var (
+	activePermissionListener uint64
+	activeMediaListener      uint64
+)
 
 // SetPermissionRequestHandler registers a permission handler (Electron
 // `session.setPermissionRequestHandler`). When the renderer requests a
 // permission (geolocation/notifications/clipboard/...), handler is called and
-// returns true to grant, false to deny. Pass nil to clear (CEF default after).
-// Re-registering detaches the previous handler (1 handler active).
+// returns true to grant, false to deny. camera/mic (getUserMedia) is also routed
+// here (Permissions=["media"], MediaTypes=["audio"]/["video"]; true grants the
+// requested types). Pass nil to clear. Re-registering detaches the previous handler.
 //
-// Subscribes `session:permission-request` and responds via
-// `session_permission_response` (same wire as JS/Node/Rust). Honest boundary:
-// camera/mic (getUserMedia) is a separate CEF media-access path — not covered.
+// Subscribes `session:permission-request` + `session:media-access-request` and
+// responds via `session_permission_response` / `session_media_access_response`
+// (same wire as JS/Node/Rust). Honest boundary: media real grant needs a real
+// camera + permission dialog → not headless-e2e verifiable.
 func SetPermissionRequestHandler(handler func(PermissionRequest) bool) {
 	if activePermissionListener != 0 {
 		suji.Off(activePermissionListener)
 		activePermissionListener = 0
+	}
+	if activeMediaListener != 0 {
+		suji.Off(activeMediaListener)
+		activeMediaListener = 0
 	}
 	if handler == nil {
 		suji.Invoke("__core__", `{"cmd":"session_set_permission_handler","enabled":false}`)
@@ -87,6 +98,37 @@ func SetPermissionRequestHandler(handler func(PermissionRequest) bool) {
 			"cmd":          "session_permission_response",
 			"permissionId": d.PermissionID,
 			"granted":      granted,
+		})
+		suji.Invoke("__core__", string(resp))
+	})
+	activeMediaListener = suji.On("session:media-access-request", func(_ string, data string) {
+		var raw struct {
+			MediaRequestID uint64 `json:"mediaRequestId"`
+			Origin         string `json:"origin"`
+			Audio          bool   `json:"audio"`
+			Video          bool   `json:"video"`
+		}
+		if err := json.Unmarshal([]byte(data), &raw); err != nil {
+			return
+		}
+		var mediaTypes []string
+		if raw.Audio {
+			mediaTypes = append(mediaTypes, "audio")
+		}
+		if raw.Video {
+			mediaTypes = append(mediaTypes, "video")
+		}
+		granted := handler(PermissionRequest{
+			PermissionID: 0,
+			Origin:       raw.Origin,
+			Permissions:  []string{"media"},
+			MediaTypes:   mediaTypes,
+		})
+		resp, _ := json.Marshal(map[string]any{
+			"cmd":            "session_media_access_response",
+			"mediaRequestId": raw.MediaRequestID,
+			"audio":          granted && raw.Audio,
+			"video":          granted && raw.Video,
 		})
 		suji.Invoke("__core__", string(resp))
 	})

--- a/src/main.zig
+++ b/src/main.zig
@@ -2733,6 +2733,15 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         const ok = if (id_i < 0) false else cef.permissionRespond(@intCast(id_i), granted);
         return std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"session_permission_response\",\"success\":{}}}", .{ok}) catch null;
     }
+    // getUserMedia(camera/mic) 권한 — session:media-access-request 이벤트에 대한 app 응답.
+    // 같은 setPermissionRequestHandler 등록(g_have_handler) 흐름. audio/video 각각 grant.
+    if (std.mem.eql(u8, cmd, "session_media_access_response")) {
+        const id_i = util.extractJsonInt(req_clean, "mediaRequestId") orelse -1;
+        const audio = util.extractJsonBool(req_clean, "audio") orelse false;
+        const video = util.extractJsonBool(req_clean, "video") orelse false;
+        const ok = if (id_i < 0) false else cef.mediaAccessRespond(@intCast(id_i), audio, video);
+        return std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"session_media_access_response\",\"success\":{}}}", .{ok}) catch null;
+    }
     if (std.mem.eql(u8, cmd, "session_clear_storage_data")) {
         var origin_buf: [2048]u8 = undefined;
         var types_buf: [256]u8 = undefined;

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -136,6 +136,7 @@ pub const PermissionEmitFn = cef_public_api.PermissionEmitFn;
 pub const setPermissionEmitHandler = cef_public_api.setPermissionEmitHandler;
 pub const permissionSetHandlerEnabled = cef_public_api.permissionSetHandlerEnabled;
 pub const permissionRespond = cef_public_api.permissionRespond;
+pub const mediaAccessRespond = cef_public_api.mediaAccessRespond;
 pub const getPermissionHandler = cef_public_api.getPermissionHandler;
 pub const DownloadEmitFn = cef_public_api.DownloadEmitFn;
 pub const setDownloadEmitHandler = cef_public_api.setDownloadEmitHandler;

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -337,6 +337,7 @@ pub const PermissionEmitFn = cef_session_permission.PermissionEmitFn;
 pub const setPermissionEmitHandler = cef_session_permission.setPermissionEmitHandler;
 pub const permissionSetHandlerEnabled = cef_session_permission.permissionSetHandlerEnabled;
 pub const permissionRespond = cef_session_permission.permissionRespond;
+pub const mediaAccessRespond = cef_session_permission.mediaAccessRespond;
 pub const getPermissionHandler = cef_session_permission.getPermissionHandler;
 
 // session.setDownloadPath + session:will-download — cef_download_handler.zig

--- a/src/platform/cef_session_permission.zig
+++ b/src/platform/cef_session_permission.zig
@@ -20,10 +20,14 @@
 //! cont 는 UI 스레드 컨텍스트가 안전 — 프론트 invoke(UI 스레드)는 직접 cont, 백엔드
 //! 워커 스레드는 UI 로 task post(cef_session_proxy SetProxyTask 동형).
 //!
-//! 범위(정직): getUserMedia(camera/mic)는 별도 콜백 `on_request_media_access_permission`
-//! 경로라 이 모듈 미포함(헤드리스 CI 트리거 곤란 → e2e 불가). on_show_permission_prompt
-//! 가 덮는 권한군(geolocation/notifications/clipboard/midi/idle/pointer-lock/window-
-//! management/file-system 등)이 대상. media 는 후속.
+//! getUserMedia(camera/mic)는 별도 콜백 `on_request_media_access_permission` 경로 —
+//! 같은 cef_permission_handler_t 에 슬롯 추가(별도 handler 불필요). prompt 와 callback
+//! 타입(cef_media_access_callback_t)·cont 인자(allowed bitmask)가 달라 media pending pool +
+//! `session:media-access-request {mediaRequestId,origin,audio,video}` 이벤트 +
+//! `mediaAccessRespond(id,audio,video)` 로 분리. 정직 경계: ① camera/mic 실 grant 는 실
+//! 카메라+권한 다이얼로그라 헤드리스 e2e 불가(빌드+wire 가드가 천장) ② media 는 prompt 의
+//! on_dismiss 같은 외부-종료 알림이 CEF 에 없어 navigation/close 중 미응답 callback 정리가
+//! prompt 보다 약함(앱이 respond 보장 필요).
 
 const std = @import("std");
 const util = @import("util");
@@ -94,6 +98,49 @@ fn pendingTake(id: u64) ?*c.cef_permission_prompt_callback_t {
             g_pending[i] = g_pending[g_pending_count - 1];
             g_pending_count -= 1;
             return cb;
+        }
+    }
+    return null;
+}
+
+// ---- pending media-access callbacks (getUserMedia camera/mic) ----
+// on_request_media_access_permission 은 prompt_id 가 없으므로 자체 media id 부여.
+// g_lock 공유(prompt/media 직렬화 — 둘 다 UI 스레드 콜백 + 임의 스레드 respond).
+const PendingMedia = struct {
+    id: u64,
+    callback: *c.cef_media_access_callback_t,
+    // 요청된 permission mask — cont(allowed) 시 allowed ⊆ requested 클램프용(CEF 계약:
+    // "allowed_permissions must match required_permissions"). SDK 도 보장하지만 core 방어.
+    requested: u32,
+};
+
+var g_pending_media: [MAX_PENDING]PendingMedia = undefined;
+var g_pending_media_count: usize = 0;
+var g_next_media_id: std.atomic.Value(u64) = .init(1);
+
+fn nextMediaId() u64 {
+    return g_next_media_id.fetchAdd(1, .acq_rel);
+}
+
+fn pendingPushMedia(id: u64, callback: *c.cef_media_access_callback_t, requested: u32) bool {
+    pendingLock();
+    defer pendingUnlock();
+    if (g_pending_media_count >= MAX_PENDING) return false;
+    g_pending_media[g_pending_media_count] = .{ .id = id, .callback = callback, .requested = requested };
+    g_pending_media_count += 1;
+    return true;
+}
+
+fn pendingTakeMedia(id: u64) ?PendingMedia {
+    pendingLock();
+    defer pendingUnlock();
+    var i: usize = 0;
+    while (i < g_pending_media_count) : (i += 1) {
+        if (g_pending_media[i].id == id) {
+            const pm = g_pending_media[i];
+            g_pending_media[i] = g_pending_media[g_pending_media_count - 1];
+            g_pending_media_count -= 1;
+            return pm;
         }
     }
     return null;
@@ -172,6 +219,21 @@ fn emitRequest(prompt_id: u64, origin: []const u8, mask: c_uint) void {
     emit("session:permission-request", payload.ptr);
 }
 
+fn emitMediaRequest(media_id: u64, origin: []const u8, mask: u32) void {
+    const emit = g_emit_fn orelse return;
+    const audio = (mask & c.CEF_MEDIA_PERMISSION_DEVICE_AUDIO_CAPTURE) != 0;
+    const video = (mask & c.CEF_MEDIA_PERMISSION_DEVICE_VIDEO_CAPTURE) != 0;
+    var origin_esc: [1024]u8 = undefined;
+    const oe = util.escapeJsonStrFull(origin, &origin_esc) orelse return;
+    var payload_buf: [1536]u8 = undefined;
+    const payload = std.fmt.bufPrintZ(
+        &payload_buf,
+        "{{\"mediaRequestId\":{d},\"origin\":\"{s}\",\"audio\":{},\"video\":{}}}",
+        .{ media_id, origin_esc[0..oe], audio, video },
+    ) catch return;
+    emit("session:media-access-request", payload.ptr);
+}
+
 // ---- CEF cef_permission_handler_t 싱글톤(cef_request_handler 동형) ----
 var g_handler: c.cef_permission_handler_t = undefined;
 var g_handler_initialized: bool = false;
@@ -182,6 +244,7 @@ fn ensureHandler() void {
     initBaseRefCounted(&g_handler.base);
     g_handler.on_show_permission_prompt = &onShowPermissionPrompt;
     g_handler.on_dismiss_permission_prompt = &onDismissPermissionPrompt;
+    g_handler.on_request_media_access_permission = &onRequestMediaAccess;
     g_handler_initialized = true;
 }
 
@@ -209,6 +272,35 @@ fn onShowPermissionPrompt(
     var origin_buf: [1024]u8 = undefined;
     const origin = if (requesting_origin != null) cefStringToUtf8(requesting_origin, &origin_buf) else "";
     emitRequest(prompt_id, origin, requested_permissions);
+    return 1; // async — app 응답까지 hold
+}
+
+/// getUserMedia(camera/mic) 권한 요청 — CEF `on_request_media_access_permission`(UI 스레드).
+/// prompt 경로(on_show_permission_prompt)와 별개 콜백·callback 타입(cef_media_access_callback_t).
+/// 자체 media id 부여 → `session:media-access-request {mediaRequestId,origin,audio,video}` 발신
+/// + 1(async) → app 이 `session_media_access_response {mediaRequestId,audio,video}` 로 응답하면
+/// cont(allowed bitmask). 미등록(g_have_handler=false) 시 0 반환 → CEF 기본(Alloy=deny).
+/// 정직 경계: media 는 prompt 의 on_dismiss 같은 외부-종료 알림이 CEF 에 없어, navigation/
+/// close 중 미응답 callback 은 hold 채로 남는다(앱이 respond 보장 필요 — prompt 보다 약한 정리).
+fn onRequestMediaAccess(
+    _: ?*c._cef_permission_handler_t,
+    _: ?*c._cef_browser_t,
+    _: ?*c._cef_frame_t,
+    requesting_origin: [*c]const c.cef_string_t,
+    requested_permissions: u32,
+    callback: ?*c._cef_media_access_callback_t,
+) callconv(.c) c_int {
+    if (!g_have_handler.load(.acquire)) return 0; // 미등록 → CEF 기본 처리(deny)
+    const cb = callback orelse return 0;
+    if (cb.base.add_ref) |add_ref| _ = add_ref(&cb.base);
+    const id = nextMediaId();
+    if (!pendingPushMedia(id, cb, requested_permissions)) {
+        if (cb.base.release) |rel| _ = rel(&cb.base);
+        return 0; // pool 가득 → 기본 처리 fallback
+    }
+    var origin_buf: [1024]u8 = undefined;
+    const origin = if (requesting_origin != null) cefStringToUtf8(requesting_origin, &origin_buf) else "";
+    emitMediaRequest(id, origin, requested_permissions);
     return 1; // async — app 응답까지 hold
 }
 
@@ -305,6 +397,85 @@ pub fn permissionRespond(prompt_id: u64, granted: bool) bool {
         return false;
     }
     return true; // posted — UI 스레드에서 곧 cont
+}
+
+// ---- media-access cont(allowed bitmask) — prompt 와 callback 타입/cont 인자가 달라 별도 ----
+fn contMediaAndRelease(cb: *c.cef_media_access_callback_t, allowed: u32) void {
+    if (cb.cont) |fp| fp(cb, allowed);
+    if (cb.base.release) |rel| _ = rel(&cb.base);
+}
+
+const MediaRespondTask = struct {
+    task: c.cef_task_t = undefined,
+    allocator: std.mem.Allocator,
+    ref_count: std.atomic.Value(u32) = .init(1),
+    callback: *c.cef_media_access_callback_t,
+    allowed: u32,
+};
+
+fn mediaTaskFromBase(base: ?*c.cef_base_ref_counted_t) ?*MediaRespondTask {
+    return @ptrCast(@alignCast(base orelse return null));
+}
+fn mediaTaskFromSelf(self: ?*c._cef_task_t) ?*MediaRespondTask {
+    return @ptrCast(@alignCast(self orelse return null));
+}
+fn mediaTaskAddRef(base: ?*c.cef_base_ref_counted_t) callconv(.c) void {
+    const t = mediaTaskFromBase(base) orelse return;
+    _ = t.ref_count.fetchAdd(1, .acq_rel);
+}
+fn mediaTaskRelease(base: ?*c.cef_base_ref_counted_t) callconv(.c) i32 {
+    const t = mediaTaskFromBase(base) orelse return 0;
+    if (t.ref_count.fetchSub(1, .acq_rel) != 1) return 0;
+    t.allocator.destroy(t);
+    return 1;
+}
+fn mediaTaskHasOneRef(base: ?*c.cef_base_ref_counted_t) callconv(.c) i32 {
+    const t = mediaTaskFromBase(base) orelse return 0;
+    return if (t.ref_count.load(.acquire) == 1) 1 else 0;
+}
+fn mediaTaskHasAtLeastOneRef(base: ?*c.cef_base_ref_counted_t) callconv(.c) i32 {
+    const t = mediaTaskFromBase(base) orelse return 0;
+    return if (t.ref_count.load(.acquire) >= 1) 1 else 0;
+}
+fn mediaTaskExecute(self: ?*c._cef_task_t) callconv(.c) void {
+    const t = mediaTaskFromSelf(self) orelse return;
+    contMediaAndRelease(t.callback, t.allowed);
+}
+
+/// Electron media-access 결정 적용. mediaRequestId 로 hold callback 을 찾아 cont(allowed
+/// bitmask). audio/video 각각 grant. 없는 id(이미 resolve) → false. UI 스레드면 즉시 cont,
+/// 백엔드 워커면 UI 로 post(permissionRespond 동형).
+pub fn mediaAccessRespond(media_id: u64, audio_allowed: bool, video_allowed: bool) bool {
+    const pm = pendingTakeMedia(media_id) orelse return false;
+    const cb = pm.callback;
+    var allowed: u32 = 0;
+    if (audio_allowed) allowed |= c.CEF_MEDIA_PERMISSION_DEVICE_AUDIO_CAPTURE;
+    if (video_allowed) allowed |= c.CEF_MEDIA_PERMISSION_DEVICE_VIDEO_CAPTURE;
+    allowed &= pm.requested; // CEF 계약: allowed ⊆ requested (요청 안 된 타입 grant 방지)
+
+    if (c.cef_currently_on(c.TID_UI) == 1) {
+        contMediaAndRelease(cb, allowed);
+        return true;
+    }
+
+    const t = c_allocator.create(MediaRespondTask) catch {
+        if (cb.base.release) |rel| _ = rel(&cb.base);
+        return false;
+    };
+    t.* = .{ .allocator = c_allocator, .callback = cb, .allowed = allowed };
+    @memset(std.mem.asBytes(&t.task), 0);
+    t.task.base.size = @sizeOf(c.cef_task_t);
+    t.task.base.add_ref = &mediaTaskAddRef;
+    t.task.base.release = &mediaTaskRelease;
+    t.task.base.has_one_ref = &mediaTaskHasOneRef;
+    t.task.base.has_at_least_one_ref = &mediaTaskHasAtLeastOneRef;
+    t.task.execute = &mediaTaskExecute;
+    if (c.cef_post_task(c.TID_UI, &t.task) != 1) {
+        _ = mediaTaskRelease(&t.task.base);
+        if (cb.base.release) |rel| _ = rel(&cb.base);
+        return false;
+    }
+    return true;
 }
 
 // 검증: 이 모듈은 cef.zig(@cImport CEF) 의존이라 standalone unit-test 모듈이 될 수 없다


### PR DESCRIPTION
## 요약

백로그 정리 **PR 3 (camera/mic media-access)** — getUserMedia(camera/mic) 권한을 기존 `setPermissionRequestHandler` 에 통합. PR1·PR2 머지 후 main 기준.

핵심: 별도 handler 파일 불필요 — 같은 `cef_permission_handler_t` 에 `on_request_media_access_permission` 콜백 슬롯만 추가.

- **코어** (`cef_session_permission.zig`): media pending pool(자체 id — CEF media 콜백은 prompt_id 부재) + `session:media-access-request {mediaRequestId,origin,audio,video}` 이벤트 + `mediaAccessRespond` off-UI task(permissionRespond 동형). `allowed &= requested` 클램프(CEF 계약 "allowed ⊆ requested").
- **전 SDK**: `setPermissionRequestHandler` 단일 핸들러가 media 도 받음(`permissions=["media"]`, `details.mediaTypes`). JS/Node 두 구독 합성 off, Rust 공유 leaked handler + `media_trampoline`, Go media listener. **Electron 패리티**(단일 핸들러, true → 요청된 미디어 타입 grant).

## 검증

- `zig build`(host) + `tsc`(JS/Node) + `cargo check`(Rust) + `go build`(Go) + `zig build test` 952/954
- **permission(geolocation) prompt e2e 137 pass** — `setPermissionRequestHandler` 리팩터(합성 off + media 구독)가 기존 prompt 경로 회귀 없음(handler 등록→cont(DENY)→PERMISSION_DENIED 왕복)
- `/simplify`(allowed⊆requested core 클램프) + `/code-review max`(필드명/ref-count/clamp 정상; 지적된 leak/race 는 기존 leak-by-design·문서화된 정직경계)

## 정직 경계

- camera/mic 실 grant 는 실 카메라 + 권한 다이얼로그라 **헤드리스 e2e 불가**(빌드+wire 가드가 천장; prompt e2e 가 공유 핸들러 wire 를 간접 커버)
- media 는 CEF 에 prompt 의 `on_dismiss` 같은 외부-종료 알림이 없어 navigation/close 중 미응답 callback 정리가 prompt 보다 약함(MAX_PENDING 64 bounded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)