### PR TITLE
feat(parity): dialog.showMessageBox icon + readFindText/accessibility 정직경계 (A 묶음 2/4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -539,7 +539,8 @@ suji.platform                                                // "macos" | "linux
 // await clipboard.readHTML() / writeHTML(html)                            (macOS NSPasteboard / Linux GTK text/html / Windows CF_HTML)
 // await shell.openExternal(url) / showItemInFolder(path) / beep() / trashItem(path)
 //   (macOS NSWorkspace + NSFileManager, Linux GIO/FileManager1, Windows ShellExecute/explorer/MessageBeep/SHFileOperation)
-// await dialog.showMessageBox({ type, message, buttons, defaultId, ... }) (macOS NSAlert / Linux GTK / Windows TaskDialog)
+// await dialog.showMessageBox({ type, message, buttons, defaultId, icon?, ... }) (macOS NSAlert / Linux GTK / Windows TaskDialog)
+//   icon=커스텀 아이콘 이미지 경로 → NSAlert.setIcon (macOS only, fs sandbox gate)
 // await dialog.showMessageBox(windowId, options)  — macOS sheet, Linux/Windows free-floating
 // await dialog.showOpenDialog({ properties:['openFile','multiSelections'], filters }) (NSOpenPanel / GTK FileChooser / Win32 file dialog)
 // await dialog.showOpenDialog(windowId, options) — macOS sheet, Linux/Windows free-floating

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -2629,6 +2629,8 @@ pub mod dialog {
         pub cancel_id: Option<usize>,
         pub checkbox_label: Option<&'a str>,
         pub checkbox_checked: bool,
+        /// 커스텀 아이콘 이미지 경로 (macOS NSAlert.setIcon).
+        pub icon: Option<&'a str>,
     }
 
     pub fn show_message_box(opts: MessageBoxOpts) -> Option<String> {
@@ -2675,6 +2677,9 @@ pub mod dialog {
         }
         if opts.checkbox_checked {
             req.insert("checkboxChecked".into(), serde_json::Value::Bool(true));
+        }
+        if let Some(ic) = opts.icon {
+            req.insert("icon".into(), serde_json::Value::String(ic.into()));
         }
         invoke("__core__", &serde_json::Value::Object(req).to_string())
     }

--- a/docs/electron-parity-audit.md
+++ b/docs/electron-parity-audit.md
@@ -232,9 +232,9 @@
 - **[low]** `app.getGPUInfo(infoType)` — Add app.getGPUInfo(infoType: 'basic'|'complete') to Suji's app module. Implementation: (1) Expose CEF GPU info getter in src/platform/cef.zig (CEF BrowserHost has GetVisibleNavigationEntry → GPU conte
 - **[low]** `getLoginItemSettings(options?)` — Add app.getLoginItemSettings([options?]) to both @suji/api (frontend) and @suji/node (backend). Implement platform-specific handlers: (1) macOS: query NSWorkspace / LaunchServices / UserDefaults for a
 - **[low]** `app.setLoginItemSettings(settings)` — Add app.setLoginItemSettings(settings) and app.getLoginItemSettings() methods to /Users/yoonhb/Documents/workspace/suji/packages/suji-js/src/index.ts and /packages/suji-node/src/index.ts, mirroring th
-- **[low]** `app.isAccessibilitySupportEnabled()` — Add `isAccessibilitySupportEnabled(): Promise<boolean>` to the `app` module in both packages/suji-node/src/index.ts (line ~1620) and packages/suji-js/src/index.ts. Implementation: async invoke of a ne
+- **[보류]** `app.isAccessibilitySupportEnabled()` — CEF 가 Chromium accessibility(screen reader) 활성 상태를 노출 안 함; NSWorkspace 엔 시각 접근성 플래그(고대비/투명도)만 있고 VoiceOver 상태는 부재 → Electron 의미(screen reader 감지)로 정확 구현 불가(정직 경계). Add `isAccessibilitySupportEnabled(): Promise<boolean>` to the `app` module in both packages/suji-node/src/index.ts (line ~1620) and packages/suji-js/src/index.ts. Implementation: async invoke of a ne
 - **[low]** `app.setAccessibilitySupportEnabled(enabled: boolean) and app.isAccessibilitySupportEnabled()` — Add accessibility support methods to the app namespace in /packages/suji-js/src/index.ts: setAccessibilitySupportEnabled(enabled: boolean) -> coreCall with cmd "app_set_accessibility_support_enabled",
-- **[low]** `app.getAccessibilitySupportFeatures()` — Add app.getAccessibilitySupportFeatures() method returning string[] to all 5 SDK surfaces. Implementation would query CEF for active accessibility modes (screen reader, native APIs, etc.) and map to E
+- **[보류]** `app.getAccessibilitySupportFeatures()` — CEF accessibility 상태 미노출(isAccessibilitySupportEnabled 와 동일 사유, 정직 경계). Add app.getAccessibilitySupportFeatures() method returning string[] to all 5 SDK surfaces. Implementation would query CEF for active accessibility modes (screen reader, native APIs, etc.) and map to E
 - **[low]** `setAccessibilitySupportFeatures` — Add setAccessibilitySupportFeatures(features: string[]): Promise<boolean> method to the app module in both @suji/js (packages/suji-js/src/index.ts around line 1523 where app object is defined) and @su
 - **[low]** `app.setAboutPanelOptions(options) / app.showAboutPanel()` — Add two methods to the app namespace: 1. app.setAboutPanelOptions(options) — accepts {applicationName?, applicationVersion?, copyright?, credits?, version?, authors?, website?, iconPath?} 2. app.showA
 - **[low]** `app.isEmojiPanelSupported()` — Add app.isEmojiPanelSupported() method to all SDK layers (suji-js, suji-node, Rust, Go) — follows the pattern of other app.* boolean checks like isPackaged()/isReady(). Backend: Zig core should expose
@@ -244,14 +244,14 @@
 
 ### clipboard
 
-- **[low]** `clipboard.readFindText()` — Add readFindText(): Promise<string> to clipboard module. Implement in Zig core (src/main.zig): add clipboard_read_find_text command handler that calls new cef.clipboardReadFindText() function. In cef.
+- ~~**[low]** `clipboard.readFindText()`~~ ✅ (이미 구현 — cef_clipboard.zig clipboardReadFindText + main.zig dispatch + JS/Go SDK; audit outdated) — Add readFindText(): Promise<string> to clipboard module. Implement in Zig core (src/main.zig): add clipboard_read_find_text command handler that calls new cef.clipboardReadFindText() function. In cef.
 - ~~**[low]** `clipboard.has(format[, type])`~~ ✅ — Add optional `type?: 'clipboard' | 'selection'` parameter to `clipboard.has()` in packages/suji-js/src/index.ts and packages/suji-node/src/index.ts. Update Zig handler at src/main.zig:2204 to extract 
 
 ### dialog
 
-- **[low]** `dialog.showMessageBox() — option: 'icon' (custom icon)` — Add optional 'icon' field to MessageBoxOptions interfaces (suji-js and suji-node packages), add corresponding 'icon: []const u8 = ""' field to MessageBoxOpts struct in src/platform/cef.zig (line 3675)
-- **[low]** `dialog.showSaveDialog() — option: 'securityScopedBookmarks' (macOS/MAS)` — Add `securityScopedBookmarks?: boolean` to SaveDialogOptions in packages/suji-js/src/index.ts (line 1229) and packages/suji-node/src/index.ts (line 1190). Add field to SaveDialogJson struct in src/mai
-- **[low]** `dialog.showOpenDialog() / dialog.showSaveDialog() — properties: 'dontAddToRecent'` — Add "dontAddToRecent" as a string literal to OpenDialogProperty (line 1202-1209 in packages/suji-js/src/index.ts) and SaveDialogProperty (line 1224-1227). This matches Electron's current API which exp
+- ~~**[low]** `dialog.showMessageBox() — option: 'icon' (custom icon)`~~ ✅ (PR2 — MessageBoxOpts.icon → 이미지경로 NSImage → NSAlert.setIcon, 전 5 SDK + rendererPathFsGate) — Add optional 'icon' field to MessageBoxOptions interfaces (suji-js and suji-node packages), add corresponding 'icon: []const u8 = ""' field to MessageBoxOpts struct in src/platform/cef.zig (line 3675)
+- **[보류]** `dialog.showSaveDialog() — option: 'securityScopedBookmarks' (macOS/MAS)` — MAS(App Sandbox) 전용 — 비-sandbox 빌드에선 무의미하고, app.createSecurityScopedBookmark(이미 구현)로 저장 경로 bookmark 가능(정직 경계). Add `securityScopedBookmarks?: boolean` to SaveDialogOptions in packages/suji-js/src/index.ts (line 1229) and packages/suji-node/src/index.ts (line 1190). Add field to SaveDialogJson struct in src/mai
+- **[보류]** `dialog.showOpenDialog() / dialog.showSaveDialog() — properties: 'dontAddToRecent'` — macOS NSOpenPanel/NSSavePanel 은 자동으로 recent 에 추가하지 않음 → no-op (Windows JumpList 전용 개념, 정직 경계). Add "dontAddToRecent" as a string literal to OpenDialogProperty (line 1202-1209 in packages/suji-js/src/index.ts) and SaveDialogProperty (line 1224-1227). This matches Electron's current API which exp
 
 ### ipc
 

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -2072,6 +2072,8 @@ export interface MessageBoxOptions {
   checkboxLabel?: string;
   /** 체크박스 초기 상태. */
   checkboxChecked?: boolean;
+  /** 커스텀 아이콘 이미지 경로 (Electron MessageBoxOptions.icon — macOS NSAlert.setIcon). */
+  icon?: string;
 }
 
 export interface FileFilter {

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -2143,6 +2143,8 @@ export interface MessageBoxOptions {
   cancelId?: number;
   checkboxLabel?: string;
   checkboxChecked?: boolean;
+  /** 커스텀 아이콘 이미지 경로 (Electron MessageBoxOptions.icon — macOS NSAlert.setIcon). */
+  icon?: string;
 }
 
 export interface FileFilter {

--- a/sdks/suji-go/dialog/dialog.go
+++ b/sdks/suji-go/dialog/dialog.go
@@ -25,6 +25,7 @@ type MessageBoxOpts struct {
 	CancelID         *int
 	CheckboxLabel    string
 	CheckboxChecked  bool
+	Icon             string // 커스텀 아이콘 이미지 경로 (macOS NSAlert.setIcon)
 }
 
 // ShowMessageBox displays modal message box.
@@ -60,6 +61,9 @@ func ShowMessageBox(opts MessageBoxOpts) string {
 	}
 	if opts.CheckboxChecked {
 		m["checkboxChecked"] = true
+	}
+	if opts.Icon != "" {
+		m["icon"] = opts.Icon
 	}
 	b, _ := json.Marshal(m)
 	return suji.Invoke("__core__", string(b))

--- a/src/main.zig
+++ b/src/main.zig
@@ -3550,6 +3550,7 @@ const MessageBoxJson = struct {
     cancelId: ?usize = null,
     checkboxLabel: []const u8 = "",
     checkboxChecked: bool = false,
+    icon: []const u8 = "",
     windowId: ?u32 = null,
 };
 
@@ -3647,6 +3648,10 @@ fn handleDialogShowMessageBox(req_clean: []const u8, response_buf: []u8) ?[]cons
     defer parsed.deinit();
     const opts = parsed.value;
 
+    // icon 경로 fs gate (이미지 로드 = 렌더러-제어 경로 읽기 sink — tray_create.iconPath 동일).
+    if (opts.icon.len > 0) {
+        if (rendererPathFsGate(response_buf, "dialog_show_message_box", opts.icon)) |e| return e;
+    }
     const r = cef.showMessageBox(.{
         .style = parseStyleString(opts.type),
         .title = opts.title,
@@ -3657,6 +3662,7 @@ fn handleDialogShowMessageBox(req_clean: []const u8, response_buf: []u8) ?[]cons
         .cancel_id = opts.cancelId,
         .checkbox_label = opts.checkboxLabel,
         .checkbox_checked = opts.checkboxChecked,
+        .icon = opts.icon,
         .parent_window = dialogParentNSWindow(opts.windowId),
     });
 
@@ -4279,7 +4285,7 @@ fn rendererPathAllowed(path: []const u8) bool {
 ///  - 읽기: native_image_get_size / native_image_to_png|jpeg (임의 파일을
 ///    base64 로 인코딩해 렌더러로 반환 = 파일내용 유출) /
 ///    native_image_is_empty|is_template (파일 존재·디코드·메타 유출)
-///  - 파일 probe/read sink: tray_create.iconPath
+///  - 파일 probe/read sink: tray_create.iconPath / dialog_show_message_box.icon
 /// (menu_set_application_menu 의 MenuItem.icon 은 per-item drop 이라 menuIconPathAllowed 로 별도 게이트)
 /// **opt-in**: fs.allowedRoots 미설정/빈이면 레거시 무제한(비파괴 — 이 API
 /// 들은 그동안 무제한 출하), 설정 시 `fs.*` 와 동일 경계로 enforce(설정한 fs

--- a/src/platform/cef_dialog.zig
+++ b/src/platform/cef_dialog.zig
@@ -53,6 +53,10 @@ pub fn showMessageBox(opts: MessageBoxOpts) MessageBoxResult {
     if (opts.detail.len > 0) {
         if (nsStringFromSlice(opts.detail)) |ns| msgSendVoid1(alert, "setInformativeText:", ns);
     }
+    // 커스텀 아이콘 (Electron MessageBoxOptions.icon). 이미지 경로 → NSImage → NSAlert.setIcon.
+    if (opts.icon.len > 0) {
+        if (cef.loadNSImageFromFile(opts.icon)) |img| msgSendVoid1(alert, "setIcon:", img);
+    }
 
     // NSAlertStyle: warning=0, info=1, critical=2. question/none → warning(0).
     const style: u64 = switch (opts.style) {

--- a/src/platform/cef_dialog_types.zig
+++ b/src/platform/cef_dialog_types.zig
@@ -15,6 +15,9 @@ pub const MessageBoxOpts = struct {
     cancel_id: ?usize = null,
     checkbox_label: []const u8 = "",
     checkbox_checked: bool = false,
+    /// 커스텀 아이콘 이미지 경로 (Electron MessageBoxOptions.icon) — NSAlert.setIcon (NSImage).
+    /// 빈 문자열이면 기본 스타일 아이콘. macOS only.
+    icon: []const u8 = "",
     /// 부모 창 NSWindow 포인터 — null이면 free-floating runModal, 있으면 sheet.
     parent_window: ?*anyopaque = null,
 };


### PR DESCRIPTION
## 요약 (A 묶음 PR 2/4 — "실효만 구현 + 정직경계 문서화")

조사 결과 PR2 영역 대부분이 이미 구현됐거나 CEF 제약이라, 실효 있는 `dialog.icon`만 구현하고 나머지는 정직 경계로 문서화.

### 실효 구현
- **`dialog.showMessageBox({ icon })`** — 커스텀 아이콘 이미지 경로 → NSImage → `NSAlert.setIcon`. 전 5 SDK(JS/Node interface, Rust/Go struct) + `cef_dialog.zig` + `rendererPathFsGate`(tray_create.iconPath 동형 보안 게이트).

### 이미 구현 (audit outdated → ✅)
- `clipboard.readFindText()` — `cef_clipboard.zig` + dispatch + JS/Go SDK가 이미 존재.

### 정직 경계 (audit `[low]`→`[보류]`)
- `app.isAccessibilitySupportEnabled` / `getAccessibilitySupportFeatures` — CEF가 Chromium screen-reader 상태를 노출 안 함(NSWorkspace엔 시각 플래그만).
- dialog `securityScopedBookmarks`(MAS 전용) / `dontAddToRecent`(macOS no-op).

## 검증
- zig build / cargo / go / JS·Node tsc 통과
- **/simplify + /code-review max 전부 clean** (loadNSImageFromFile 재사용·fs gate·cross-file 동형 정확). 유일 발견(rendererPathFsGate sink 목록 문서 드리프트) 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)