### PR TITLE
feat(sdk): add Request.stringUnescaped() + fix latent JSON-unescape path bugs

### DIFF
--- a/plugins/upload/zig/app.zig
+++ b/plugins/upload/zig/app.zig
@@ -158,19 +158,6 @@ fn expandHome(arena: std.mem.Allocator, path: []const u8) []const u8 {
     return std.fmt.allocPrint(arena, "{s}{s}", .{ home, path[1..] }) catch path;
 }
 
-/// req.string() (util.extractJsonString) 는 JSON escape 를 **unescape 하지 않고** 따옴표
-/// 사이 raw 바이트를 반환한다 → Windows 경로가 `C:\\Users\\...`(이중 백슬래시) 로 온다.
-/// 반면 set_allowed_paths 는 std.json(parseStringArrayInto)으로 **unescape** 해 `C:\Users\...`
-/// (단일 백슬래시)로 저장한다. 둘을 그대로 비교하면 Windows 에서 startsWith 가 항상 어긋나
-/// 모든 업로드/다운로드가 "forbidden path" 가 된다(파일 I/O 는 Windows 가 `\\` 를 정규화해
-/// 통과하지만 문자열 비교만 실패 — macOS/Linux 는 경로에 escape 가 없어 무증상). filePath 도
-/// allowlist 와 동일하게 unescape 해 양쪽 표현을 맞춘다.
-fn unescapePath(arena: std.mem.Allocator, raw: []const u8) []const u8 {
-    const buf = arena.alloc(u8, raw.len) catch return raw;
-    const n = util.unescapeJsonStr(raw, buf) orelse return raw;
-    return buf[0..n];
-}
-
 /// multipart 폼 필드 값(파일명/필드명) 안의 `"`/CR/LF 차단 — 헤더 인젝션 방지.
 fn validFormToken(s: []const u8) bool {
     if (s.len == 0 or s.len > 256) return false;
@@ -200,9 +187,12 @@ fn emitProgress(arena: std.mem.Allocator, id: []const u8, n: u64) void {
 fn uploadFile(req: suji.Request, _: suji.InvokeEvent) suji.Response {
     const url = req.string("url") orelse return req.err("missing url");
     if (validateUrl(req, url)) |e| return e;
-    const raw_path = req.string("filePath") orelse return req.err("missing filePath");
+    // stringUnescaped: filePath 를 allowlist(std.json 파싱, unescaped)와 동일 표현으로.
+    // string() 은 raw 바이트라 Windows 경로가 `C:\\Users\\…`(이중 백슬래시) → startsWith
+    // 불일치로 항상 forbidden(파일 I/O 는 통과, 비교만 실패; macOS/Linux 무증상).
+    const raw_path = req.stringUnescaped("filePath") orelse return req.err("missing filePath");
     if (raw_path.len == 0 or raw_path.len > MAX_PATH_LEN) return req.err("invalid filePath");
-    const file_path = expandHome(req.arena, unescapePath(req.arena, raw_path));
+    const file_path = expandHome(req.arena, raw_path);
     if (!isPathAllowed(file_path)) return req.err("forbidden path");
 
     const field = req.string("fieldName") orelse "file";
@@ -265,9 +255,12 @@ fn uploadFile(req: suji.Request, _: suji.InvokeEvent) suji.Response {
 fn downloadFile(req: suji.Request, _: suji.InvokeEvent) suji.Response {
     const url = req.string("url") orelse return req.err("missing url");
     if (validateUrl(req, url)) |e| return e;
-    const raw_path = req.string("filePath") orelse return req.err("missing filePath");
+    // stringUnescaped: filePath 를 allowlist(std.json 파싱, unescaped)와 동일 표현으로.
+    // string() 은 raw 바이트라 Windows 경로가 `C:\\Users\\…`(이중 백슬래시) → startsWith
+    // 불일치로 항상 forbidden(파일 I/O 는 통과, 비교만 실패; macOS/Linux 무증상).
+    const raw_path = req.stringUnescaped("filePath") orelse return req.err("missing filePath");
     if (raw_path.len == 0 or raw_path.len > MAX_PATH_LEN) return req.err("invalid filePath");
-    const file_path = expandHome(req.arena, unescapePath(req.arena, raw_path));
+    const file_path = expandHome(req.arena, raw_path);
     if (!isPathAllowed(file_path)) return req.err("forbidden path");
     const id = req.string("id") orelse "";
     if (id.len > 256) return req.err("id too long");

--- a/src/core/app.zig
+++ b/src/core/app.zig
@@ -215,6 +215,21 @@ pub const Request = struct {
         return extractStringField(self.raw, key);
     }
 
+    /// JSON에서 문자열 필드 추출 + JSON escape **unescape** (req.arena 할당).
+    /// string()은 따옴표 사이 raw 바이트를 반환(zero-alloc)하므로 escape(`\\`/`\"`/`\n`/
+    /// `\uXXXX` 등)가 그대로 남는다. 특히 Windows 경로는 와이어에서 `C:\\Users\\x`로
+    /// 이스케이프돼 오므로 string()은 이중 백슬래시를 돌려준다 → 이를 std.json으로
+    /// 파싱된 값(예: allowlist root)과 startsWith 비교하면 항상 어긋난다("forbidden path").
+    /// **실제 문자열로** 비교/사용해야 하는 경로·escape 포함 값은 이걸 쓴다.
+    /// 키 부재 시 null, alloc 실패 시 raw(string()) 폴백(best-effort, 비파괴).
+    /// macOS/Linux 경로엔 escape가 없어 사실상 string()과 동일(복사만).
+    pub fn stringUnescaped(self: *const Request, key: []const u8) ?[]const u8 {
+        const raw = extractStringField(self.raw, key) orelse return null;
+        const buf = self.arena.alloc(u8, raw.len) catch return raw;
+        const n = util.unescapeJsonStr(raw, buf) orelse return raw;
+        return buf[0..n];
+    }
+
     /// JSON에서 정수 필드 추출
     pub fn int(self: *const Request, key: []const u8) ?i64 {
         return extractIntField(self.raw, key);

--- a/src/main.zig
+++ b/src/main.zig
@@ -2470,7 +2470,13 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
     }
     if (std.mem.eql(u8, cmd, "desktop_capturer_capture_thumbnail")) {
         const source_id = util.extractJsonString(req_clean, "sourceId") orelse "";
-        const path = util.extractJsonString(req_clean, "path") orelse "";
+        // 다른 게이트 호출부(native_image / print_to_pdf / shell_* 등)와 동일하게 path 를
+        // unescape 한 뒤 게이트/캡처에 사용 — extractJsonString 은 raw(미-unescape)라 Windows
+        // 경로가 `C:\\…`(이중 백슬래시)로 남아 allowedRoots(config std.json, unescaped)와 어긋나
+        // (opt-in fs.allowedRoots 설정 시) 정상 경로가 forbidden 된다. 이 호출부만 누락돼 있었다.
+        const raw_path = util.extractJsonString(req_clean, "path") orelse "";
+        var dc_path_buf: [FS_MAX_PATH_BYTES]u8 = undefined;
+        const path = if (util.unescapeJsonStr(raw_path, &dc_path_buf)) |n| dc_path_buf[0..n] else raw_path;
         if (rendererPathFsGate(response_buf, "desktop_capturer_capture_thumbnail", path)) |e| return e;
         const ok = source_id.len > 0 and path.len > 0 and
             cef.desktopCapturerCaptureThumbnail(source_id, path);

--- a/tests/app_test.zig
+++ b/tests/app_test.zig
@@ -1843,3 +1843,23 @@ test "emitSchemaTs: schema 미등록이면 빈 interface(라인 0)" {
     // wrapper 는 나오되 interface 본문 0줄.
     try std.testing.expect(std.mem.indexOf(u8, buf[0..n], "interface SujiHandlers {\n  }") != null);
 }
+
+test "Request.stringUnescaped: JSON escape unescaped (Windows path)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    // 와이어 JSON 값의 백슬래시는 이스케이프돼 온다(x5c=백슬래시, x22=따옴표 hex escape —
+    // 리터럴 백슬래시 중첩 혼동 방지). 즉 값 바이트는 이중 백슬래시(C:\x5c\x5cUsers...).
+    const raw = "{\x22filePath\x22:\x22C:\x5c\x5cUsers\x5c\x5cout.bin\x22}";
+    const req = app_mod.Request{ .raw = raw, .arena = arena.allocator() };
+
+    // string(): raw 바이트 — 이스케이프된 이중 백슬래시 그대로(미해제).
+    try std.testing.expectEqualStrings("C:\x5c\x5cUsers\x5c\x5cout.bin", req.string("filePath").?);
+    // stringUnescaped(): 실제 경로 — 단일 백슬래시.
+    try std.testing.expectEqualStrings("C:\x5cUsers\x5cout.bin", req.stringUnescaped("filePath").?);
+    // 키 부재 → null.
+    try std.testing.expect(req.stringUnescaped("nope") == null);
+
+    // escape 없는 값(macOS/Linux 경로)은 그대로(no-op 복사).
+    const req2 = app_mod.Request{ .raw = "{\x22p\x22:\x22/Users/out.bin\x22}", .arena = arena.allocator() };
+    try std.testing.expectEqualStrings("/Users/out.bin", req2.stringUnescaped("p").?);
+}


### PR DESCRIPTION
## 배경

#156 에서 잡은 upload "forbidden path" 의 **근본 원인**을 중앙에서 해결. `req.string()`/`util.extractJsonString` 는 따옴표 사이 **raw 바이트**(zero-alloc 차용 슬라이스, 의도적 미-unescape)를 반환 → Windows 경로 `"C:\Users\x"` 가 이중 백슬래시로 옴. 이를 std.json 으로 파싱된 값(allowlist root, unescaped)과 비교하면 두 번째 글자부터 어긋남 → forbidden. macOS/Linux 경로엔 백슬래시가 없어 무증상(CI 도 macOS/Linux 에서만 해당 e2e 실행).

## 변경

- **`src/core/app.zig`**: `Request.stringUnescaped(key)` 신설 — 필드 추출 후 `util.unescapeJsonStr`(std.json 과 동일 primitive)로 `req.arena` 에 unescape. 경로 비교/사용 시 `string()` 대신 사용. `string()` 자체는 raw/zero-alloc 유지(의도).
- **`plugins/upload/zig/app.zig`**: filePath 를 `req.stringUnescaped()` 로 이관 — #156 의 로컬 헬퍼 제거, 수정이 SDK 로 통합.
- **`src/main.zig`**: 렌더러-경로 게이트 호출부 10곳 전수 감사. 9곳은 이미 게이트 전 unescape(`unescapeField`/수동/`std.json`). 유일 outlier `desktop_capturer_capture_thumbnail` 가 raw 경로를 게이트에 넘기던 것 → sibling 패턴대로 unescape(`fs.allowedRoots` 설정 시 영향, `..`/`\u` traversal 검사도 실경로로). ⚠️ 게이트 **내부** unescape 는 일부러 안 함 — 대부분 호출부가 이미 unescape 하므로 이중 적용 시 `C:\temp`→`C:<TAB>emp` 손상.
- **`tests/app_test.zig`**: stringUnescaped 유닛 테스트(Windows escaped 경로 → string() 이중 백슬래시 vs stringUnescaped() 단일; 키 부재 null; escape-free no-op). 백슬래시 모호성 회피 위해 `\x5c`/`\x22` hex escape 사용.

## 검증 (Windows 로컬)

- `zig build` + `zig build test` → **77/77 steps, 944/955 passed (11 skipped, 0 fail)** (신규 stringUnescaped 테스트 포함)
- `zig build test-upload` ok
- `bash tests/e2e/run-plugin-upload.sh` → **5 pass / 0 fail** (upload 가 이제 req.stringUnescaped 경유)

🤖 Generated with [Claude Code](https://claude.com/claude-code)