### PR TITLE
chore(review): address /code-review max findings on PRs #151-157

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,11 +341,11 @@ suji::export_handlers!(ping);
 // suji::dock::{set_badge("99"), get_badge()}
 // suji::get_path("userData") / get_path("home") ...
 // suji::web_request::set_blocked_urls(&["https://*.ad/*"])  — URL glob blocklist
-// suji::auto_updater::{check_for_updates(cur,latest,url,sha256,notes,pub_date),
-//   verify_file(path,sha256), download_artifact(url,path,sha256),
-//   prepare_install(path,target,stage_dir,format,sha256),
-//   quit_and_install(path,target,sha256,relaunch,helper_path)}  — Electron autoUpdater
-//   (manifest check + download + SHA-256 verify + quit-and-install; raw Option<String>.
+// suji::auto_updater::check_for_updates(&CheckUpdate{ current_version, latest_version, url, sha256, notes, pub_date })
+//   / verify_file(&VerifyFile{path,sha256}) / download_artifact(&DownloadArtifact{url,path,sha256})
+//   / prepare_install(&PrepareInstall{path,target,stage_dir,format,sha256})
+//   / quit_and_install(&QuitAndInstall{path,target,sha256,relaunch,helper_path})  — Electron autoUpdater
+//   (옵션 구조체로 인자 위치 혼동 방지, ..Default::default() 생략 가능; raw Option<String>.
 //    backend SDK 라 manifest fetch 없이 명시 파라미터로 core 호출 — JS/Node 와 동일 5 커맨드)
 // suji::request_user_attention(true) / suji::cancel_user_attention_request(id)
 // suji::quit()                 — 앱 종료 (Electron app.quit())
@@ -398,11 +398,12 @@ var _ = suji.Bind(&App{})
 // import "github.com/ohah/suji-go/powersaveblocker"
 // powersaveblocker.Start("prevent_display_sleep") / Stop(id)
 // import "github.com/ohah/suji-go/autoupdater"
-// autoupdater.CheckForUpdates(cur, latest, url, sha256, notes, pubDate) / VerifyFile(path, sha256)
-//   / DownloadArtifact(url, path, sha256) / PrepareInstall(path, target, stageDir, format, sha256)
-//   / QuitAndInstall(path, target, sha256, relaunch, helperPath)  — Electron autoUpdater
-//   (manifest check + download + SHA-256 verify + quit-and-install; raw JSON. backend SDK 라
-//    manifest fetch 없이 명시 파라미터로 core 호출 — JS/Node 와 동일 5 커맨드)
+// autoupdater.CheckForUpdates(autoupdater.CheckUpdateArgs{CurrentVersion, LatestVersion, URL, Sha256, Notes, PubDate})
+//   / VerifyFile(VerifyFileArgs{Path,Sha256}) / DownloadArtifact(DownloadArtifactArgs{URL,Path,Sha256})
+//   / PrepareInstall(PrepareInstallArgs{Path,Target,StageDir,Format,Sha256})
+//   / QuitAndInstall(QuitAndInstallArgs{Path,Target,Sha256,Relaunch,HelperPath})  — Electron autoUpdater
+//   (옵션 구조체로 인자 위치 혼동 방지; raw JSON. backend SDK 라 manifest fetch 없이 명시
+//    파라미터로 core 호출 — JS/Node 와 동일 5 커맨드)
 // import "github.com/ohah/suji-go/safestorage"
 // safestorage.SetItem(svc, acc, "v") / GetItem(svc, acc) / DeleteItem(svc, acc)
 // import "github.com/ohah/suji-go/dock"

--- a/build.zig
+++ b/build.zig
@@ -577,44 +577,9 @@ pub fn build(b: *std.Build) void {
     python_options.addOption([]const u8, "python_home", python_path);
     python_options.addOption([]const u8, "python_minor", python_minor);
     root_module.addImport("python_config", python_options.createModule());
-    if (python_available) {
-        root_module.link_libc = true;
-        switch (os_tag) {
-            // Windows: PBS 레이아웃은 헤더가 include/ 직접, import-lib 는 libs/.
-            // python313.lib(full API → python313.dll). MinGW zig 가 MSVC import-lib 를
-            // 링크하는 것은 libcef(MSVC)와 동일 선례. python.zig 의 c.Py* 직접 호출이
-            // 전체 C API 라 stable-ABI python3.lib 가 아닌 python313.lib 사용.
-            .windows => {
-                const py_include = std.fmt.allocPrint(b.allocator, "{s}/include", .{python_path}) catch @panic("OOM");
-                root_module.addIncludePath(.{ .cwd_relative = py_include });
-                const import_lib = std.fmt.allocPrint(b.allocator, "{s}/libs/python{s}.lib", .{ python_path, python_abi }) catch @panic("OOM");
-                root_module.addObjectFile(.{ .cwd_relative = import_lib });
-            },
-            else => {
-                const py_include = std.fmt.allocPrint(b.allocator, "{s}/include/python{s}", .{ python_path, python_minor }) catch @panic("OOM");
-                root_module.addIncludePath(.{ .cwd_relative = py_include });
-                const py_libdir = std.fmt.allocPrint(b.allocator, "{s}/lib", .{python_path}) catch @panic("OOM");
-                root_module.addLibraryPath(.{ .cwd_relative = py_libdir });
-                // weak-link: python staging 머신에서 빌드해도 비-python 앱은
-                // libpython 부재 시 graceful(심볼 null, start 미호출이면 무영향).
-                root_module.linkSystemLibrary(std.fmt.allocPrint(b.allocator, "python{s}", .{python_minor}) catch @panic("OOM"), .{ .weak = true });
-                switch (os_tag) {
-                    // @executable_path/$ORIGIN: packaged 시 addInstallPythonRuntimeStep 이
-                    // libpython 을 exe 옆에 둔다. py_libdir: dev(zig-out/bin/suji dev) 가
-                    // staging libpython 을 바로 찾도록 하는 절대경로 폴백.
-                    .macos => {
-                        root_module.addRPathSpecial("@executable_path");
-                        root_module.addRPathSpecial(py_libdir);
-                    },
-                    .linux => {
-                        root_module.addRPathSpecial("$ORIGIN");
-                        root_module.addRPathSpecial(py_libdir);
-                    },
-                    else => {},
-                }
-            },
-        }
-    }
+    // weak=true: python staging 머신에서 빌드해도 비-python 앱은 libpython 부재 시
+    // graceful(심볼 null, start 미호출이면 무영향). 인라인 test 모듈도 같은 헬퍼 사용.
+    if (python_available) linkPythonModule(b, root_module, os_tag, python_path, python_minor, python_abi, true);
 
     const exe = b.addExecutable(.{
         .name = "suji",
@@ -1498,27 +1463,11 @@ pub fn build(b: *std.Build) void {
         });
         python_runtime_test_mod.addImport("python_config", python_options.createModule());
         python_runtime_test_mod.addImport("runtime", runtime_module);
-        // main module(위 python 링크, line 580+)과 동형 — Windows 는 PBS 레이아웃
-        // (헤더 include/ 직접, import-lib libs/python<abi>.lib → python<abi>.dll),
-        // POSIX 는 include/python<minor> + lib/ + linkSystemLibrary + rpath.
-        // 테스트는 python_available 게이트 안에서만 빌드되므로 libpython 존재 보장.
-        switch (os_tag) {
-            .windows => {
-                const py_inc = std.fmt.allocPrint(b.allocator, "{s}/include", .{python_path}) catch @panic("OOM");
-                python_runtime_test_mod.addIncludePath(.{ .cwd_relative = py_inc });
-                const import_lib = std.fmt.allocPrint(b.allocator, "{s}/libs/python{s}.lib", .{ python_path, python_abi }) catch @panic("OOM");
-                python_runtime_test_mod.addObjectFile(.{ .cwd_relative = import_lib });
-            },
-            else => {
-                const py_inc = std.fmt.allocPrint(b.allocator, "{s}/include/python{s}", .{ python_path, python_minor }) catch @panic("OOM");
-                python_runtime_test_mod.addIncludePath(.{ .cwd_relative = py_inc });
-                const py_lib = std.fmt.allocPrint(b.allocator, "{s}/lib", .{python_path}) catch @panic("OOM");
-                python_runtime_test_mod.addLibraryPath(.{ .cwd_relative = py_lib });
-                // rpath: cache 디렉토리에서 실행되는 테스트가 staging libpython 을 찾도록.
-                python_runtime_test_mod.linkSystemLibrary(std.fmt.allocPrint(b.allocator, "python{s}", .{python_minor}) catch @panic("OOM"), .{});
-                python_runtime_test_mod.addRPathSpecial(py_lib);
-            },
-        }
+        // main module 과 동일 헬퍼 — 링크 레시피 단일 출처(weak=false: 테스트는
+        // python_available 게이트 안에서만 빌드돼 libpython 존재가 보장되므로 hard-link).
+        // 헬퍼의 @executable_path/$ORIGIN rpath 는 cache-dir 테스트에선 무해(절대 py_libdir
+        // rpath 가 staging libpython 을 해석). Windows DLL 은 아래 run-step PATH 로 노출.
+        linkPythonModule(b, python_runtime_test_mod, os_tag, python_path, python_minor, python_abi, false);
         const python_runtime_test = b.addTest(.{ .root_module = python_runtime_test_mod });
         // Windows 는 rpath 부재 → python<abi>.dll(+vcruntime140*.dll, python_path 에 동반)을
         // run step PATH 로 노출. cwd=project root(인라인 test 가 main.py 상대경로 로드).
@@ -1541,6 +1490,19 @@ pub fn build(b: *std.Build) void {
     });
     const clipboard_cf_html_test = b.addTest(.{ .root_module = clipboard_cf_html_test_mod });
     test_step.dependOn(&b.addRunArtifact(clipboard_cf_html_test).step);
+
+    // core util 인라인 테스트(matchGlob/pathHasRootBoundary/unescapeJsonStr surrogate 등) —
+    // 그동안 `zig build test` 에 미배선이라 직접 `zig test` 로만 돌았다. CEF-free leaf 라
+    // 안전하게 스위트에 포함(unescapeJsonStr surrogate 페어 회귀 등을 CI 가 가드).
+    const util_test_mod = b.createModule(.{
+        .root_source_file = b.path("src/core/util.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    const util_test = b.addTest(.{ .root_module = util_test_mod });
+    test_step.dependOn(&b.addRunArtifact(util_test).step);
+
     cef_ipc_test_mod.addImport("clipboard_cf_html", clipboard_cf_html_test_mod);
     const cef_ipc_test = b.addTest(.{ .root_module = cef_ipc_test_mod });
     test_step.dependOn(&b.addRunArtifact(cef_ipc_test).step);
@@ -1640,6 +1602,50 @@ pub fn build(b: *std.Build) void {
 // 런타임에 PYTHONHOME=`<exe>/python`(backend_lifecycle.startPython)으로 가리킨다.
 // dev 는 이 복사본을 쓰지 않고 staging(python_config.python_home)을 직접 참조하므로
 // 큰 stdlib 복사는 `dest` 가 이미 있으면 skip(증분 빌드 비용 0).
+/// Embedded CPython 링크 레시피 — main 모듈(exe)과 인라인 test 모듈이 공유(단일 출처).
+/// Windows: PBS 레이아웃(헤더 include/ 직접, import-lib libs/python<abi>.lib → python<abi>.dll;
+///   MinGW zig 가 MSVC import-lib 링크 = libcef 선례, python.zig c.Py* 전체 C API 라 python<abi>.lib).
+/// POSIX: include/python<minor> + lib/ + linkSystemLibrary("python<minor>") + rpath
+///   (@executable_path/$ORIGIN = packaged exe 옆 libpython, py_libdir = dev staging 절대경로 폴백).
+/// weak=true(메인): 비-python 앱 graceful. weak=false(테스트): python_available 게이트 안이라 보장.
+fn linkPythonModule(
+    b: *std.Build,
+    mod: *std.Build.Module,
+    os_tag: std.Target.Os.Tag,
+    python_path: []const u8,
+    python_minor: []const u8,
+    python_abi: []const u8,
+    weak: bool,
+) void {
+    mod.link_libc = true;
+    switch (os_tag) {
+        .windows => {
+            const py_include = std.fmt.allocPrint(b.allocator, "{s}/include", .{python_path}) catch @panic("OOM");
+            mod.addIncludePath(.{ .cwd_relative = py_include });
+            const import_lib = std.fmt.allocPrint(b.allocator, "{s}/libs/python{s}.lib", .{ python_path, python_abi }) catch @panic("OOM");
+            mod.addObjectFile(.{ .cwd_relative = import_lib });
+        },
+        else => {
+            const py_include = std.fmt.allocPrint(b.allocator, "{s}/include/python{s}", .{ python_path, python_minor }) catch @panic("OOM");
+            mod.addIncludePath(.{ .cwd_relative = py_include });
+            const py_libdir = std.fmt.allocPrint(b.allocator, "{s}/lib", .{python_path}) catch @panic("OOM");
+            mod.addLibraryPath(.{ .cwd_relative = py_libdir });
+            mod.linkSystemLibrary(std.fmt.allocPrint(b.allocator, "python{s}", .{python_minor}) catch @panic("OOM"), .{ .weak = weak });
+            switch (os_tag) {
+                .macos => {
+                    mod.addRPathSpecial("@executable_path");
+                    mod.addRPathSpecial(py_libdir);
+                },
+                .linux => {
+                    mod.addRPathSpecial("$ORIGIN");
+                    mod.addRPathSpecial(py_libdir);
+                },
+                else => {},
+            }
+        },
+    }
+}
+
 fn addInstallPythonRuntimeStep(b: *std.Build, python_path: []const u8, python_minor: []const u8, ext: []const u8, bin_dir: []const u8) *std.Build.Step {
     const copy = b.addSystemCommand(&.{
         "sh",

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2909,128 +2909,131 @@ pub mod crash_reporter {
 pub mod auto_updater {
     use crate::{invoke, serde_json};
 
-    pub(crate) fn check_update_request(
-        current_version: &str,
-        latest_version: &str,
-        url: &str,
-        sha256: &str,
-        notes: &str,
-        pub_date: &str,
-    ) -> String {
+    // 옵션 구조체 — 동일-타입 &str 인자의 위치 혼동(currentVersion↔latestVersion,
+    // path↔target, notes↔pubDate 등)을 named field 로 방지. 필드명 = core 커맨드 JSON 키.
+    // Default 로 미사용 필드 생략 가능: `CheckUpdate { current_version, latest_version, url, ..Default::default() }`.
+
+    /// manifest 의 latest 버전/URL 을 current 버전과 비교.
+    #[derive(Clone, Copy, Default)]
+    pub struct CheckUpdate<'a> {
+        pub current_version: &'a str,
+        pub latest_version: &'a str,
+        pub url: &'a str,
+        pub sha256: &'a str,
+        pub notes: &'a str,
+        pub pub_date: &'a str,
+    }
+
+    /// 다운로드된 파일의 SHA-256 검증.
+    #[derive(Clone, Copy, Default)]
+    pub struct VerifyFile<'a> {
+        pub path: &'a str,
+        pub sha256: &'a str,
+    }
+
+    /// artifact URL 을 지정 경로로 다운로드(+ optional SHA-256).
+    #[derive(Clone, Copy, Default)]
+    pub struct DownloadArtifact<'a> {
+        pub url: &'a str,
+        pub path: &'a str,
+        pub sha256: &'a str,
+    }
+
+    /// artifact 포맷(zip/dmg/app/AppImage/deb 또는 "auto") install 입력 정규화.
+    #[derive(Clone, Copy, Default)]
+    pub struct PrepareInstall<'a> {
+        pub path: &'a str,
+        pub target: &'a str,
+        pub stage_dir: &'a str,
+        pub format: &'a str,
+        pub sha256: &'a str,
+    }
+
+    /// staged artifact 를 종료 후 target 으로 교체.
+    #[derive(Clone, Copy, Default)]
+    pub struct QuitAndInstall<'a> {
+        pub path: &'a str,
+        pub target: &'a str,
+        pub sha256: &'a str,
+        pub relaunch: bool,
+        pub helper_path: &'a str,
+    }
+
+    pub(crate) fn check_update_request(a: &CheckUpdate) -> String {
         serde_json::json!({
             "cmd": "auto_updater_check_update",
-            "currentVersion": current_version,
-            "latestVersion": latest_version,
-            "url": url,
-            "sha256": sha256,
-            "notes": notes,
-            "pubDate": pub_date,
+            "currentVersion": a.current_version,
+            "latestVersion": a.latest_version,
+            "url": a.url,
+            "sha256": a.sha256,
+            "notes": a.notes,
+            "pubDate": a.pub_date,
         })
         .to_string()
     }
 
-    pub(crate) fn verify_file_request(path: &str, sha256: &str) -> String {
-        serde_json::json!({ "cmd": "auto_updater_verify_file", "path": path, "sha256": sha256 })
+    pub(crate) fn verify_file_request(a: &VerifyFile) -> String {
+        serde_json::json!({ "cmd": "auto_updater_verify_file", "path": a.path, "sha256": a.sha256 })
             .to_string()
     }
 
-    pub(crate) fn download_artifact_request(url: &str, path: &str, sha256: &str) -> String {
+    pub(crate) fn download_artifact_request(a: &DownloadArtifact) -> String {
         serde_json::json!({
             "cmd": "auto_updater_download_artifact",
-            "url": url,
-            "path": path,
-            "sha256": sha256,
+            "url": a.url,
+            "path": a.path,
+            "sha256": a.sha256,
         })
         .to_string()
     }
 
-    pub(crate) fn prepare_install_request(
-        path: &str,
-        target: &str,
-        stage_dir: &str,
-        format: &str,
-        sha256: &str,
-    ) -> String {
+    pub(crate) fn prepare_install_request(a: &PrepareInstall) -> String {
         serde_json::json!({
             "cmd": "auto_updater_prepare_install",
-            "path": path,
-            "target": target,
-            "stageDir": stage_dir,
-            "format": format,
-            "sha256": sha256,
+            "path": a.path,
+            "target": a.target,
+            "stageDir": a.stage_dir,
+            "format": a.format,
+            "sha256": a.sha256,
         })
         .to_string()
     }
 
-    pub(crate) fn quit_and_install_request(
-        path: &str,
-        target: &str,
-        sha256: &str,
-        relaunch: bool,
-        helper_path: &str,
-    ) -> String {
+    pub(crate) fn quit_and_install_request(a: &QuitAndInstall) -> String {
         serde_json::json!({
             "cmd": "auto_updater_quit_and_install",
-            "path": path,
-            "target": target,
-            "sha256": sha256,
-            "relaunch": relaunch,
-            "helperPath": helper_path,
+            "path": a.path,
+            "target": a.target,
+            "sha256": a.sha256,
+            "relaunch": a.relaunch,
+            "helperPath": a.helper_path,
         })
         .to_string()
     }
 
     /// manifest 의 latest 버전/URL 을 current 버전과 비교 → updateAvailable 등 raw JSON.
-    pub fn check_for_updates(
-        current_version: &str,
-        latest_version: &str,
-        url: &str,
-        sha256: &str,
-        notes: &str,
-        pub_date: &str,
-    ) -> Option<String> {
-        invoke(
-            "__core__",
-            &check_update_request(current_version, latest_version, url, sha256, notes, pub_date),
-        )
+    pub fn check_for_updates(args: &CheckUpdate) -> Option<String> {
+        invoke("__core__", &check_update_request(args))
     }
 
     /// 다운로드된 파일의 SHA-256 검증(mismatch 면 success=false + actualSha256).
-    pub fn verify_file(path: &str, sha256: &str) -> Option<String> {
-        invoke("__core__", &verify_file_request(path, sha256))
+    pub fn verify_file(args: &VerifyFile) -> Option<String> {
+        invoke("__core__", &verify_file_request(args))
     }
 
     /// artifact URL 을 지정 경로로 다운로드 + optional SHA-256 검증.
-    pub fn download_artifact(url: &str, path: &str, sha256: &str) -> Option<String> {
-        invoke("__core__", &download_artifact_request(url, path, sha256))
+    pub fn download_artifact(args: &DownloadArtifact) -> Option<String> {
+        invoke("__core__", &download_artifact_request(args))
     }
 
     /// artifact 포맷(zip/dmg/app/AppImage/deb 또는 "auto")을 install 입력으로 정규화.
-    pub fn prepare_install(
-        path: &str,
-        target: &str,
-        stage_dir: &str,
-        format: &str,
-        sha256: &str,
-    ) -> Option<String> {
-        invoke(
-            "__core__",
-            &prepare_install_request(path, target, stage_dir, format, sha256),
-        )
+    pub fn prepare_install(args: &PrepareInstall) -> Option<String> {
+        invoke("__core__", &prepare_install_request(args))
     }
 
     /// staged artifact 를 종료 후 target 으로 교체하고 quit 요청(relaunch 옵션).
-    pub fn quit_and_install(
-        path: &str,
-        target: &str,
-        sha256: &str,
-        relaunch: bool,
-        helper_path: &str,
-    ) -> Option<String> {
-        invoke(
-            "__core__",
-            &quit_and_install_request(path, target, sha256, relaunch, helper_path),
-        )
+    pub fn quit_and_install(args: &QuitAndInstall) -> Option<String> {
+        invoke("__core__", &quit_and_install_request(args))
     }
 }
 
@@ -4071,14 +4074,15 @@ mod tests {
 
     #[test]
     fn auto_updater_requests_build_valid_json() {
-        let check: serde_json::Value = serde_json::from_str(&crate::auto_updater::check_update_request(
-            "1.0.0",
-            "1.1.0",
-            "https://example.test/app.zip",
-            "abc",
-            "notes",
-            "2026-05-25T00:00:00Z",
-        ))
+        use crate::auto_updater::*;
+        let check: serde_json::Value = serde_json::from_str(&check_update_request(&CheckUpdate {
+            current_version: "1.0.0",
+            latest_version: "1.1.0",
+            url: "https://example.test/app.zip",
+            sha256: "abc",
+            notes: "notes",
+            pub_date: "2026-05-25T00:00:00Z",
+        }))
         .unwrap();
         assert_eq!(check["cmd"], "auto_updater_check_update");
         assert_eq!(check["currentVersion"], "1.0.0");
@@ -4086,30 +4090,41 @@ mod tests {
         assert_eq!(check["url"], "https://example.test/app.zip");
         assert_eq!(check["pubDate"], "2026-05-25T00:00:00Z");
 
-        let verify: serde_json::Value =
-            serde_json::from_str(&crate::auto_updater::verify_file_request("/tmp/app.zip", "abc"))
-                .unwrap();
+        let verify: serde_json::Value = serde_json::from_str(&verify_file_request(&VerifyFile {
+            path: "/tmp/app.zip",
+            sha256: "abc",
+        }))
+        .unwrap();
         assert_eq!(verify["cmd"], "auto_updater_verify_file");
         assert_eq!(verify["path"], "/tmp/app.zip");
         assert_eq!(verify["sha256"], "abc");
 
-        let download: serde_json::Value = serde_json::from_str(
-            &crate::auto_updater::download_artifact_request("https://x/app.zip", "/tmp/app.zip", ""),
-        )
-        .unwrap();
+        let download: serde_json::Value =
+            serde_json::from_str(&download_artifact_request(&DownloadArtifact {
+                url: "https://x/app.zip",
+                path: "/tmp/app.zip",
+                ..Default::default()
+            }))
+            .unwrap();
         assert_eq!(download["cmd"], "auto_updater_download_artifact");
         assert_eq!(download["url"], "https://x/app.zip");
 
-        let prepare: serde_json::Value = serde_json::from_str(
-            &crate::auto_updater::prepare_install_request("/tmp/app.zip", "", "", "auto", ""),
-        )
-        .unwrap();
+        let prepare: serde_json::Value =
+            serde_json::from_str(&prepare_install_request(&PrepareInstall {
+                path: "/tmp/app.zip",
+                format: "auto",
+                ..Default::default()
+            }))
+            .unwrap();
         assert_eq!(prepare["cmd"], "auto_updater_prepare_install");
         assert_eq!(prepare["format"], "auto");
 
-        let quit: serde_json::Value = serde_json::from_str(
-            &crate::auto_updater::quit_and_install_request("/tmp/app.zip", "/Applications/X.app", "", true, ""),
-        )
+        let quit: serde_json::Value = serde_json::from_str(&quit_and_install_request(&QuitAndInstall {
+            path: "/tmp/app.zip",
+            target: "/Applications/X.app",
+            relaunch: true,
+            ..Default::default()
+        }))
         .unwrap();
         assert_eq!(quit["cmd"], "auto_updater_quit_and_install");
         assert_eq!(quit["target"], "/Applications/X.app");

--- a/sdks/suji-go/autoupdater/autoupdater.go
+++ b/sdks/suji-go/autoupdater/autoupdater.go
@@ -3,6 +3,10 @@
 // prepare/quit-and-install). Calls the same five `auto_updater_*` core commands
 // as the JS/Node SDK, but as a backend SDK it takes explicit params (no manifest
 // fetch / app.getVersion() client step — that is the caller's responsibility).
+//
+// Args are passed as option structs (not positional strings) so same-typed
+// fields (currentVersion vs latestVersion, path vs target, notes vs pubDate)
+// cannot be silently transposed. Struct field names map 1:1 to core JSON keys.
 package autoupdater
 
 import (
@@ -12,61 +16,100 @@ import (
 	"github.com/ohah/suji-go/internal/jsonesc"
 )
 
-// CheckForUpdates compares a manifest latest version/URL against the current
-// version and returns raw JSON (updateAvailable/version/url/...).
-func CheckForUpdates(currentVersion, latestVersion, url, sha256, notes, pubDate string) string {
-	return suji.Invoke("__core__", buildCheckUpdateRequest(currentVersion, latestVersion, url, sha256, notes, pubDate))
+// CheckUpdateArgs compares a manifest latest version/URL against the current version.
+type CheckUpdateArgs struct {
+	CurrentVersion string
+	LatestVersion  string
+	URL            string
+	Sha256         string
+	Notes          string
+	PubDate        string
 }
 
-// VerifyFile validates a downloaded file's SHA-256 (mismatch → success=false + actualSha256).
-func VerifyFile(path, sha256 string) string {
-	return suji.Invoke("__core__", buildVerifyFileRequest(path, sha256))
+// VerifyFileArgs validates a downloaded file's SHA-256.
+type VerifyFileArgs struct {
+	Path   string
+	Sha256 string
 }
 
-// DownloadArtifact downloads an artifact URL to path and optionally verifies SHA-256.
-func DownloadArtifact(url, path, sha256 string) string {
-	return suji.Invoke("__core__", buildDownloadArtifactRequest(url, path, sha256))
+// DownloadArtifactArgs downloads an artifact URL to a path (+ optional SHA-256).
+type DownloadArtifactArgs struct {
+	URL    string
+	Path   string
+	Sha256 string
 }
 
-// PrepareInstall normalizes an artifact format (zip/dmg/app/AppImage/deb or "auto")
-// into a quitAndInstall / system-package handoff input.
-func PrepareInstall(path, target, stageDir, format, sha256 string) string {
-	return suji.Invoke("__core__", buildPrepareInstallRequest(path, target, stageDir, format, sha256))
+// PrepareInstallArgs normalizes an artifact format (zip/dmg/app/AppImage/deb or "auto").
+type PrepareInstallArgs struct {
+	Path     string
+	Target   string
+	StageDir string
+	Format   string
+	Sha256   string
+}
+
+// QuitAndInstallArgs swaps the staged artifact into target after quit.
+type QuitAndInstallArgs struct {
+	Path       string
+	Target     string
+	Sha256     string
+	Relaunch   bool
+	HelperPath string
+}
+
+// CheckForUpdates returns raw JSON (updateAvailable/version/url/...).
+func CheckForUpdates(a CheckUpdateArgs) string {
+	return suji.Invoke("__core__", buildCheckUpdateRequest(a))
+}
+
+// VerifyFile returns raw JSON (success / actualSha256 on mismatch).
+func VerifyFile(a VerifyFileArgs) string {
+	return suji.Invoke("__core__", buildVerifyFileRequest(a))
+}
+
+// DownloadArtifact downloads and optionally verifies, returning raw JSON.
+func DownloadArtifact(a DownloadArtifactArgs) string {
+	return suji.Invoke("__core__", buildDownloadArtifactRequest(a))
+}
+
+// PrepareInstall normalizes an artifact into a quitAndInstall / handoff input.
+func PrepareInstall(a PrepareInstallArgs) string {
+	return suji.Invoke("__core__", buildPrepareInstallRequest(a))
 }
 
 // QuitAndInstall swaps the staged artifact into target after quit and requests quit.
-func QuitAndInstall(path, target, sha256 string, relaunch bool, helperPath string) string {
-	return suji.Invoke("__core__", buildQuitAndInstallRequest(path, target, sha256, relaunch, helperPath))
+func QuitAndInstall(a QuitAndInstallArgs) string {
+	return suji.Invoke("__core__", buildQuitAndInstallRequest(a))
 }
 
-func buildCheckUpdateRequest(currentVersion, latestVersion, url, sha256, notes, pubDate string) string {
+func buildCheckUpdateRequest(a CheckUpdateArgs) string {
 	return fmt.Sprintf(
 		`{"cmd":"auto_updater_check_update","currentVersion":"%s","latestVersion":"%s","url":"%s","sha256":"%s","notes":"%s","pubDate":"%s"}`,
-		jsonesc.Full(currentVersion), jsonesc.Full(latestVersion), jsonesc.Full(url),
-		jsonesc.Full(sha256), jsonesc.Full(notes), jsonesc.Full(pubDate))
+		jsonesc.Full(a.CurrentVersion), jsonesc.Full(a.LatestVersion), jsonesc.Full(a.URL),
+		jsonesc.Full(a.Sha256), jsonesc.Full(a.Notes), jsonesc.Full(a.PubDate))
 }
 
-func buildVerifyFileRequest(path, sha256 string) string {
+func buildVerifyFileRequest(a VerifyFileArgs) string {
 	return fmt.Sprintf(
 		`{"cmd":"auto_updater_verify_file","path":"%s","sha256":"%s"}`,
-		jsonesc.Full(path), jsonesc.Full(sha256))
+		jsonesc.Full(a.Path), jsonesc.Full(a.Sha256))
 }
 
-func buildDownloadArtifactRequest(url, path, sha256 string) string {
+func buildDownloadArtifactRequest(a DownloadArtifactArgs) string {
 	return fmt.Sprintf(
 		`{"cmd":"auto_updater_download_artifact","url":"%s","path":"%s","sha256":"%s"}`,
-		jsonesc.Full(url), jsonesc.Full(path), jsonesc.Full(sha256))
+		jsonesc.Full(a.URL), jsonesc.Full(a.Path), jsonesc.Full(a.Sha256))
 }
 
-func buildPrepareInstallRequest(path, target, stageDir, format, sha256 string) string {
+func buildPrepareInstallRequest(a PrepareInstallArgs) string {
 	return fmt.Sprintf(
 		`{"cmd":"auto_updater_prepare_install","path":"%s","target":"%s","stageDir":"%s","format":"%s","sha256":"%s"}`,
-		jsonesc.Full(path), jsonesc.Full(target), jsonesc.Full(stageDir),
-		jsonesc.Full(format), jsonesc.Full(sha256))
+		jsonesc.Full(a.Path), jsonesc.Full(a.Target), jsonesc.Full(a.StageDir),
+		jsonesc.Full(a.Format), jsonesc.Full(a.Sha256))
 }
 
-func buildQuitAndInstallRequest(path, target, sha256 string, relaunch bool, helperPath string) string {
+func buildQuitAndInstallRequest(a QuitAndInstallArgs) string {
 	return fmt.Sprintf(
 		`{"cmd":"auto_updater_quit_and_install","path":"%s","target":"%s","sha256":"%s","relaunch":%t,"helperPath":"%s"}`,
-		jsonesc.Full(path), jsonesc.Full(target), jsonesc.Full(sha256), relaunch, jsonesc.Full(helperPath))
+		jsonesc.Full(a.Path), jsonesc.Full(a.Target), jsonesc.Full(a.Sha256), a.Relaunch, jsonesc.Full(a.HelperPath))
 }

--- a/sdks/suji-go/autoupdater/autoupdater_test.go
+++ b/sdks/suji-go/autoupdater/autoupdater_test.go
@@ -7,7 +7,14 @@ import (
 
 func TestBuildCheckUpdateRequest(t *testing.T) {
 	var got map[string]any
-	if err := json.Unmarshal([]byte(buildCheckUpdateRequest("1.0.0", "1.1.0", "https://example.test/app.zip", "abc", "notes", "2026-05-25T00:00:00Z")), &got); err != nil {
+	if err := json.Unmarshal([]byte(buildCheckUpdateRequest(CheckUpdateArgs{
+		CurrentVersion: "1.0.0",
+		LatestVersion:  "1.1.0",
+		URL:            "https://example.test/app.zip",
+		Sha256:         "abc",
+		Notes:          "notes",
+		PubDate:        "2026-05-25T00:00:00Z",
+	})), &got); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 	if got["cmd"] != "auto_updater_check_update" {
@@ -23,7 +30,7 @@ func TestBuildCheckUpdateRequest(t *testing.T) {
 
 func TestBuildVerifyFileRequest(t *testing.T) {
 	var got map[string]any
-	if err := json.Unmarshal([]byte(buildVerifyFileRequest("/tmp/app.zip", "abc")), &got); err != nil {
+	if err := json.Unmarshal([]byte(buildVerifyFileRequest(VerifyFileArgs{Path: "/tmp/app.zip", Sha256: "abc"})), &got); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 	if got["cmd"] != "auto_updater_verify_file" {
@@ -36,7 +43,7 @@ func TestBuildVerifyFileRequest(t *testing.T) {
 
 func TestBuildDownloadArtifactRequest(t *testing.T) {
 	var got map[string]any
-	if err := json.Unmarshal([]byte(buildDownloadArtifactRequest("https://x/app.zip", "/tmp/app.zip", "")), &got); err != nil {
+	if err := json.Unmarshal([]byte(buildDownloadArtifactRequest(DownloadArtifactArgs{URL: "https://x/app.zip", Path: "/tmp/app.zip"})), &got); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 	if got["cmd"] != "auto_updater_download_artifact" {
@@ -49,7 +56,7 @@ func TestBuildDownloadArtifactRequest(t *testing.T) {
 
 func TestBuildPrepareInstallRequest(t *testing.T) {
 	var got map[string]any
-	if err := json.Unmarshal([]byte(buildPrepareInstallRequest("/tmp/app.zip", "", "", "auto", "")), &got); err != nil {
+	if err := json.Unmarshal([]byte(buildPrepareInstallRequest(PrepareInstallArgs{Path: "/tmp/app.zip", Format: "auto"})), &got); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 	if got["cmd"] != "auto_updater_prepare_install" {
@@ -62,7 +69,7 @@ func TestBuildPrepareInstallRequest(t *testing.T) {
 
 func TestBuildQuitAndInstallRequest(t *testing.T) {
 	var got map[string]any
-	if err := json.Unmarshal([]byte(buildQuitAndInstallRequest("/tmp/app.zip", "/Applications/X.app", "", true, "")), &got); err != nil {
+	if err := json.Unmarshal([]byte(buildQuitAndInstallRequest(QuitAndInstallArgs{Path: "/tmp/app.zip", Target: "/Applications/X.app", Relaunch: true})), &got); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 	if got["cmd"] != "auto_updater_quit_and_install" {

--- a/src/core/app.zig
+++ b/src/core/app.zig
@@ -222,9 +222,11 @@ pub const Request = struct {
     /// 파싱된 값(예: allowlist root)과 startsWith 비교하면 항상 어긋난다("forbidden path").
     /// **실제 문자열로** 비교/사용해야 하는 경로·escape 포함 값은 이걸 쓴다.
     /// 키 부재 시 null, alloc 실패 시 raw(string()) 폴백(best-effort, 비파괴).
-    /// macOS/Linux 경로엔 escape가 없어 사실상 string()과 동일(복사만).
+    /// 백슬래시 부재(escape 없음 = macOS/Linux 경로 등 일반 케이스)면 alloc/copy 없이
+    /// raw 슬라이스 그대로 반환(zero-alloc fast-path) — string()과 동일.
     pub fn stringUnescaped(self: *const Request, key: []const u8) ?[]const u8 {
         const raw = extractStringField(self.raw, key) orelse return null;
+        if (std.mem.indexOfScalar(u8, raw, '\\') == null) return raw;
         const buf = self.arena.alloc(u8, raw.len) catch return raw;
         const n = util.unescapeJsonStr(raw, buf) orelse return raw;
         return buf[0..n];

--- a/src/core/util.zig
+++ b/src/core/util.zig
@@ -163,9 +163,41 @@ pub fn unescapeJsonStr(src: []const u8, dst: []u8) ?usize {
                 i += 5;
                 continue;
             }
-            // 비-ASCII codepoint: dst에 UTF-8 인코딩 (최대 3바이트, BMP 가정).
+            // 비-ASCII codepoint → UTF-8 인코딩. 서로게이트 페어(high 0xD800–0xDBFF +
+            // 이어지는 \uXXXX low 0xDC00–0xDFFF)는 결합해 non-BMP 코드포인트로 — std.json
+            // 과 동일(allowlist 비교 정합: 경로에 emoji/CJK-ext 같은 non-BMP 가 있어도
+            // stringUnescaped 결과가 std.json 파싱 결과와 일치). 짝 없는 surrogate 는
+            // utf8Encode 가 실패하므로 literal 백슬래시 보존(아래 catch).
+            var cp: u21 = code;
+            if (code >= 0xD800 and code <= 0xDBFF) {
+                // 뒤따르는 \uXXXX low surrogate 탐색(\uXXXX\uYYYY = 12바이트).
+                if (i + 11 < src.len and src[i + 6] == '\\' and src[i + 7] == 'u') {
+                    const lo = std.fmt.parseInt(u16, src[i + 8 .. i + 12], 16) catch 0;
+                    if (lo >= 0xDC00 and lo <= 0xDFFF) {
+                        cp = 0x10000 + (@as(u21, code - 0xD800) << 10) + (lo - 0xDC00);
+                        i += 6; // low surrogate \uYYYY 추가 소비(아래 i += 5 와 합쳐 11)
+                    } else {
+                        // 짝 없는 high surrogate — literal 백슬래시 보존(기존 동작).
+                        if (w >= dst.len) return null;
+                        dst[w] = b;
+                        w += 1;
+                        continue;
+                    }
+                } else {
+                    if (w >= dst.len) return null;
+                    dst[w] = b;
+                    w += 1;
+                    continue;
+                }
+            } else if (code >= 0xDC00 and code <= 0xDFFF) {
+                // 단독 low surrogate — literal 백슬래시 보존.
+                if (w >= dst.len) return null;
+                dst[w] = b;
+                w += 1;
+                continue;
+            }
             var utf8_buf: [4]u8 = undefined;
-            const utf8_len = std.unicode.utf8Encode(code, &utf8_buf) catch {
+            const utf8_len = std.unicode.utf8Encode(cp, &utf8_buf) catch {
                 if (w >= dst.len) return null;
                 dst[w] = b;
                 w += 1;
@@ -436,6 +468,27 @@ test "unescapeJsonStr: \\u#### ASCII fast-path" {
     var dst: [32]u8 = undefined;
     const n = unescapeJsonStr("a\\u0041b\\u0020c", &dst).?;
     try std.testing.expectEqualStrings("aAb c", dst[0..n]);
+}
+
+test "unescapeJsonStr: BMP \\u#### → UTF-8" {
+    var dst: [32]u8 = undefined;
+    // U+00E9 (é) = 2바이트, U+AC00 (가) = 3바이트.
+    const n = unescapeJsonStr("\\u00e9\\uac00", &dst).?;
+    try std.testing.expectEqualStrings("\u{00e9}\u{ac00}", dst[0..n]);
+}
+
+test "unescapeJsonStr: surrogate pair \\uD83D\\uDE00 → non-BMP UTF-8 (std.json 정합)" {
+    var dst: [32]u8 = undefined;
+    // U+1F600 😀 = 😀 → 4바이트 UTF-8. std.json 과 동일하게 결합돼야.
+    const n = unescapeJsonStr("x\\uD83D\\uDE00y", &dst).?;
+    try std.testing.expectEqualStrings("x\u{1F600}y", dst[0..n]);
+}
+
+test "unescapeJsonStr: 짝 없는 high surrogate 는 literal 백슬래시 보존" {
+    var dst: [32]u8 = undefined;
+    // 뒤에 low surrogate 없음 → utf8Encode 불가 → 백슬래시 그대로(기존 동작 유지).
+    const n = unescapeJsonStr("\\uD83Dz", &dst).?;
+    try std.testing.expectEqualStrings("\\uD83Dz", dst[0..n]);
 }
 
 test "unescapeJsonStr: round-trip with escapeJsonStrFull" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1827,9 +1827,11 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         // 그대로 CEF·응답·event 로 흘러 path 라운드트립이 깨진다(JS 단 single
         // backslash ≠ echo double). unescape 로 실제 경로 복원(deferred-response
         // event 매칭 + FS gate 정확도). macOS 경로(`/`)는 unescape no-op.
-        var pdf_path_buf: [2048]u8 = undefined;
-        const pdf_raw = util.extractJsonString(req_clean, "path") orelse "";
-        const pdf_path = if (util.unescapeJsonStr(pdf_raw, &pdf_path_buf)) |n| pdf_path_buf[0..n] else pdf_raw;
+        // path unescape: 렌더러-경로 게이트 공용 primitive(extractUnescapedField).
+        // raw escaped 경로(Windows `\\`) → 실제 경로(FS gate 정확도 + deferred-response
+        // event path 매칭). macOS 경로(`/`)는 no-op.
+        var pdf_path_buf: [FS_MAX_PATH_BYTES]u8 = undefined;
+        const pdf_path = extractUnescapedField(req_clean, "path", &pdf_path_buf) orelse "";
         if (rendererPathFsGate(response_buf, "print_to_pdf", pdf_path)) |e| return e;
         return window_ipc.handlePrintToPDF(.{
             .window_id = win_id,
@@ -1855,9 +1857,9 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
             null;
         // print_to_pdf 와 동일 — raw escaped 경로를 unescape 해 Windows `\\`
         // 라운드트립 + event path 매칭 정상화.
-        var cap_path_buf: [2048]u8 = undefined;
-        const cap_raw = util.extractJsonString(req_clean, "path") orelse "";
-        const cap_path = if (util.unescapeJsonStr(cap_raw, &cap_path_buf)) |n| cap_path_buf[0..n] else cap_raw;
+        // print_to_pdf 와 동일 — extractUnescapedField 공용 primitive 로 unescape.
+        var cap_path_buf: [FS_MAX_PATH_BYTES]u8 = undefined;
+        const cap_path = extractUnescapedField(req_clean, "path", &cap_path_buf) orelse "";
         if (rendererPathFsGate(response_buf, "capture_page", cap_path)) |e| return e;
         return window_ipc.handleCapturePage(.{
             .window_id = win_id,
@@ -2470,13 +2472,12 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
     }
     if (std.mem.eql(u8, cmd, "desktop_capturer_capture_thumbnail")) {
         const source_id = util.extractJsonString(req_clean, "sourceId") orelse "";
-        // 다른 게이트 호출부(native_image / print_to_pdf / shell_* 등)와 동일하게 path 를
-        // unescape 한 뒤 게이트/캡처에 사용 — extractJsonString 은 raw(미-unescape)라 Windows
-        // 경로가 `C:\\…`(이중 백슬래시)로 남아 allowedRoots(config std.json, unescaped)와 어긋나
-        // (opt-in fs.allowedRoots 설정 시) 정상 경로가 forbidden 된다. 이 호출부만 누락돼 있었다.
-        const raw_path = util.extractJsonString(req_clean, "path") orelse "";
+        // path 는 extractUnescapedField(렌더러-경로 게이트 공용 primitive)로 unescape —
+        // extractJsonString 은 raw(미-unescape)라 Windows `C:\\…`(이중 백슬래시)가
+        // allowedRoots(std.json, unescaped)와 어긋나 forbidden 됨. helper 는 overflow/실패
+        // 시 null → "" → 아래 path.len 체크가 거부(escaped raw 통과 방지).
         var dc_path_buf: [FS_MAX_PATH_BYTES]u8 = undefined;
-        const path = if (util.unescapeJsonStr(raw_path, &dc_path_buf)) |n| dc_path_buf[0..n] else raw_path;
+        const path = extractUnescapedField(req_clean, "path", &dc_path_buf) orelse "";
         if (rendererPathFsGate(response_buf, "desktop_capturer_capture_thumbnail", path)) |e| return e;
         const ok = source_id.len > 0 and path.len > 0 and
             cef.desktopCapturerCaptureThumbnail(source_id, path);

--- a/tests/e2e/run-python-packaged.sh
+++ b/tests/e2e/run-python-packaged.sh
@@ -41,18 +41,34 @@ echo "[pkg-py] installing python-backend frontend deps"
 ( cd "$EXAMPLE/frontend" && bun install >/dev/null 2>&1 )
 
 echo "[pkg-py] suji build (package)"
+# stale 패키지 출력 제거 — 이전 빌드의 잔존 디렉토리를 잘못 선택하지 않도록(전부 gitignored 산출물).
+rm -rf "$EXAMPLE"/*-windows-x64 "$EXAMPLE"/*-windows-x64.zip \
+       "$EXAMPLE"/*-linux-x64 "$EXAMPLE"/*-linux-x64.tar.gz \
+       "$EXAMPLE"/*.app 2>/dev/null || true
 ( cd "$EXAMPLE" && "$SUJI_BIN" build )
 
-# 패키지 디렉토리 + exe 탐색 (현재 OS).
-plat="windows-x64"
-[ "$WIN" = 1 ] || plat="$(uname -s | tr '[:upper:]' '[:lower:]')-x64"
-PKG="$(ls -d "$EXAMPLE"/*"${plat}" 2>/dev/null | head -1 || true)"
-[ -n "$PKG" ] || { echo "FAIL: package dir (*${plat}) not found under $EXAMPLE"; ls "$EXAMPLE"; exit 1; }
-if [ "$WIN" = 1 ]; then
-  EXE="$(ls "$PKG"/*.exe 2>/dev/null | grep -ivE "subprocess|crashpad" | head -1 || true)"
-else
-  EXE="$(find "$PKG" -maxdepth 3 -type f -perm -u+x 2>/dev/null | grep -ivE "Helper|crashpad|\.so|\.dylib" | head -1 || true)"
-fi
+# 패키지 디렉토리 + exe 탐색 — suji build 출력은 OS마다 다르다:
+#   Windows: <name>-<ver>-windows-x64/  + .exe                 (packageWindows)
+#   Linux:   <name>-<ver>-linux-x64/    + bin/<name>            (packageLinux stage dir, 아카이브 후 잔존)
+#   macOS:   <name>.app                 + Contents/MacOS/<name> (bundle_macos.createBundle)
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    PKG="$(ls -d "$EXAMPLE"/*-windows-x64 2>/dev/null | head -1 || true)"
+    [ -n "$PKG" ] || { echo "FAIL: Windows package dir (*-windows-x64) not found under $EXAMPLE"; ls "$EXAMPLE"; exit 1; }
+    EXE="$(ls "$PKG"/*.exe 2>/dev/null | grep -ivE "subprocess|crashpad" | head -1 || true)"
+    ;;
+  Darwin)
+    PKG="$(ls -d "$EXAMPLE"/*.app 2>/dev/null | head -1 || true)"
+    [ -n "$PKG" ] || { echo "FAIL: macOS package (*.app) not found under $EXAMPLE"; ls "$EXAMPLE"; exit 1; }
+    # BSD find: -perm +111 = any exec bit. Contents/MacOS 의 main 바이너리(헬퍼 제외).
+    EXE="$(find "$PKG/Contents/MacOS" -maxdepth 1 -type f -perm +111 2>/dev/null | grep -ivE "Helper|crashpad" | head -1 || true)"
+    ;;
+  *)
+    PKG="$(ls -d "$EXAMPLE"/*-linux-x64 2>/dev/null | head -1 || true)"
+    [ -n "$PKG" ] || { echo "FAIL: Linux package dir (*-linux-x64) not found under $EXAMPLE"; ls "$EXAMPLE"; exit 1; }
+    EXE="$(find "$PKG/bin" -maxdepth 1 -type f -perm -u+x 2>/dev/null | grep -ivE "Helper|crashpad|\.so" | head -1 || true)"
+    ;;
+esac
 [ -n "$EXE" ] || { echo "FAIL: packaged executable not found in $PKG"; ls "$PKG"; exit 1; }
 
 echo "[pkg-py] launching packaged app: $EXE"


### PR DESCRIPTION
`/code-review max` (PRs #151–157) followups. No high-severity bugs were found; 이건 correctness edge-case + maintainability/dedup 수정.

## Correctness
- **`util.unescapeJsonStr` 서로게이트 페어 결합** — non-BMP(emoji/CJK-ext) 경로가 `😀` 로 와도 std.json(allowlist 파서)과 동일하게 결합. 안 하면 mangled → startsWith 불일치 → 정상 디렉토리가 forbidden. 짝 없는 surrogate 는 literal 보존. +유닛 테스트 3.
- **`run-python-packaged.sh` OS별 패키지 탐색** — 비-Windows glob(`*darwin-x64`/`*linux-x64`)이 실제 `suji build` 출력과 안 맞던 것(macOS=`.app`, Linux=`*-linux-x64/`, Windows=`*-windows-x64/`)을 OS-aware 로. + 빌드 전 stale 출력 제거. Windows 재검증 green.
- **desktop_capturer/print_to_pdf/capture_page → 공용 `extractUnescapedField`** — 3곳의 hand-rolled extract+unescape 복사본을 기존 helper 로 통합. helper 는 overflow 시 null→거부(over-length 에서 escaped raw 통과하던 엣지 해소). 단일 primitive → 다음 path-gate caller 가 Windows 를 재차 깨뜨릴 수 없음.

## Maintainability / dedup
- **`build.zig` `linkPythonModule` 공용 헬퍼** — main 모듈과 인라인 python test 모듈의 near-verbatim 링크 레시피(`.weak` 만 다름)를 단일 출처로.
- **`build.zig` util 테스트 스위트 배선** — `src/core/util.zig` 의 54개 인라인 테스트가 그동안 `zig build test` 미포함이었음(직접 `zig test` 만). 이제 포함(944→998) → 위 surrogate 수정이 CI 가드.
- **Rust/Go autoUpdater 옵션 구조체화** — 6개 동일-타입 string 인자(`currentVersion`↔`latestVersion`↔`notes`↔`pubDate`)가 silently 위치 전치 가능하던 것을 named-field 구조체로(`CheckUpdate`/`VerifyFile`/… , Go `*Args`). 테스트 + CLAUDE.md 갱신(unreleased API, 무breakage).
- **`Request.stringUnescaped` zero-alloc fast-path** — 백슬래시 없으면(POSIX 일반) arena alloc+copy skip.

## 의도적으로 안 고침 (리뷰에 명시)
- `e2e.yml` Windows python 스텝 순서(comment 로 enforce): 별도 job 분리는 CI 실행 검증 필요라 위험>이득 → 보류.
- `plugins/log`·`plugins/sqlite` 의 `req.string` 경로: 현재 allowlist 비교 없어 양성. 추가 시 stringUnescaped 로.
- `cef_single_instance_state` setter 무가드: startup-before-runtime 관례로 안전(기존, verbatim 이동).

## 검증 (Windows)
- `zig build test` → **79/79 steps, 998/1009 tests (11 skipped, 0 fail)**
- `cargo test auto_updater` ok / `go test ./autoupdater/` + `go build ./...` ok
- `run-python-packaged.sh` → PASS (embedded CPython init + frontend bind)

🤖 Generated with [Claude Code](https://claude.com/claude-code)