### PR TITLE
feat(cli): suji types on Windows + fix e2e-split test regression + doc currency

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1136,9 +1136,11 @@ app.on("ready", () => {
       유일한 CI 자동 *기능* 커버리지. 검증: `run.sh` **68/68**(python 3 케이스 포함).
 - 핫 리로드(정직): node/lua/python 임베드 런타임 모두 in-process 핫 리로드 미지원
       (dev 재시작) — python 특이 결함 아님. Py init·finalize 프로세스당 1회라 구조적.
-- 정직 경계(후속): Windows packaging(import-lib hard-link → build gate 에서 python off
-      강제, footgun 방지; PBS Windows 레이아웃 + Windows CI 반복 필요) / iOS·Android
-      실기기(시뮬레이터/에뮬레이터 검증 천장 — clipboard 모바일 e2e 와 동일 바) /
+- Windows packaging 완료: import-lib(python313.lib) hard-link + addInstallPythonRuntimeStep
+      Windows pwsh 분기(python313.dll/python3.dll/vcruntime140*.dll + packaged 시 Lib/DLLs),
+      python_available 게이트 staging-기반 활성(강제-off 제거), webcontentsview-windows CI job
+      이 dev+packaged 가드. 남은 후속은 released CLI(release.yml 이 아직 Windows staging off).
+- 정직 경계(후속): iOS·Android 실기기(시뮬레이터/에뮬레이터 검증 천장 — clipboard 모바일 e2e 와 동일 바) /
       Android gradle apk 빌드는 AGP 호환 JDK(17~21) 필요 / lib-dynload filesDir dlopen
       은 최신 Android W^X 제약(json 등 pure-python 폴백이라 무영향).
 
@@ -1729,9 +1731,9 @@ scheme-handler IO-스레드 결함 규명(업스트림 수정/정확 API 사용 
 8. ✅ **macOS App Sandbox 자동화** (CEF Helper entitlements) — Mac App Store 진출 시 필수
 9. ✅ **보안 모델** (Phase 7: fs sandbox + cache 격리 + IPC 검증 + CSP + contextIsolation audit) — Phase 7 핵심 완료
 10. ✅ **CLI 배포** (`npx @suji/cli init my-app` / Homebrew tap / curl) — `@suji/cli` 스캐폴더, Homebrew Formula 생성/검증, curl installer 완료. npm publish/tap push는 토큰 보유 환경에서 수행
-11. **Windows frameless drag region 후속** — macOS/Linux `frame:false`
-    drag/no-drag는 E2E 완료. Linux 잔여 창 옵션(`transparent`/`parent` 등)은 CEF Views
-    native path로 완료. Windows frameless parity는 후속.
+11. ✅ **Frameless drag region** — macOS/Linux/Windows `frame:false` drag/no-drag E2E
+    완료(Windows 는 webcontentsview-windows CI job 의 run-frameless-drag-region — CEF Views
+    공유 경로라 동형). Linux 잔여 창 옵션(`transparent`/`parent` 등)도 CEF Views native path 로 완료.
 12. **앱 패키징** (Windows .msi, Linux .AppImage, macOS notarize 자동화) — 배포 단계
 13. 🟡 **자동 업데이트** — manifest check + artifact download + SHA-256 verify + macOS/Linux/Windows prepareInstall/quit-and-install 1차 완료. macOS `.zip/.dmg` stage, Windows `.zip` PowerShell stage/helper, Linux `.AppImage`/raw 교체 입력, `.deb` package-manager handoff 정책까지 문서화/검증(macOS `.zip` + Linux `.AppImage` E2E). 남은 것: Windows 실제 교체 E2E/인스톨러 연계
 14. ✅ **`child_process` / HTTP / SQLite SDK** — child_process(`suji.process.run`)와 backend 전용 HTTP(`suji.http.fetch`) 완료. renderer-safe HTTP는 `@suji/plugin-http` 공식 플러그인으로 완료. SQLite는 `plugins/sqlite` 공식 플러그인으로 완료.

--- a/docs/plans/17-B-cef-views-architecture.md
+++ b/docs/plans/17-B-cef-views-architecture.md
@@ -149,8 +149,9 @@ macOS에서 `NSWindow` 직접 관리 코드(Phase 1~5의 자산)를 `CefWindow` 
 - 현재 SujiKeyableWindow.sendEvent: override는 NSWindow 직접 관리 전제
 - CefWindow가 만든 NSWindow에 같은 override 주입 가능한지 검증
 - 안 되면 CEF의 drag handler 콜백 활용 우회
-- macOS는 NSWindow hit-test override, Linux는 CEF Views `set_draggable_regions` 경로로
-  `run-frameless-drag-region.sh` runtime E2E 검증. Windows는 별도 후속.
+- macOS는 NSWindow hit-test override, Linux/Windows는 CEF Views `set_draggable_regions`
+  경로로 `run-frameless-drag-region.sh` runtime E2E 검증(Windows는 webcontentsview-windows
+  CI job — CEF Views 공유 경로라 동형).
 
 ### 17-B.5 — multi-WebContentsView 검증 (완료)
 - host는 `CefWindow + CefBrowserView`, child WebContentsView는 CEF-managed child
@@ -168,7 +169,7 @@ macOS에서 `NSWindow` 직접 관리 코드(Phase 1~5의 자산)를 `CefWindow` 
 - Linux top-level 창 옵션은 `frame:false`, drag/no-drag, `transparent`, `parent`,
   alwaysOnTop/resizable/min·max/fullscreen/backgroundColor까지 CEF Views native path로 배선.
   `parent`는 `CefWindowDelegate::GetParentWindow` + non-modal dialog로 부모 컨트롤을 비활성화하지 않음.
-  Windows frameless parity는 별도 후속.
+  Windows frameless drag/no-drag parity도 완료(webcontentsview-windows CI job 검증).
 - 17-A에서 빠진 native 백엔드 SDK (Rust/Go/Node) view API 노출 완료
 - CEF-free 단위 테스트로 platform default와 child path 선택을 고정
   - macOS 기본: attached child `CefWindow`

--- a/src/backends/loader.zig
+++ b/src/backends/loader.zig
@@ -68,10 +68,10 @@ const win = if (is_windows) struct {
     const LOAD_WITH_ALTERED_SEARCH_PATH: u32 = 0x00000008;
 } else struct {};
 
-const WinDynLib = struct {
+pub const WinDynLib = struct {
     handle: std.os.windows.HMODULE,
 
-    fn open(path: [:0]const u8) !WinDynLib {
+    pub fn open(path: [:0]const u8) !WinDynLib {
         var buf: [std.os.windows.PATH_MAX_WIDE + 1]u16 = undefined;
         const len = std.unicode.utf8ToUtf16Le(buf[0..], path) catch return error.BadPathName;
         buf[len] = 0;
@@ -80,18 +80,20 @@ const WinDynLib = struct {
         return .{ .handle = h };
     }
 
-    fn lookup(self: *WinDynLib, comptime T: type, name: [:0]const u8) ?T {
+    pub fn lookup(self: *WinDynLib, comptime T: type, name: [:0]const u8) ?T {
         const p = win.GetProcAddress(self.handle, name.ptr) orelse return null;
         return @ptrCast(@alignCast(p));
     }
 
-    fn close(self: *WinDynLib) void {
+    pub fn close(self: *WinDynLib) void {
         _ = win.FreeLibrary(self.handle);
     }
 };
 
-/// 크로스 플랫폼 동적 라이브러리 핸들. 호출부(load/deinit)는 동일 API 사용.
-const DynLib = if (is_windows) WinDynLib else std.DynLib;
+/// 크로스 플랫폼 동적 라이브러리 핸들. 호출부(open/lookup/close)는 동일 API 사용.
+/// POSIX=std.DynLib, Windows=WinDynLib(kernel32). BackendRegistry 외에 `suji types`
+/// (cli/types_cmd.zig)도 백엔드 dlopen→backend_dump_schema 에 재사용(단일 출처).
+pub const DynLib = if (is_windows) WinDynLib else std.DynLib;
 
 /// C ABI 백엔드 인터페이스
 pub const Backend = struct {

--- a/src/cli/types_cmd.zig
+++ b/src/cli/types_cmd.zig
@@ -3,15 +3,14 @@ const builtin = @import("builtin");
 const runtime = @import("runtime");
 const suji = @import("../root.zig");
 const backend_build = @import("../core/backend_build.zig");
+const loader = @import("loader");
 
 /// `suji types [--out <path>]` — zig 백엔드의 `.schema()` 체인을 SujiHandlers
 /// `.d.ts` 로 자동 생성(수동 augment 불요). 빌드→dlopen→`backend_dump_schema`.
 /// zig 백엔드만 — Rust=specta 수동/Go·Node=수동 augment(정직 한계, 후속).
+/// dlopen 은 loader.DynLib(POSIX std.DynLib / Windows kernel32 WinDynLib) — Windows
+/// 도 backend .dll 로드 가능(이전엔 std.DynLib Windows 부재로 차단했었음).
 fn dumpZigSchema(allocator: std.mem.Allocator, entry: []const u8, out: *std.ArrayList(u8)) void {
-    if (builtin.os.tag == .windows) {
-        std.debug.print("[suji types] Windows dlopen 경로는 후속 — macOS/Linux 사용\n", .{});
-        return;
-    }
     backend_build.buildByLang(allocator, "zig", entry, false) catch |err| {
         std.debug.print("[suji types] {s} 빌드 실패: {}\n", .{ entry, err });
         return;
@@ -20,7 +19,7 @@ fn dumpZigSchema(allocator: std.mem.Allocator, entry: []const u8, out: *std.Arra
     defer allocator.free(path);
     const path_z = allocator.dupeZ(u8, path) catch return;
     defer allocator.free(path_z);
-    var lib = std.DynLib.open(path_z) catch |err| {
+    var lib = loader.DynLib.open(path_z) catch |err| {
         std.debug.print("[suji types] dlopen 실패 {s}: {}\n", .{ path, err });
         return;
     };
@@ -76,19 +75,24 @@ pub fn run(allocator: std.mem.Allocator, types_args: []const [:0]const u8) !void
         std.debug.print("[suji types] 생성할 schema 없음 (zig 백엔드 + `.schema()` 필요).\n", .{});
         return;
     }
-    // 생성된 .d.ts 는 stdout(`suji types > suji.d.ts`) 또는 --out 파일.
-    // 진단/빌드로그는 std.debug.print=stderr 라 .d.ts 와 안 섞임. Zig 0.16
-    // std.fs.File/posix.write 부재 → 코드베이스 std.Io 경로 재사용(stdout 은
-    // `/dev/stdout` 특수파일, Windows 는 dumpZigSchema 가 이미 차단).
-    const target = out_path orelse "/dev/stdout";
-    const f = std.Io.Dir.cwd().createFile(runtime.io, target, .{}) catch |err| {
-        std.debug.print("[suji types] {s} 쓰기 실패: {}\n", .{ target, err });
-        return;
-    };
-    defer f.close(runtime.io);
+    // 생성된 .d.ts 는 stdout(`suji types > suji.d.ts`) 또는 --out 파일. 진단/빌드로그는
+    // std.debug.print=stderr 라 .d.ts 와 안 섞임. stdout 은 std.Io.File.stdout()(크로스
+    // 플랫폼 — 이전 `/dev/stdout` 은 POSIX 전용이라 Windows 차단 사유였음). stdout 은
+    // 프로세스 핸들이라 close 하지 않는다(파일만 close).
     var wbuf: [4096]u8 = undefined;
-    var fw = f.writer(runtime.io, &wbuf);
-    fw.interface.writeAll(out.items) catch return;
-    fw.interface.flush() catch return;
-    if (out_path) |p| std.debug.print("[suji types] → {s} ({d} bytes)\n", .{ p, out.items.len });
+    if (out_path) |p| {
+        const f = std.Io.Dir.cwd().createFile(runtime.io, p, .{}) catch |err| {
+            std.debug.print("[suji types] {s} 쓰기 실패: {}\n", .{ p, err });
+            return;
+        };
+        defer f.close(runtime.io);
+        var fw = f.writer(runtime.io, &wbuf);
+        fw.interface.writeAll(out.items) catch return;
+        fw.interface.flush() catch return;
+        std.debug.print("[suji types] → {s} ({d} bytes)\n", .{ p, out.items.len });
+    } else {
+        var fw = std.Io.File.stdout().writer(runtime.io, &wbuf);
+        fw.interface.writeAll(out.items) catch return;
+        fw.interface.flush() catch return;
+    }
 }

--- a/tests/cef_ipc_test.zig
+++ b/tests/cef_ipc_test.zig
@@ -1438,7 +1438,7 @@ test "powerSaveBlocker IPC — start/stop + 두 type 모두 노출" {
     inline for (.{
         "E2E — powerSaveBlocker",
         "E2E — powerSaveBlocker (Linux)",
-        "E2E — powerSaveBlocker (Windows)",
+        "webcontentsview-windows", // Windows e2e 는 전용 job (이전 매트릭스 `(Windows)` 스텝에서 분리)
         "run-power-save-blocker.sh",
     }) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, workflow_src, needle) != null);
@@ -1768,7 +1768,7 @@ test "powerMonitor — install hook + 4 이벤트 채널 emit 패턴" {
     inline for (.{
         "E2E — powerMonitor",
         "E2E — powerMonitor idle (Linux)",
-        "E2E — powerMonitor idle (Windows)",
+        "webcontentsview-windows", // Windows e2e 는 전용 job (이전 매트릭스 `(Windows)` 스텝에서 분리)
     }) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, workflow_src, needle) != null);
     }
@@ -2139,19 +2139,23 @@ test "clipboard.has/availableFormats + app.isReady/focus/hide IPC" {
     defer std.testing.allocator.free(workflow_src);
     inline for (.{
         "E2E — clipboard text/HTML (Linux)",
-        "E2E — clipboard text/HTML (Windows)",
+        "webcontentsview-windows", // Windows e2e 는 전용 job (이전 매트릭스 `(Windows)` 스텝에서 분리)
         "bash tests/e2e/run-clipboard-text-runtime.sh",
     }) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, workflow_src, needle) != null);
     }
+    // Linux job(matrix): deps → clipboard → autoUpdater 순서.
     const matrix_job_pos = std.mem.indexOf(u8, workflow_src, "webcontentsview-cross-platform:").?;
     const deps_pos = std.mem.indexOfPos(u8, workflow_src, matrix_job_pos, "Install frontend dependencies").?;
     const linux_clip_pos = std.mem.indexOfPos(u8, workflow_src, matrix_job_pos, "E2E — clipboard text/HTML (Linux)").?;
     const linux_auto_pos = std.mem.indexOf(u8, workflow_src, "E2E — autoUpdater prepare/quit (Linux)").?;
-    const windows_clip_pos = std.mem.indexOf(u8, workflow_src, "E2E — clipboard text/HTML (Windows)").?;
-    const windows_wcv_pos = std.mem.indexOf(u8, workflow_src, "E2E — WebContentsView lifecycle (Windows)").?;
     try std.testing.expect(deps_pos < linux_clip_pos);
     try std.testing.expect(linux_clip_pos < linux_auto_pos);
+    // Windows e2e 는 전용 webcontentsview-windows job — 그 안에서 clipboard → WebContentsView 순서
+    // (스텝명은 job 이 Windows 전용이라 `(Windows)` 접미사 없음; job 시작 위치 기준 탐색).
+    const win_job_pos = std.mem.indexOf(u8, workflow_src, "webcontentsview-windows:").?;
+    const windows_clip_pos = std.mem.indexOfPos(u8, workflow_src, win_job_pos, "E2E — clipboard text/HTML").?;
+    const windows_wcv_pos = std.mem.indexOfPos(u8, workflow_src, win_job_pos, "E2E — WebContentsView lifecycle").?;
     try std.testing.expect(windows_clip_pos < windows_wcv_pos);
 }
 


### PR DESCRIPTION
Windows 백로그(B1 + A) + main red 회귀 수정.

## B1 — `suji types` Windows 지원 (이전: "Windows dlopen 경로는 후속 — macOS/Linux 사용")
두 블로커: ① `std.DynLib`(Zig 0.16 Windows 제거) ② `/dev/stdout`(POSIX 전용).
- `loader.zig` 의 크로스플랫폼 `DynLib`(POSIX std.DynLib / Windows kernel32 `WinDynLib`)를 **pub 화해 CLI 가 동일 dlopen primitive 재사용**(중복 없음). backend dylib→`backend_dump_schema` Windows 로드.
- 출력은 `std.Io.File.stdout()`(크로스플랫폼). 생성 파일만 close(프로세스 stdout 제외).
- 검증: `run-types-cli.sh` → **2 pass / 0 fail**(schema 생성, --out + stdout 양쪽).

## 회귀 수정 — PR #160(e2e Windows 잡 분리)이 `zig build test` 를 red 로
- 분리가 Windows 스텝명에서 `" (Windows)"` 접미사를 제거 → `cef_ipc_test.zig` 의 소스-계약 assertion(e2e.yml 의 `"E2E — … (Windows)"` grep + ordering)이 깨짐. PR #160 은 YAML 만 바꿔 `zig build test` 미실행 → 놓침.
- assertion 을 새 구조로 갱신: Windows-커버리지 needle → 전용 `webcontentsview-windows` job 존재 확인, clipboard→WebContentsView ordering → 그 job 내부 탐색(bare 스텝명). Linux ordering 불변.

## A — 문서 현행화 (Windows packaging/frameless 는 이번 사이클 완료인데 "후속"으로 남아있었음)
- `docs/PLAN.md`: Windows packaging 완료(released-CLI python 번들만 잔여), frameless #11 ✅(webcontentsview-windows CI).
- `docs/plans/17-B`: Windows frameless parity 완료(CEF Views 공유 경로, CI 검증).

## 검증 (Windows)
`zig build` + `zig build test` → **79/79 steps, 998/1009 tests (11 skipped, 0 fail)** · `run-types-cli.sh` green · `test-state`(loader dlopen) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)