### PR TITLE
feat(app): app.getFileIcon — 파일 시스템 아이콘 PNG (Electron parity)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,8 @@ fn onAllClosed(_: suji.Event) void {
 // suji.nativeImage.getSize("/path/to/img.png")  — {width, height} (NSImage)
 //   / toPng(path) / toJpeg(path, quality)        — base64 인코딩 (raw ~8KB)
 //   / isEmpty(path) / isTemplateImage(path)       — 빈 이미지/template 여부 (macOS NSImage)
+//   / fileIcon(path)                              — 파일 시스템 아이콘 PNG base64
+//     (Electron app.getFileIcon, macOS NSWorkspace.iconForFile 32x32, raw ~8KB)
 // suji.screen.getCursorScreenPoint()      — 플랫폼 native cursor point
 // suji.dialog.messageBoxSimple("info", "안녕", &.{ "OK", "Cancel" })   — 응답 raw JSON
 // suji.dialog.showOpenDialog("\"properties\":[\"openFile\"]")          — raw fields
@@ -545,6 +547,8 @@ suji.platform                                                // "macos" | "linux
 // await app.setBadgeCount(5) / app.getBadgeCount()                        (Electron app badge count)
 //   macOS dock label / Linux libunity / Windows taskbar overlay best-effort
 // await app.getPath("userData" | "home" | "documents" | ...)              — Electron app.getPath
+// await app.getFileIcon("/path/to/file")  — 파일 시스템 아이콘 PNG base64
+//   (Electron app.getFileIcon, macOS NSWorkspace.iconForFile 32x32; Win/Linux 빈 문자열)
 // await app.setAsDefaultProtocolClient("myapp") / isDefaultProtocolClient("myapp")
 //   / removeAsDefaultProtocolClient("myapp")     — Electron 기본 URL scheme 핸들러 (전 5 SDK)
 //   macOS Launch Services. scheme 등록 자체는 suji.json app.deepLinkSchemes(CFBundleURLTypes)가

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -3263,6 +3263,12 @@ pub fn get_path(name: &str) -> Option<String> {
     invoke("__core__", &get_path_request(name))
 }
 
+/// Electron `app.getFileIcon(path)` — 파일 시스템 아이콘 PNG base64
+/// (macOS NSWorkspace.iconForFile). raw JSON: `{"data":"<base64>"}`.
+pub fn get_file_icon(path: &str) -> Option<String> {
+    invoke("__core__", &serde_json::json!({ "cmd": "app_get_file_icon", "path": path }).to_string())
+}
+
 /// suji.json `app.name` 반환. raw JSON: `{"name":"..."}`.
 pub fn get_name() -> Option<String> {
     invoke("__core__", r#"{"cmd":"app_get_name"}"#)

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -3178,6 +3178,13 @@ export const app = {
     return r.path;
   },
 
+  /** Electron `app.getFileIcon(path)` 동등. 파일의 시스템 아이콘 PNG base64
+   *  (macOS NSWorkspace.iconForFile). raw ~8KB 한도. 파일 없거나 Win/Linux는 빈 문자열. */
+  async getFileIcon(path: string): Promise<string> {
+    const r = await coreCall<{ data: string }>({ cmd: "app_get_file_icon", path });
+    return r.data ?? "";
+  },
+
   /** dock 아이콘 바운스 시작. 0이면 no-op (앱이 이미 active). 아니면 cancel용 id. */
   async requestUserAttention(critical = true): Promise<number> {
     const r = await coreCall<{ id: number }>({ cmd: "app_attention_request", critical });

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -3013,6 +3013,13 @@ export const app = {
     return r.path;
   },
 
+  /** Electron `app.getFileIcon(path)` 동등. 파일 시스템 아이콘 PNG base64
+   *  (macOS NSWorkspace.iconForFile). 파일 없거나 Win/Linux는 빈 문자열. */
+  async getFileIcon(path: string): Promise<string> {
+    const r = await invoke<{ data: string }>('__core__', { cmd: 'app_get_file_icon', path });
+    return r.data ?? '';
+  },
+
   /** dock 아이콘 바운스 시작. 0이면 no-op (앱이 이미 active). 아니면 cancel용 id. */
   async requestUserAttention(critical = true): Promise<number> {
     const r = await invoke<{ id: number }>('__core__', { cmd: 'app_attention_request', critical });

--- a/sdks/suji-go/app/app.go
+++ b/sdks/suji-go/app/app.go
@@ -20,6 +20,13 @@ func buildGetPathRequest(name string) string {
 	return fmt.Sprintf(`{"cmd":"app_get_path","name":"%s"}`, jsonesc.Full(name))
 }
 
+// GetFileIcon returns the file's system icon as PNG base64 (Electron
+// `app.getFileIcon`, macOS NSWorkspace.iconForFile). Response: `{"data":"<base64>"}`.
+// 파일 없거나 Win/Linux는 빈 문자열.
+func GetFileIcon(path string) string {
+	return suji.Invoke("__core__", fmt.Sprintf(`{"cmd":"app_get_file_icon","path":"%s"}`, jsonesc.Full(path)))
+}
+
 // GetName returns suji.json app.name. raw JSON: `{"name":"..."}`.
 func GetName() string {
 	return suji.Invoke("__core__", `{"cmd":"app_get_name"}`)

--- a/src/core/app.zig
+++ b/src/core/app.zig
@@ -1160,6 +1160,16 @@ pub const nativeImage = struct {
         const fields = std.fmt.bufPrint(&fields_buf, "\"path\":\"{s}\"", .{p_buf[0..p_n]}) catch return null;
         return coreCmd("native_image_is_template", fields);
     }
+
+    /// 파일의 시스템 아이콘 PNG base64(Electron `app.getFileIcon`, macOS
+    /// NSWorkspace.iconForFile). 응답: `{"data":"<base64>"}`.
+    pub fn fileIcon(path: []const u8) ?[]const u8 {
+        var p_buf: [4096]u8 = undefined;
+        const p_n = util.escapeJsonStrFull(path, &p_buf) orelse return null;
+        var fields_buf: [4200]u8 = undefined;
+        const fields = std.fmt.bufPrint(&fields_buf, "\"path\":\"{s}\"", .{p_buf[0..p_n]}) catch return null;
+        return coreCmd("app_get_file_icon", fields);
+    }
 };
 
 pub const nativeTheme = struct {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2680,6 +2680,16 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         const bytes = cef.nativeImageEncodeFromPath(path_buf[0..path_n], file_type, quality, &raw_buf);
         return respondBase64Data(response_buf, cmd, bytes);
     }
+    // Electron app.getFileIcon(path) — 파일의 시스템 아이콘 PNG(base64). NSWorkspace
+    // iconForFile(아이콘은 file type 기반이라 파일 내용 유출 아님 → fs gate 불요).
+    if (std.mem.eql(u8, cmd, "app_get_file_icon")) {
+        const raw_path = util.extractJsonString(req_clean, "path") orelse "";
+        var path_buf: [util.MAX_RESPONSE]u8 = undefined;
+        const path_n = util.unescapeJsonStr(raw_path, &path_buf) orelse return respondBase64Data(response_buf, cmd, &.{});
+        var raw_buf: [8 * 1024]u8 = undefined;
+        const bytes = cef.nativeImageFileIconPng(path_buf[0..path_n], &raw_buf);
+        return respondBase64Data(response_buf, cmd, bytes);
+    }
     if (std.mem.eql(u8, cmd, "app_exit")) {
         cef.quit();
         return std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"app_exit\",\"success\":true}}", .{}) catch null;

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -121,6 +121,7 @@ pub const securityScopedAccessStart = cef_public_api.securityScopedAccessStart;
 pub const securityScopedAccessStop = cef_public_api.securityScopedAccessStop;
 pub const NSBitmapImageFileType = cef_public_api.NSBitmapImageFileType;
 pub const nativeImageEncodeFromPath = cef_public_api.nativeImageEncodeFromPath;
+pub const nativeImageFileIconPng = cef_public_api.nativeImageFileIconPng;
 pub const nativeImageGetSize = cef_public_api.nativeImageGetSize;
 pub const nativeImageIsEmpty = cef_public_api.nativeImageIsEmpty;
 pub const nativeImageIsTemplate = cef_public_api.nativeImageIsTemplate;

--- a/src/platform/cef_native_image.zig
+++ b/src/platform/cef_native_image.zig
@@ -21,6 +21,25 @@ pub const NSBitmapImageFileType = enum(c_long) {
     jpeg2000 = 5,
 };
 
+/// NSBitmapImageRep → 인코딩된 bytes(`representationUsingType:properties:`). out_buf
+/// 부족 시 빈 slice. nativeImageEncodeFromPath/nativeImageFileIconPng 공용 tail.
+/// rep 수명은 호출자 소유(EncodeFromPath=imageRepWithData autoreleased, fileIcon=
+/// alloc+defer release) — 헬퍼는 rep 을 retain/release 하지 않는다.
+fn encodeRepToBuf(rep: ?*anyopaque, file_type: NSBitmapImageFileType, props: ?*anyopaque, out_buf: []u8) []const u8 {
+    const repr_fn: *const fn (?*anyopaque, ?*anyopaque, c_long, ?*anyopaque) callconv(.c) ?*anyopaque =
+        @ptrCast(&objc.objc_msgSend);
+    const out_data = repr_fn(rep, @ptrCast(objc.sel_registerName("representationUsingType:properties:")), @intFromEnum(file_type), props) orelse
+        return out_buf[0..0];
+    const len_fn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) usize = @ptrCast(&objc.objc_msgSend);
+    const len = len_fn(out_data, @ptrCast(objc.sel_registerName("length")));
+    if (len > out_buf.len) return out_buf[0..0];
+    const bytes_fn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) [*c]const u8 = @ptrCast(&objc.objc_msgSend);
+    const bytes = bytes_fn(out_data, @ptrCast(objc.sel_registerName("bytes")));
+    if (bytes == null) return out_buf[0..0];
+    @memcpy(out_buf[0..len], bytes[0..len]);
+    return out_buf[0..len];
+}
+
 /// 이미지 파일 → 인코딩된 bytes (Electron `nativeImage.createFromPath(path).toPNG()` /
 /// `.toJPEG(quality)`). 파일 bytes → NSBitmapImageRep `imageRepWithData:` 한 번 디코드 후
 /// `representationUsingType:properties:`로 재인코딩. NSImage 우회 시 TIFF 중간 단계 발생해서 회피.
@@ -57,23 +76,36 @@ pub fn nativeImageEncodeFromPath(
         props = dict_fn(NSDict, @ptrCast(objc.sel_registerName("dictionaryWithObject:forKey:")), factor, factor_key);
     }
 
-    const repr_fn: *const fn (?*anyopaque, ?*anyopaque, c_long, ?*anyopaque) callconv(.c) ?*anyopaque =
-        @ptrCast(&objc.objc_msgSend);
-    const out_data = repr_fn(
-        rep,
-        @ptrCast(objc.sel_registerName("representationUsingType:properties:")),
-        @intFromEnum(file_type),
-        props,
-    ) orelse return out_buf[0..0];
+    return encodeRepToBuf(rep, file_type, props, out_buf);
+}
 
-    const len_fn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) usize = @ptrCast(&objc.objc_msgSend);
-    const len = len_fn(out_data, @ptrCast(objc.sel_registerName("length")));
-    if (len > out_buf.len) return out_buf[0..0];
-    const bytes_fn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) [*c]const u8 = @ptrCast(&objc.objc_msgSend);
-    const bytes = bytes_fn(out_data, @ptrCast(objc.sel_registerName("bytes")));
-    if (bytes == null) return out_buf[0..0];
-    @memcpy(out_buf[0..len], bytes[0..len]);
-    return out_buf[0..len];
+/// 파일의 시스템 아이콘 → PNG bytes (Electron `app.getFileIcon(path)`).
+/// NSWorkspace.iconForFile: → NSImage → CGImageForProposedRect 32x32 →
+/// NSBitmapImageRep → PNG. macOS only(NSWorkspace). Win/Linux: 빈 slice(honest).
+/// out_buf 부족 시 빈 slice.
+pub fn nativeImageFileIconPng(path: []const u8, out_buf: []u8) []const u8 {
+    if (!comptime is_macos) return out_buf[0..0];
+    const ns_path = nsStringFromSlice(path) orelse return out_buf[0..0];
+    const NSWorkspace = getClass("NSWorkspace") orelse return out_buf[0..0];
+    const obj0_fn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque = @ptrCast(&objc.objc_msgSend);
+    const ws = obj0_fn(NSWorkspace, @ptrCast(objc.sel_registerName("sharedWorkspace"))) orelse return out_buf[0..0];
+    const icon_fn: *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque = @ptrCast(&objc.objc_msgSend);
+    const img = icon_fn(ws, @ptrCast(objc.sel_registerName("iconForFile:")), ns_path) orelse return out_buf[0..0];
+    // multi-rep TIFF 의 PNG 는 12KB(b64) 한도를 넘으므로 32x32 단일 비트맵으로 축소
+    // (CGImageForProposedRect: → NSBitmapImageRep initWithCGImage:). 런처/파일매니저용 작은 아이콘.
+    var rect = cef.NSRect{ .x = 0, .y = 0, .width = 32, .height = 32 };
+    const cg_fn: *const fn (?*anyopaque, ?*anyopaque, *cef.NSRect, ?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque = @ptrCast(&objc.objc_msgSend);
+    const cg = cg_fn(img, @ptrCast(objc.sel_registerName("CGImageForProposedRect:context:hints:")), &rect, null, null) orelse return out_buf[0..0];
+    const NSBitmapImageRep = getClass("NSBitmapImageRep") orelse return out_buf[0..0];
+    const rep_raw = obj0_fn(NSBitmapImageRep, @ptrCast(objc.sel_registerName("alloc"))) orelse return out_buf[0..0];
+    const init_fn: *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque = @ptrCast(&objc.objc_msgSend);
+    const rep = init_fn(rep_raw, @ptrCast(objc.sel_registerName("initWithCGImage:")), cg) orelse return out_buf[0..0];
+    // rep 은 alloc+init(retain +1) — Zig 는 ARC 아니므로 명시적 release(누수 방지).
+    defer {
+        const rel_fn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) void = @ptrCast(&objc.objc_msgSend);
+        rel_fn(rep, @ptrCast(objc.sel_registerName("release")));
+    }
+    return encodeRepToBuf(rep, .png, null, out_buf);
 }
 
 /// 이미지 파일 → dimensions (Electron `nativeImage.createFromPath(path).getSize()`).

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -321,6 +321,7 @@ pub const nativeImageEncodeFromPath = cef_native_image.nativeImageEncodeFromPath
 pub const nativeImageGetSize = cef_native_image.nativeImageGetSize;
 pub const nativeImageIsEmpty = cef_native_image.nativeImageIsEmpty;
 pub const nativeImageIsTemplate = cef_native_image.nativeImageIsTemplate;
+pub const nativeImageFileIconPng = cef_native_image.nativeImageFileIconPng;
 
 pub const appSetProgressBar = cef_app_progress.appSetProgressBar;
 

--- a/tests/e2e/system-integration.test.ts
+++ b/tests/e2e/system-integration.test.ts
@@ -657,6 +657,15 @@ describe("nativeImage.getSize", () => {
     }
   });
 
+  test("app.getFileIcon: 존재 파일 → PNG base64 (macOS NSWorkspace 아이콘)", async () => {
+    // 존재하는 파일의 시스템 아이콘. macOS NSWorkspace.iconForFile 은 항상 아이콘 반환.
+    const r = await core<{ data: string }>({ cmd: "app_get_file_icon", path: "/bin/ls" });
+    expect(typeof r.data).toBe("string");
+    expect(r.data.length).toBeGreaterThan(0);
+    const buf = Buffer.from(r.data, "base64");
+    expect(buf.subarray(0, 4).toString("latin1")).toBe("\x89PNG"); // PNG signature
+  });
+
   test("toPNG: 1x1 PNG 파일 → base64 비어있지 않고 PNG signature 시작", async () => {
     const tmp = `/tmp/suji-topng-${Date.now()}.png`;
     fs.writeFileSync(tmp, PNG_1X1);


### PR DESCRIPTION
## app.getFileIcon — 파일 시스템 아이콘 PNG (Electron parity)

NSWorkspace.iconForFile → 32x32 PNG base64. 전 5 SDK + 코어 cmd + e2e.

### 변경
- **cef_native_image.zig**: `nativeImageFileIconPng` (NSWorkspace.iconForFile → CGImageForProposedRect 32x32 → NSBitmapImageRep → PNG)
- **/simplify**: `encodeRepToBuf` 헬퍼 추출(`nativeImageEncodeFromPath`와 rep→png tail 공유) + NSBitmapImageRep 명시적 release(Zig 비-ARC 누수 방지) + docstring 정정
- **5 SDK**: frontend/node `app.getFileIcon`, rust `get_file_icon`, go `GetFileIcon`, zig `nativeImage.fileIcon`(이미지 카테고리)
- **e2e**: system-integration 138 pass (PNG signature 검증)

### 검증
- ✅ 로컬 e2e **138 pass** (getFileIcon + toPng/getSize 회귀 없음)
- ✅ /simplify(헬퍼+누수) + /code-review max (**0 confirmed 버그**)
- ✅ zig/node/rust/go SDK 컴파일

### 정직 경계
32x32 고정(Electron size 옵션 미지원, 12KB b64 한도), Win/Linux 빈 문자열(NSWorkspace macOS-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)