### PR TITLE
fix(test): repair python unit tests broken by version-constant refactor

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1498,17 +1498,34 @@ pub fn build(b: *std.Build) void {
         });
         python_runtime_test_mod.addImport("python_config", python_options.createModule());
         python_runtime_test_mod.addImport("runtime", runtime_module);
-        const py_inc = std.fmt.allocPrint(b.allocator, "{s}/include/python{s}", .{ python_path, python_minor }) catch @panic("OOM");
-        python_runtime_test_mod.addIncludePath(.{ .cwd_relative = py_inc });
-        const py_lib = std.fmt.allocPrint(b.allocator, "{s}/lib", .{python_path}) catch @panic("OOM");
-        python_runtime_test_mod.addLibraryPath(.{ .cwd_relative = py_lib });
-        // 테스트는 python_available 게이트 안에서만 빌드되므로 libpython 존재가
-        // 보장된다 → hard-link(정직한 의존). rpath 는 cache 디렉토리에서 실행되는
-        // 테스트가 staging libpython 을 찾도록 절대경로.
-        python_runtime_test_mod.linkSystemLibrary("python3.13", .{});
-        python_runtime_test_mod.addRPathSpecial(py_lib);
+        // main module(위 python 링크, line 580+)과 동형 — Windows 는 PBS 레이아웃
+        // (헤더 include/ 직접, import-lib libs/python<abi>.lib → python<abi>.dll),
+        // POSIX 는 include/python<minor> + lib/ + linkSystemLibrary + rpath.
+        // 테스트는 python_available 게이트 안에서만 빌드되므로 libpython 존재 보장.
+        switch (os_tag) {
+            .windows => {
+                const py_inc = std.fmt.allocPrint(b.allocator, "{s}/include", .{python_path}) catch @panic("OOM");
+                python_runtime_test_mod.addIncludePath(.{ .cwd_relative = py_inc });
+                const import_lib = std.fmt.allocPrint(b.allocator, "{s}/libs/python{s}.lib", .{ python_path, python_abi }) catch @panic("OOM");
+                python_runtime_test_mod.addObjectFile(.{ .cwd_relative = import_lib });
+            },
+            else => {
+                const py_inc = std.fmt.allocPrint(b.allocator, "{s}/include/python{s}", .{ python_path, python_minor }) catch @panic("OOM");
+                python_runtime_test_mod.addIncludePath(.{ .cwd_relative = py_inc });
+                const py_lib = std.fmt.allocPrint(b.allocator, "{s}/lib", .{python_path}) catch @panic("OOM");
+                python_runtime_test_mod.addLibraryPath(.{ .cwd_relative = py_lib });
+                // rpath: cache 디렉토리에서 실행되는 테스트가 staging libpython 을 찾도록.
+                python_runtime_test_mod.linkSystemLibrary(std.fmt.allocPrint(b.allocator, "python{s}", .{python_minor}) catch @panic("OOM"), .{});
+                python_runtime_test_mod.addRPathSpecial(py_lib);
+            },
+        }
         const python_runtime_test = b.addTest(.{ .root_module = python_runtime_test_mod });
-        dependOnTestWithProjectCwd(b, test_step, python_runtime_test);
+        // Windows 는 rpath 부재 → python<abi>.dll(+vcruntime140*.dll, python_path 에 동반)을
+        // run step PATH 로 노출. cwd=project root(인라인 test 가 main.py 상대경로 로드).
+        const py_test_run = b.addRunArtifact(python_runtime_test);
+        py_test_run.setCwd(b.path("."));
+        if (os_tag == .windows) py_test_run.addPathDir(python_path);
+        test_step.dependOn(&py_test_run.step);
     }
 
     // CEF IPC tests (순수 함수 — CEF 런타임 불필요)

--- a/tests/python_test.zig
+++ b/tests/python_test.zig
@@ -20,13 +20,17 @@ test "build.zig: Python staging + weak-link auto-detect + packaging install step
     const a = std.testing.allocator;
     const b = try slurp(a, "build.zig");
     defer a.free(b);
-    // staging 경로(libnode 패턴) + auto-detect 게이트.
-    try expectContains(b, ".suji/python/3.13.13");
+    // 버전 단일 출처 상수 + auto-detect 게이트. (staging 경로는 `{s}/.suji/python/{s}`
+    // 포맷 + python_version 상수로 조립되므로 리터럴 풀패스가 아니라 **상수**를 검사 —
+    // 버전 bump 시 build.zig 한 곳만 바뀌고 이 계약은 그대로 따라온다.)
+    try expectContains(b, "python_version = \"3.13.13\"");
     try expectContains(b, "python_available");
     // weak-link: python staging 머신 빌드여도 비-python 앱 graceful(심볼 null).
-    try expectContains(b, "linkSystemLibrary(\"python3.13\", .{ .weak = true })");
-    // Windows 는 MSVC import lib 게이트(node .dll.a 동형).
-    try expectContains(b, "libs/python3.lib");
+    // 링크 대상은 python_minor 파생(`python{s}`) — 버전 상수 단일 출처.
+    try expectContains(b, "\"python{s}\", .{python_minor}");
+    try expectContains(b, ".{ .weak = true }");
+    // Windows 는 MSVC import lib 게이트(node .dll.a 동형) — python_abi 파생(python313.lib).
+    try expectContains(b, "libs/python{s}.lib");
     // packaging: end-user 머신 Python 미설치 대응 — libpython+stdlib 동반.
     try expectContains(b, "addInstallPythonRuntimeStep");
 }


### PR DESCRIPTION
## 문제

`zig build test` 가 Windows 에서 **2개 스텝 실패**(`73/77 steps; 1 test fail + 1 compile fail`). 둘 다 python **버전 단일-출처 상수 리팩터**(`8689359`/`f76d335`)의 잔여 갭이며, `tests/python_test.zig` 쪽은 **전 플랫폼 공통 깨짐**(macOS/Linux CI 도 큐가 풀리면 빨갰을 것 — 현재 Actions 큐 적체로 미검출).

## 수정

1. **`tests/python_test.zig`** (build.zig 소스-계약 가드) — 리팩터 전 리터럴을 검사하고 있었음:
   - `.suji/python/3.13.13` → 이제 `{s}/.suji/python/{s}` 포맷 + `python_version` 상수 ⇒ **상수**(`python_version = "3.13.13"`)를 검사하도록 변경
   - `linkSystemLibrary("python3.13", .{ .weak = true })` → 이제 `"python{s}", .{python_minor}` 포맷 ⇒ 포맷 문자열 + `.{ .weak = true }` 분리 검사
   - `libs/python3.lib` → 이제 `libs/python{s}.lib`(python313.lib)
   - 버전 bump 시 재발하지 않도록 **상수/포맷 문자열** 기준으로 고정.

2. **`build.zig`** — `src/platform/python.zig` 인라인 런타임 test 모듈이 여전히 POSIX 링크(`-I include/python3.13 -L lib -lpython3.13`)라 Windows 에서 **컴파일 실패**(`unable to find dynamic system library 'python3.13'` — PBS Windows 는 헤더가 `include/`, import-lib 가 `libs/python313.lib`, dynamic `python3.13` 부재). main module 의 `switch (os_tag)` 분기를 그대로 미러: Windows = `include/` + `addObjectFile(libs/python313.lib)`, POSIX 불변. run step 을 인라인해 Windows 는 `python313.dll`(+vcruntime, `python_path` 동반)을 `addPathDir` 로 run PATH 에 노출(Windows 는 rpath 부재). POSIX run 동작은 기존 헬퍼와 바이트 동일.

## 검증 (로컬 Windows)

`zig build test --summary all` → **77/77 steps succeeded; 943/954 tests passed (11 skipped); exit 0**. python 런타임 test 가 이제 Windows 에서 실제로 실행됨(`Py_Initialize` + main.py 로드: `[suji-python] started`). (수정 전: `73/77 (2 failed); 941/953; 1 failed`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)