### PR TITLE
fix(review): Rust permission clear listener 누수 + getFileIcon rep autorelease

### DIFF
--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -3068,6 +3068,26 @@ pub mod session {
         pub media_types: Vec<String>,
     }
 
+    /// 등록된 (permission listener id, media listener id, leaked handler ptr usize).
+    /// 재등록/해제 시 이전 listener off + Box drop — 이전엔 clear 가 core cmd 만 보내고
+    /// `on()` 으로 건 두 trampoline 이 잔존해, 재set 시 trampoline 이 누적돼 한 요청에
+    /// 응답을 두 번 보내고(double-respond) 이전 핸들러 Box 도 누수했다.
+    static PERMISSION_LISTENERS: std::sync::Mutex<Option<(u64, u64, usize)>> =
+        std::sync::Mutex::new(None);
+
+    fn clear_permission_listeners() {
+        if let Some((id1, id2, arg)) = PERMISSION_LISTENERS.lock().unwrap().take() {
+            crate::off(id1);
+            crate::off(id2);
+            // set 에서 Box::into_raw 로 leak 한 핸들러 회수.
+            unsafe {
+                drop(Box::from_raw(
+                    arg as *mut Box<dyn Fn(PermissionRequest) -> bool + Send + Sync>,
+                ));
+            }
+        }
+    }
+
     /// Electron `session.setPermissionRequestHandler(handler)` 동등. 렌더러가 geolocation/
     /// notifications/clipboard 등 권한을 요청하면 `handler` 가 호출돼 `true`(허용)/`false`(거부)
     /// 를 반환한다. 한 번 등록(앱 수명). camera/mic(getUserMedia)도 이 핸들러가 받는다
@@ -3076,7 +3096,8 @@ pub mod session {
     ///
     /// `session:permission-request`/`session:media-access-request` 를 구독해 결정 후
     /// `session_permission_response`/`session_media_access_response` 로 응답한다(JS/Node SDK
-    /// 와 동일 wire). 핸들러는 leak 되어 앱 수명 동안 유지(두 trampoline 이 공유).
+    /// 와 동일 wire). 핸들러(두 trampoline 공유)는 PERMISSION_LISTENERS 에 저장돼
+    /// clear/재set 시 listener off + Box 회수(재set 누적/double-respond/누수 방지).
     pub fn set_permission_request_handler<F>(handler: F)
     where
         F: Fn(PermissionRequest) -> bool + Send + Sync + 'static,
@@ -3084,9 +3105,12 @@ pub mod session {
         type BoxedHandler = Box<dyn Fn(PermissionRequest) -> bool + Send + Sync>;
         let boxed: Box<BoxedHandler> = Box::new(Box::new(handler));
         let arg = Box::into_raw(boxed) as *mut std::os::raw::c_void;
-        // 같은 leaked handler 를 두 이벤트에 등록(빌림만 — arg 소유권 미이전, 앱 수명 유지).
-        crate::on("session:permission-request", permission_trampoline, arg);
-        crate::on("session:media-access-request", media_trampoline, arg);
+        // 재등록 시 이전 listener off + leaked Box 회수(trampoline 누적/double-respond 방지).
+        clear_permission_listeners();
+        // 같은 handler 를 두 이벤트에 등록. listener id + arg 를 저장해 clear/재set 시 해제.
+        let id1 = crate::on("session:permission-request", permission_trampoline, arg);
+        let id2 = crate::on("session:media-access-request", media_trampoline, arg);
+        *PERMISSION_LISTENERS.lock().unwrap() = Some((id1, id2, arg as usize));
         invoke(
             "__core__",
             r#"{"cmd":"session_set_permission_handler","enabled":true}"#,
@@ -3095,6 +3119,8 @@ pub mod session {
 
     /// 권한 핸들러 해제(이후 CEF 기본 처리).
     pub fn clear_permission_request_handler() {
+        // event listener off + leaked Box 회수(이전: core cmd 만 보내 trampoline 잔존).
+        clear_permission_listeners();
         invoke(
             "__core__",
             r#"{"cmd":"session_set_permission_handler","enabled":false}"#,

--- a/src/platform/cef_native_image.zig
+++ b/src/platform/cef_native_image.zig
@@ -100,11 +100,11 @@ pub fn nativeImageFileIconPng(path: []const u8, out_buf: []u8) []const u8 {
     const rep_raw = obj0_fn(NSBitmapImageRep, @ptrCast(objc.sel_registerName("alloc"))) orelse return out_buf[0..0];
     const init_fn: *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque = @ptrCast(&objc.objc_msgSend);
     const rep = init_fn(rep_raw, @ptrCast(objc.sel_registerName("initWithCGImage:")), cg) orelse return out_buf[0..0];
-    // rep 은 alloc+init(retain +1) — Zig 는 ARC 아니므로 명시적 release(누수 방지).
-    defer {
-        const rel_fn: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) void = @ptrCast(&objc.objc_msgSend);
-        rel_fn(rep, @ptrCast(objc.sel_registerName("release")));
-    }
+    // rep 은 alloc+init(retain +1). nativeImageEncodeFromPath 의 imageRepWithData(autoreleased)
+    // 와 일관되게 autorelease 로 등록(cefHandleCore=UI 스레드 autorelease pool 보유) — defer
+    // release 는 init 실패(rep null, 위 orelse return) 시 alloc 된 rep_raw 의 정리 경로가
+    // 갈려 모호했으나, init 성공 후 단일 autorelease 로 누수/이중해제 없이 일관 정리.
+    _ = obj0_fn(rep, @ptrCast(objc.sel_registerName("autorelease")));
     return encodeRepToBuf(rep, .png, null, out_buf);
 }
 


### PR DESCRIPTION
## 요약

`/code-review max`(전체 세션 점검)에서 확인한 PLAUSIBLE 2건 수정.

### 1. suji-rs permission clear listener 누수
`clear_permission_request_handler` 가 core cmd 만 보내고, `set` 이 `on()` 으로 건 두 trampoline(`session:permission-request` / `session:media-access-request`)을 `off` 하지 않았다. 재set 시 trampoline 이 누적돼 한 요청에 **double-respond** + 이전 핸들러 `Box` 누수.

- `PERMISSION_LISTENERS`(listener id 2개 + leaked ptr) 추적 → set/clear 시 `off()` + `Box::from_raw` 회수.
- JS/Node 의 `activePermissionOff` / Go 의 listener-id off 패턴과 일치 — **Rust 만 누락**이었음(`/simplify` 4-agent 확인).
- **UAF 안전**: EventBus `off()` 가 `waitQuiescent()` 로 in-flight 콜백 완료를 보장(`src/core/events.zig:199`, epoch barrier) → off 후 `Box` drop 안전. JS/Go 의 GC 와 동등 안전성.

### 2. getFileIcon rep autorelease
`nativeImageFileIconPng` 의 `NSBitmapImageRep` `alloc+init` 를 `defer release` → `autorelease`. `nativeImageEncodeFromPath` 의 `imageRepWithData`(autoreleased)와 일관 + init 실패 경로 단순화(`cefHandleCore` = UI 스레드 autorelease pool 보유).

## 검증
- `cargo build` OK, `zig build` OK
- `run-system-integration.sh` e2e 139 pass
- `/simplify` clean(4 agents), `/code-review max` 심각 0 (핵심 UAF 후보는 off epoch barrier 로 REFUTED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)