### PR TITLE
feat(sdk): add autoUpdater to Rust + Go SDKs (parity with JS/Node)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,12 @@ suji::export_handlers!(ping);
 // suji::dock::{set_badge("99"), get_badge()}
 // suji::get_path("userData") / get_path("home") ...
 // suji::web_request::set_blocked_urls(&["https://*.ad/*"])  — URL glob blocklist
+// suji::auto_updater::{check_for_updates(cur,latest,url,sha256,notes,pub_date),
+//   verify_file(path,sha256), download_artifact(url,path,sha256),
+//   prepare_install(path,target,stage_dir,format,sha256),
+//   quit_and_install(path,target,sha256,relaunch,helper_path)}  — Electron autoUpdater
+//   (manifest check + download + SHA-256 verify + quit-and-install; raw Option<String>.
+//    backend SDK 라 manifest fetch 없이 명시 파라미터로 core 호출 — JS/Node 와 동일 5 커맨드)
 // suji::request_user_attention(true) / suji::cancel_user_attention_request(id)
 // suji::quit()                 — 앱 종료 (Electron app.quit())
 // suji::exit()                 — 앱 강제 종료 (Electron app.exit, code 무시)
@@ -391,6 +397,12 @@ var _ = suji.Bind(&App{})
 // screen.GetAllDisplays()
 // import "github.com/ohah/suji-go/powersaveblocker"
 // powersaveblocker.Start("prevent_display_sleep") / Stop(id)
+// import "github.com/ohah/suji-go/autoupdater"
+// autoupdater.CheckForUpdates(cur, latest, url, sha256, notes, pubDate) / VerifyFile(path, sha256)
+//   / DownloadArtifact(url, path, sha256) / PrepareInstall(path, target, stageDir, format, sha256)
+//   / QuitAndInstall(path, target, sha256, relaunch, helperPath)  — Electron autoUpdater
+//   (manifest check + download + SHA-256 verify + quit-and-install; raw JSON. backend SDK 라
+//    manifest fetch 없이 명시 파라미터로 core 호출 — JS/Node 와 동일 5 커맨드)
 // import "github.com/ohah/suji-go/safestorage"
 // safestorage.SetItem(svc, acc, "v") / GetItem(svc, acc) / DeleteItem(svc, acc)
 // import "github.com/ohah/suji-go/dock"

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2902,6 +2902,138 @@ pub mod crash_reporter {
     }
 }
 
+/// Electron `autoUpdater` — manifest check + download + SHA-256 verify +
+/// prepare/quit-and-install. JS/Node SDK 와 동일한 5개 `auto_updater_*` core
+/// 커맨드를 호출하되, backend SDK 라 manifest fetch/`app.getVersion()` 같은
+/// 클라이언트 작업 없이 **명시 파라미터**로 core 를 호출한다(다른 raw 바인딩 패턴).
+pub mod auto_updater {
+    use crate::{invoke, serde_json};
+
+    pub(crate) fn check_update_request(
+        current_version: &str,
+        latest_version: &str,
+        url: &str,
+        sha256: &str,
+        notes: &str,
+        pub_date: &str,
+    ) -> String {
+        serde_json::json!({
+            "cmd": "auto_updater_check_update",
+            "currentVersion": current_version,
+            "latestVersion": latest_version,
+            "url": url,
+            "sha256": sha256,
+            "notes": notes,
+            "pubDate": pub_date,
+        })
+        .to_string()
+    }
+
+    pub(crate) fn verify_file_request(path: &str, sha256: &str) -> String {
+        serde_json::json!({ "cmd": "auto_updater_verify_file", "path": path, "sha256": sha256 })
+            .to_string()
+    }
+
+    pub(crate) fn download_artifact_request(url: &str, path: &str, sha256: &str) -> String {
+        serde_json::json!({
+            "cmd": "auto_updater_download_artifact",
+            "url": url,
+            "path": path,
+            "sha256": sha256,
+        })
+        .to_string()
+    }
+
+    pub(crate) fn prepare_install_request(
+        path: &str,
+        target: &str,
+        stage_dir: &str,
+        format: &str,
+        sha256: &str,
+    ) -> String {
+        serde_json::json!({
+            "cmd": "auto_updater_prepare_install",
+            "path": path,
+            "target": target,
+            "stageDir": stage_dir,
+            "format": format,
+            "sha256": sha256,
+        })
+        .to_string()
+    }
+
+    pub(crate) fn quit_and_install_request(
+        path: &str,
+        target: &str,
+        sha256: &str,
+        relaunch: bool,
+        helper_path: &str,
+    ) -> String {
+        serde_json::json!({
+            "cmd": "auto_updater_quit_and_install",
+            "path": path,
+            "target": target,
+            "sha256": sha256,
+            "relaunch": relaunch,
+            "helperPath": helper_path,
+        })
+        .to_string()
+    }
+
+    /// manifest 의 latest 버전/URL 을 current 버전과 비교 → updateAvailable 등 raw JSON.
+    pub fn check_for_updates(
+        current_version: &str,
+        latest_version: &str,
+        url: &str,
+        sha256: &str,
+        notes: &str,
+        pub_date: &str,
+    ) -> Option<String> {
+        invoke(
+            "__core__",
+            &check_update_request(current_version, latest_version, url, sha256, notes, pub_date),
+        )
+    }
+
+    /// 다운로드된 파일의 SHA-256 검증(mismatch 면 success=false + actualSha256).
+    pub fn verify_file(path: &str, sha256: &str) -> Option<String> {
+        invoke("__core__", &verify_file_request(path, sha256))
+    }
+
+    /// artifact URL 을 지정 경로로 다운로드 + optional SHA-256 검증.
+    pub fn download_artifact(url: &str, path: &str, sha256: &str) -> Option<String> {
+        invoke("__core__", &download_artifact_request(url, path, sha256))
+    }
+
+    /// artifact 포맷(zip/dmg/app/AppImage/deb 또는 "auto")을 install 입력으로 정규화.
+    pub fn prepare_install(
+        path: &str,
+        target: &str,
+        stage_dir: &str,
+        format: &str,
+        sha256: &str,
+    ) -> Option<String> {
+        invoke(
+            "__core__",
+            &prepare_install_request(path, target, stage_dir, format, sha256),
+        )
+    }
+
+    /// staged artifact 를 종료 후 target 으로 교체하고 quit 요청(relaunch 옵션).
+    pub fn quit_and_install(
+        path: &str,
+        target: &str,
+        sha256: &str,
+        relaunch: bool,
+        helper_path: &str,
+    ) -> Option<String> {
+        invoke(
+            "__core__",
+            &quit_and_install_request(path, target, sha256, relaunch, helper_path),
+        )
+    }
+}
+
 pub mod power_save_blocker {
     use crate::{invoke, serde_json};
 
@@ -3935,6 +4067,53 @@ mod tests {
                 .unwrap();
         assert_eq!(remove["cmd"], "crash_reporter_remove_extra_parameter");
         assert_eq!(remove["key"], "suite");
+    }
+
+    #[test]
+    fn auto_updater_requests_build_valid_json() {
+        let check: serde_json::Value = serde_json::from_str(&crate::auto_updater::check_update_request(
+            "1.0.0",
+            "1.1.0",
+            "https://example.test/app.zip",
+            "abc",
+            "notes",
+            "2026-05-25T00:00:00Z",
+        ))
+        .unwrap();
+        assert_eq!(check["cmd"], "auto_updater_check_update");
+        assert_eq!(check["currentVersion"], "1.0.0");
+        assert_eq!(check["latestVersion"], "1.1.0");
+        assert_eq!(check["url"], "https://example.test/app.zip");
+        assert_eq!(check["pubDate"], "2026-05-25T00:00:00Z");
+
+        let verify: serde_json::Value =
+            serde_json::from_str(&crate::auto_updater::verify_file_request("/tmp/app.zip", "abc"))
+                .unwrap();
+        assert_eq!(verify["cmd"], "auto_updater_verify_file");
+        assert_eq!(verify["path"], "/tmp/app.zip");
+        assert_eq!(verify["sha256"], "abc");
+
+        let download: serde_json::Value = serde_json::from_str(
+            &crate::auto_updater::download_artifact_request("https://x/app.zip", "/tmp/app.zip", ""),
+        )
+        .unwrap();
+        assert_eq!(download["cmd"], "auto_updater_download_artifact");
+        assert_eq!(download["url"], "https://x/app.zip");
+
+        let prepare: serde_json::Value = serde_json::from_str(
+            &crate::auto_updater::prepare_install_request("/tmp/app.zip", "", "", "auto", ""),
+        )
+        .unwrap();
+        assert_eq!(prepare["cmd"], "auto_updater_prepare_install");
+        assert_eq!(prepare["format"], "auto");
+
+        let quit: serde_json::Value = serde_json::from_str(
+            &crate::auto_updater::quit_and_install_request("/tmp/app.zip", "/Applications/X.app", "", true, ""),
+        )
+        .unwrap();
+        assert_eq!(quit["cmd"], "auto_updater_quit_and_install");
+        assert_eq!(quit["target"], "/Applications/X.app");
+        assert_eq!(quit["relaunch"], true);
     }
 
     #[test]

--- a/sdks/suji-go/autoupdater/autoupdater.go
+++ b/sdks/suji-go/autoupdater/autoupdater.go
@@ -1,0 +1,72 @@
+// Package autoupdater provides Suji autoUpdater API
+// (Electron `autoUpdater` shape — manifest check + download + SHA-256 verify +
+// prepare/quit-and-install). Calls the same five `auto_updater_*` core commands
+// as the JS/Node SDK, but as a backend SDK it takes explicit params (no manifest
+// fetch / app.getVersion() client step — that is the caller's responsibility).
+package autoupdater
+
+import (
+	"fmt"
+
+	suji "github.com/ohah/suji-go"
+	"github.com/ohah/suji-go/internal/jsonesc"
+)
+
+// CheckForUpdates compares a manifest latest version/URL against the current
+// version and returns raw JSON (updateAvailable/version/url/...).
+func CheckForUpdates(currentVersion, latestVersion, url, sha256, notes, pubDate string) string {
+	return suji.Invoke("__core__", buildCheckUpdateRequest(currentVersion, latestVersion, url, sha256, notes, pubDate))
+}
+
+// VerifyFile validates a downloaded file's SHA-256 (mismatch → success=false + actualSha256).
+func VerifyFile(path, sha256 string) string {
+	return suji.Invoke("__core__", buildVerifyFileRequest(path, sha256))
+}
+
+// DownloadArtifact downloads an artifact URL to path and optionally verifies SHA-256.
+func DownloadArtifact(url, path, sha256 string) string {
+	return suji.Invoke("__core__", buildDownloadArtifactRequest(url, path, sha256))
+}
+
+// PrepareInstall normalizes an artifact format (zip/dmg/app/AppImage/deb or "auto")
+// into a quitAndInstall / system-package handoff input.
+func PrepareInstall(path, target, stageDir, format, sha256 string) string {
+	return suji.Invoke("__core__", buildPrepareInstallRequest(path, target, stageDir, format, sha256))
+}
+
+// QuitAndInstall swaps the staged artifact into target after quit and requests quit.
+func QuitAndInstall(path, target, sha256 string, relaunch bool, helperPath string) string {
+	return suji.Invoke("__core__", buildQuitAndInstallRequest(path, target, sha256, relaunch, helperPath))
+}
+
+func buildCheckUpdateRequest(currentVersion, latestVersion, url, sha256, notes, pubDate string) string {
+	return fmt.Sprintf(
+		`{"cmd":"auto_updater_check_update","currentVersion":"%s","latestVersion":"%s","url":"%s","sha256":"%s","notes":"%s","pubDate":"%s"}`,
+		jsonesc.Full(currentVersion), jsonesc.Full(latestVersion), jsonesc.Full(url),
+		jsonesc.Full(sha256), jsonesc.Full(notes), jsonesc.Full(pubDate))
+}
+
+func buildVerifyFileRequest(path, sha256 string) string {
+	return fmt.Sprintf(
+		`{"cmd":"auto_updater_verify_file","path":"%s","sha256":"%s"}`,
+		jsonesc.Full(path), jsonesc.Full(sha256))
+}
+
+func buildDownloadArtifactRequest(url, path, sha256 string) string {
+	return fmt.Sprintf(
+		`{"cmd":"auto_updater_download_artifact","url":"%s","path":"%s","sha256":"%s"}`,
+		jsonesc.Full(url), jsonesc.Full(path), jsonesc.Full(sha256))
+}
+
+func buildPrepareInstallRequest(path, target, stageDir, format, sha256 string) string {
+	return fmt.Sprintf(
+		`{"cmd":"auto_updater_prepare_install","path":"%s","target":"%s","stageDir":"%s","format":"%s","sha256":"%s"}`,
+		jsonesc.Full(path), jsonesc.Full(target), jsonesc.Full(stageDir),
+		jsonesc.Full(format), jsonesc.Full(sha256))
+}
+
+func buildQuitAndInstallRequest(path, target, sha256 string, relaunch bool, helperPath string) string {
+	return fmt.Sprintf(
+		`{"cmd":"auto_updater_quit_and_install","path":"%s","target":"%s","sha256":"%s","relaunch":%t,"helperPath":"%s"}`,
+		jsonesc.Full(path), jsonesc.Full(target), jsonesc.Full(sha256), relaunch, jsonesc.Full(helperPath))
+}

--- a/sdks/suji-go/autoupdater/autoupdater_test.go
+++ b/sdks/suji-go/autoupdater/autoupdater_test.go
@@ -1,0 +1,77 @@
+package autoupdater
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBuildCheckUpdateRequest(t *testing.T) {
+	var got map[string]any
+	if err := json.Unmarshal([]byte(buildCheckUpdateRequest("1.0.0", "1.1.0", "https://example.test/app.zip", "abc", "notes", "2026-05-25T00:00:00Z")), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["cmd"] != "auto_updater_check_update" {
+		t.Fatalf("cmd = %v", got["cmd"])
+	}
+	if got["currentVersion"] != "1.0.0" || got["latestVersion"] != "1.1.0" {
+		t.Fatalf("versions = %v/%v", got["currentVersion"], got["latestVersion"])
+	}
+	if got["url"] != "https://example.test/app.zip" || got["pubDate"] != "2026-05-25T00:00:00Z" {
+		t.Fatalf("url/pubDate = %v/%v", got["url"], got["pubDate"])
+	}
+}
+
+func TestBuildVerifyFileRequest(t *testing.T) {
+	var got map[string]any
+	if err := json.Unmarshal([]byte(buildVerifyFileRequest("/tmp/app.zip", "abc")), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["cmd"] != "auto_updater_verify_file" {
+		t.Fatalf("cmd = %v", got["cmd"])
+	}
+	if got["path"] != "/tmp/app.zip" || got["sha256"] != "abc" {
+		t.Fatalf("path/sha256 = %v/%v", got["path"], got["sha256"])
+	}
+}
+
+func TestBuildDownloadArtifactRequest(t *testing.T) {
+	var got map[string]any
+	if err := json.Unmarshal([]byte(buildDownloadArtifactRequest("https://x/app.zip", "/tmp/app.zip", "")), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["cmd"] != "auto_updater_download_artifact" {
+		t.Fatalf("cmd = %v", got["cmd"])
+	}
+	if got["url"] != "https://x/app.zip" || got["path"] != "/tmp/app.zip" {
+		t.Fatalf("url/path = %v/%v", got["url"], got["path"])
+	}
+}
+
+func TestBuildPrepareInstallRequest(t *testing.T) {
+	var got map[string]any
+	if err := json.Unmarshal([]byte(buildPrepareInstallRequest("/tmp/app.zip", "", "", "auto", "")), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["cmd"] != "auto_updater_prepare_install" {
+		t.Fatalf("cmd = %v", got["cmd"])
+	}
+	if got["format"] != "auto" {
+		t.Fatalf("format = %v", got["format"])
+	}
+}
+
+func TestBuildQuitAndInstallRequest(t *testing.T) {
+	var got map[string]any
+	if err := json.Unmarshal([]byte(buildQuitAndInstallRequest("/tmp/app.zip", "/Applications/X.app", "", true, "")), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["cmd"] != "auto_updater_quit_and_install" {
+		t.Fatalf("cmd = %v", got["cmd"])
+	}
+	if got["target"] != "/Applications/X.app" {
+		t.Fatalf("target = %v", got["target"])
+	}
+	if got["relaunch"] != true {
+		t.Fatalf("relaunch = %v", got["relaunch"])
+	}
+}


### PR DESCRIPTION
## 무엇을

per-language SDK 패리티 감사에서 발견한 유일한 실 기능 gap 을 메움: **autoUpdater 가 JS(`@suji/api`)·Node(`@suji/node`) SDK 엔 있는데 Rust·Go backend SDK 엔 누락**(5개 `auto_updater_*` core 커맨드가 JS/Node 에서만 호출 가능했음).

## 변경

양 SDK 모두 JS/Node 와 **동일한 5개 `__core__` 커맨드**(`auto_updater_check_update`/`verify_file`/`download_artifact`/`prepare_install`/`quit_and_install`)를 동일 camelCase JSON 키로 래핑. backend SDK 라 manifest fetch/`app.getVersion()` 같은 frontend 편의 단계 없이 **명시 파라미터**로 core 호출(crash_reporter/power_save_blocker 바인딩과 동형).

- `crates/suji-rs/src/lib.rs`: `pub mod auto_updater` — request builder + 5개 public fn(`Option<String>` raw JSON), crash_reporter/power_save_blocker 옆. `auto_updater_requests_build_valid_json` 유닛 테스트 추가.
- `sdks/suji-go/autoupdater/`: 신규 package — 5개 func + `build*Request`(jsonesc), `suji-go/crashreporter` 동형. `autoupdater_test.go`(5 request-shape 테스트).
- `CLAUDE.md`: Rust(`suji::auto_updater`)·Go(`suji-go/autoupdater`) per-language API 섹션 문서화.

## 검증

- `cargo test auto_updater` → 1 passed
- `go test ./autoupdater/` → ok / `go build ./...` → ok
- 양 crate clean compile. request JSON 은 core 가 이미 e2e(run-auto-updater-quit-install.sh)로 검증하는 JS/Node wire 포맷과 바이트 동형.

> 참고: examples 도 함께 감사했으나, rust/go 예제의 `@suji/api` 미선언은 **버그가 아니라 의도**(전역 `window.__suji__` raw bridge 데모 — zig/node 는 typed `@suji/api` import 데모). 나머지(README/lua·python plain-JS frontend)는 기능 결함 아닌 cosmetic 이라 이 PR 범위 외.

🤖 Generated with [Claude Code](https://claude.com/claude-code)