### PR TITLE
fix(upload): Windows "forbidden path" — unescape filePath to match allowlist

### DIFF
--- a/plugins/upload/zig/app.zig
+++ b/plugins/upload/zig/app.zig
@@ -158,6 +158,19 @@ fn expandHome(arena: std.mem.Allocator, path: []const u8) []const u8 {
     return std.fmt.allocPrint(arena, "{s}{s}", .{ home, path[1..] }) catch path;
 }
 
+/// req.string() (util.extractJsonString) 는 JSON escape 를 **unescape 하지 않고** 따옴표
+/// 사이 raw 바이트를 반환한다 → Windows 경로가 `C:\\Users\\...`(이중 백슬래시) 로 온다.
+/// 반면 set_allowed_paths 는 std.json(parseStringArrayInto)으로 **unescape** 해 `C:\Users\...`
+/// (단일 백슬래시)로 저장한다. 둘을 그대로 비교하면 Windows 에서 startsWith 가 항상 어긋나
+/// 모든 업로드/다운로드가 "forbidden path" 가 된다(파일 I/O 는 Windows 가 `\\` 를 정규화해
+/// 통과하지만 문자열 비교만 실패 — macOS/Linux 는 경로에 escape 가 없어 무증상). filePath 도
+/// allowlist 와 동일하게 unescape 해 양쪽 표현을 맞춘다.
+fn unescapePath(arena: std.mem.Allocator, raw: []const u8) []const u8 {
+    const buf = arena.alloc(u8, raw.len) catch return raw;
+    const n = util.unescapeJsonStr(raw, buf) orelse return raw;
+    return buf[0..n];
+}
+
 /// multipart 폼 필드 값(파일명/필드명) 안의 `"`/CR/LF 차단 — 헤더 인젝션 방지.
 fn validFormToken(s: []const u8) bool {
     if (s.len == 0 or s.len > 256) return false;
@@ -189,7 +202,7 @@ fn uploadFile(req: suji.Request, _: suji.InvokeEvent) suji.Response {
     if (validateUrl(req, url)) |e| return e;
     const raw_path = req.string("filePath") orelse return req.err("missing filePath");
     if (raw_path.len == 0 or raw_path.len > MAX_PATH_LEN) return req.err("invalid filePath");
-    const file_path = expandHome(req.arena, raw_path);
+    const file_path = expandHome(req.arena, unescapePath(req.arena, raw_path));
     if (!isPathAllowed(file_path)) return req.err("forbidden path");
 
     const field = req.string("fieldName") orelse "file";
@@ -254,7 +267,7 @@ fn downloadFile(req: suji.Request, _: suji.InvokeEvent) suji.Response {
     if (validateUrl(req, url)) |e| return e;
     const raw_path = req.string("filePath") orelse return req.err("missing filePath");
     if (raw_path.len == 0 or raw_path.len > MAX_PATH_LEN) return req.err("invalid filePath");
-    const file_path = expandHome(req.arena, raw_path);
+    const file_path = expandHome(req.arena, unescapePath(req.arena, raw_path));
     if (!isPathAllowed(file_path)) return req.err("forbidden path");
     const id = req.string("id") orelse "";
     if (id.len > 256) return req.err("id too long");


### PR DESCRIPTION
## 증상

Windows 에서 upload 플러그인의 모든 업로드/다운로드가 **"forbidden path"** 로 거부됨 — allowed root 안의 파일인데도. (전체 Windows e2e 쓸이 중 발견; CI 는 이 e2e 를 macOS/Linux 에서만 돌려 미검출.)

## 루트커즈 — JSON unescape 불일치

PATH allowlist 체크의 양쪽이 **다른 JSON 문자열 추출**을 사용:
- `set_allowed_paths`: `std.json.parseFromSlice` → **unescape** → root 저장 = `C:\Users\...`(단일 `\`)
- 업로드/다운로드 `filePath`: `req.string()`(`util.extractJsonString`) → 따옴표 사이 **raw 바이트**(unescape 안 함) → wire 의 `C:\Users\...`(이중 `\`) 그대로

`isPathAllowed` 의 `startsWith(filePath, root)` 가 두 번째 글자부터 어긋남(`\` vs `\`) → 항상 forbidden. 파일 I/O 자체는 Windows 가 `\` 를 정규화해 통과하므로 **문자열 비교만** 깨짐. macOS/Linux 경로엔 백슬래시가 없어 escape 가 안 생겨 무증상(그래서 CI 도 macOS/Linux 에서만 이 e2e 실행).

## 수정

`filePath` 를 `expandHome`+`isPathAllowed` 전에 `util.unescapeJsonStr`(std.json 과 동일 primitive)로 unescape → 양쪽이 동일한 실제 경로를 비교. macOS/Linux 는 escape-free 라 no-op(무회귀).

## 검증 (Windows 로컬)

- `plugins/upload/zig` 재빌드 ok
- `zig build test-upload` ok
- `bash tests/e2e/run-plugin-upload.sh` → **5 pass / 0 fail** (이전: multipart 업로드 + 다운로드 라운드트립이 "forbidden path" 로 실패)

> 잠재(이 PR 범위 외): `req.string()`/`util.extractJsonString` 가 일반적으로 raw-escaped 값을 반환 — Windows 에서 req.string 경로를 std.json 파싱 값과 비교하는 다른 백엔드도 동일 mismatch 가능. 현재 다른 플러그인/fs-sandbox e2e 는 통과. 중앙 `req.stringUnescaped()` 도입은 더 큰 SDK 변경이라 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)