### PR TITLE
docs(python): mark Windows packaging done; narrow the remaining follow-up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,9 +184,10 @@ jobs:
           Copy-Item -Force -LiteralPath $importLib -Destination "$nodeDir\libnode.dll.a"
           Copy-Item -Recurse -Force -Path "$includeDir\*" -Destination "$nodeDir\include\"
           Write-Host "libnode staged from MSYS2: $nodeDir"
-      # Windows 는 python3.lib import-lib hard-link 이라 python313.dll 동반 staging 이
-      # 필요한데 addInstallPythonRuntimeStep Windows 분기가 후속(정직 경계) → macOS/Linux
-      # 에서만 staging 해 released CLI 가 python 지원. Windows 릴리스는 python off.
+      # macOS/Linux 에서만 staging 해 released CLI 가 python 지원(batteries-included).
+      # Windows 릴리스는 아직 python off — addInstallPythonRuntimeStep Windows pwsh 분기는
+      # 구현됐고(dev/CI webcontentsview-windows job 이 packaged python 검증), released
+      # 아티팩트 경로(staging→번들→exe 옆 python/ 자립 해석) 검증만 후속이라 보수적으로 off.
       - name: Stage Python (python-build-standalone)
         if: runner.os != 'Windows'
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1256,13 +1256,19 @@ curl-install 시 그 sibling 들을 함께 설치. CLI suji 는 sentinel 없이 
 빌트인 `suji` 모듈용 `.pyi`(handle/invoke/send/on). IDE/mypy/pyright 용, 런타임 코드
 없음. PyPI 발행만 후속(토큰 대기).
 
-**정직 경계(후속)**: ① **Windows packaging** — Windows 는 `python3.lib` import-lib
-hard-link 라 `python313.dll`+`Lib`/`DLLs` 동반 staging(PBS Windows 레이아웃)이
-필요해 build gate 에서 **python off 로 강제**(깨진 exe footgun 방지). `addInstall
-PythonRuntimeStep` Windows pwsh 분기 + Windows CI 반복이 필요한 별도 작업. CI/release
-의 python staging 도 macOS/Linux 한정. ② **iOS**: V8 처럼 CPython JIT 아닌
-인터프리터라 가능성은 있으나 iOS 용 python-build-standalone + 코드서명/샌드박스 +
-모바일 호스트(examples/ios) 배선이 필요 — 모바일 트랙 별도 작업, 미배선.
+**Windows packaging(완료)**: Windows 도 packaged python 동작 — `python313.lib` import-lib
+hard-link + `addInstallPythonRuntimeStep` Windows pwsh 분기가 `python313.dll`+`python3.dll`+
+`vcruntime140*.dll`(+ packaged 시 `Lib/`+`DLLs/`)를 exe 옆에 동반하고, `build.zig`
+python_available 게이트는 staging 존재만으로 활성(Windows 강제-off 제거 — macOS/Linux 동형).
+`suji build`→패키지 exe→번들 libpython init + frontend bind 를 `webcontentsview-windows`
+CI job 이 dev(`run-python-e2e.sh`) + packaged(`run-python-packaged.sh`) 양쪽으로 가드.
+
+**정직 경계(후속)**: ① **released Windows CLI 의 python 번들** — `release.yml` 은 아직
+Windows 에서 python off(`if: runner.os != 'Windows'` staging gate). 구현 블로커(Windows
+install step)는 해소됐고 release 아티팩트 경로(staging→번들→released `suji` 자립 해석) 검증만
+후속이라 release 에선 보수적으로 off. ② **iOS**: V8 처럼 CPython JIT 아닌 인터프리터라
+가능성은 있으나 iOS 용 python-build-standalone + 코드서명/샌드박스 + 모바일 호스트(examples/ios)
+배선이 필요 — 모바일 트랙 별도 작업, 미배선.
 
 ## 배포 / 설치
 


### PR DESCRIPTION
CLAUDE.md python "정직 경계(후속) ① Windows packaging" 노트(+ 매칭되는 release.yml 코멘트)가 stale — Windows packaged python 은 이번 사이클(PR #150/#151)에 구현됨.

## 변경 (doc/comment-only, 동작 불변)
- **CLAUDE.md**: ① 을 "**Windows packaging(완료)**" 으로 재작성. `addInstallPythonRuntimeStep` Windows pwsh 분기가 python313.dll+python3.dll+vcruntime140*.dll(+packaged 시 Lib/DLLs) 동반, `build.zig` python_available 게이트가 staging 존재만으로 활성(Windows 강제-off 제거), `webcontentsview-windows` CI job 이 dev+packaged 가드. 남은 후속은 **released CLI** — `release.yml` 이 아직 `if: runner.os != 'Windows'` 로 Windows staging skip(배포 Windows `suji` 에 python 미번들). 구현 블로커는 해소, release 아티팩트 경로 검증만 후속이라 보수적 off. ② iOS 무변경.
- **release.yml**: 코멘트가 "addInstallPythonRuntimeStep Windows 분기가 후속"이라 주장하던 것(이미 구현됨) 정정. release gate(`if: runner.os != 'Windows'`)는 **그대로** — 동작 변경 없음.

## 무영향 확인
`release_workflow_test.zig` 의 CLAUDE.md assertion 은 배포/설치 문자열(curl/install.sh/GitHub Releases/release.yml/Homebrew)만 검사 — 변경한 python 섹션과 무관. release.yml YAML 파싱 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)