### PR TITLE
feat(login-item): Windows registry Run key (setLoginItemSettings parity)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1516,6 +1516,17 @@ pub fn build(b: *std.Build) void {
     const cef_drag_region_test = b.addTest(.{ .root_module = cef_drag_region_test_mod });
     test_step.dependOn(&b.addRunArtifact(cef_drag_region_test).step);
 
+    // cef_login_item: Windows HKCU\…\Run 레지스트리 round-trip 테스트(Windows 만 실행,
+    // macOS/Linux skip). runtime import 필요(모듈이 runtime.io 참조 — 테스트는 advapi32 만).
+    const cef_login_item_test_mod = b.createModule(.{
+        .root_source_file = b.path("src/platform/cef_login_item.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    cef_login_item_test_mod.addImport("runtime", runtime_module);
+    const cef_login_item_test = b.addTest(.{ .root_module = cef_login_item_test_mod });
+    test_step.dependOn(&b.addRunArtifact(cef_login_item_test).step);
+
     // CEF Views platform policy tests (CEF 런타임/헤더 불필요).
     const cef_views_policy_test_mod = b.createModule(.{
         .root_source_file = b.path("src/platform/cef_views_policy.zig"),

--- a/src/platform/cef_login_item.zig
+++ b/src/platform/cef_login_item.zig
@@ -1,7 +1,8 @@
 //! app.getLoginItemSettings / setLoginItemSettings (Electron) — 로그인 시 앱 자동 실행.
 //! macOS: ~/Library/LaunchAgents/<label>.plist (LaunchAgent RunAtLoad),
 //! Linux: ~/.config/autostart/<label>.desktop (XDG autostart).
-//! Windows: 후속(honest false — 레지스트리 Run 키 미구현, plugins/autostart 와 동일 경계).
+//! Windows: HKCU\Software\Microsoft\Windows\CurrentVersion\Run REG_SZ 값(name=label,
+//!   data=exe 경로). enable=set / disable=delete(멱등) / enabled=query. 다음 로그온부터 발효.
 //! plugins/autostart/zig 의 검증된 로직을 코어(runtime.io)로 포팅 — 네이티브는 bool 만,
 //! Electron 필드(openAtLogin/wasOpenedAtLogin/…) JSON 조립은 dispatch(main.zig)가 담당.
 //!
@@ -13,7 +14,56 @@ const runtime = @import("runtime");
 
 const is_macos = builtin.os.tag == .macos;
 const is_linux = builtin.os.tag == .linux;
-const supported = is_macos or is_linux;
+const is_windows = builtin.os.tag == .windows;
+const supported = is_macos or is_linux or is_windows;
+
+// Windows: HKCU\…\Run REG_SZ 값. cef_native_theme.zig 와 동일 advapi32 패턴.
+const win_login = if (is_windows) struct {
+    const HKEY_CURRENT_USER: usize = 0x80000001;
+    const KEY_SET_VALUE: u32 = 0x0002;
+    const REG_SZ: u32 = 1;
+    const RRF_RT_REG_SZ: u32 = 0x00000002;
+    const ERROR_FILE_NOT_FOUND: i32 = 2;
+    const RUN_KEY = std.unicode.utf8ToUtf16LeStringLiteral("Software\\Microsoft\\Windows\\CurrentVersion\\Run");
+
+    extern "advapi32" fn RegOpenKeyExW(hkey: usize, lpSubKey: ?[*:0]const u16, ulOptions: u32, samDesired: u32, phkResult: *usize) callconv(.winapi) i32;
+    extern "advapi32" fn RegSetValueExW(hkey: usize, lpValueName: ?[*:0]const u16, Reserved: u32, dwType: u32, lpData: *const anyopaque, cbData: u32) callconv(.winapi) i32;
+    extern "advapi32" fn RegDeleteValueW(hkey: usize, lpValueName: ?[*:0]const u16) callconv(.winapi) i32;
+    extern "advapi32" fn RegGetValueW(hkey: usize, lpSubKey: ?[*:0]const u16, lpValue: ?[*:0]const u16, dwFlags: u32, pdwType: ?*u32, pvData: ?*anyopaque, pcbData: ?*u32) callconv(.winapi) i32;
+    extern "advapi32" fn RegCloseKey(hkey: usize) callconv(.winapi) i32;
+
+    /// utf8 → utf16le NUL-종단(buf). 과길이/실패 시 null.
+    fn toW(buf: []u16, s: []const u8) ?[:0]const u16 {
+        const n = std.unicode.utf8ToUtf16Le(buf, s) catch return null;
+        if (n >= buf.len) return null;
+        buf[n] = 0;
+        return buf[0..n :0];
+    }
+
+    /// Run 값 존재 여부(데이터 불요 — RRF_RT_REG_SZ 로 타입만 맞춰 query).
+    fn enabled(label: []const u8) bool {
+        var name_buf: [256]u16 = undefined;
+        const name = toW(&name_buf, label) orelse return false;
+        return RegGetValueW(HKEY_CURRENT_USER, RUN_KEY.ptr, name.ptr, RRF_RT_REG_SZ, null, null, null) == 0;
+    }
+
+    /// enable=set REG_SZ(data=exe), disable=delete(부재 시 멱등 성공).
+    fn set(label: []const u8, exe: []const u8, enable: bool) bool {
+        var hkey: usize = 0;
+        if (RegOpenKeyExW(HKEY_CURRENT_USER, RUN_KEY.ptr, 0, KEY_SET_VALUE, &hkey) != 0) return false;
+        defer _ = RegCloseKey(hkey);
+        var name_buf: [256]u16 = undefined;
+        const name = toW(&name_buf, label) orelse return false;
+        if (!enable) {
+            const rc = RegDeleteValueW(hkey, name.ptr);
+            return rc == 0 or rc == ERROR_FILE_NOT_FOUND;
+        }
+        var data_buf: [2048]u16 = undefined;
+        const data = toW(&data_buf, exe) orelse return false;
+        const cb: u32 = @intCast((data.len + 1) * 2); // NUL 포함 바이트
+        return RegSetValueExW(hkey, name.ptr, 0, REG_SZ, @ptrCast(data.ptr), cb) == 0;
+    }
+} else struct {};
 
 /// label sanitize — path 분리자/traversal 차단 (autostart sanitizeLabel 동등).
 fn sanitizeLabel(raw: []const u8) []const u8 {
@@ -65,6 +115,7 @@ fn entryContent(buf: []u8, label: []const u8, exe: []const u8) ?[]const u8 {
 pub fn loginItemEnabled(app_name: []const u8) bool {
     if (!comptime supported) return false;
     const label = sanitizeLabel(app_name);
+    if (comptime is_windows) return win_login.enabled(label);
     var path_buf: [1024]u8 = undefined;
     const path = entryPath(&path_buf, label) orelse return false;
     std.Io.Dir.cwd().access(runtime.io, path, .{}) catch return false;
@@ -76,6 +127,12 @@ pub fn loginItemEnabled(app_name: []const u8) bool {
 pub fn setLoginItem(app_name: []const u8, enable: bool) bool {
     if (!comptime supported) return false;
     const label = sanitizeLabel(app_name);
+    if (comptime is_windows) {
+        if (!enable) return win_login.set(label, "", false);
+        var exe_buf: [4096]u8 = undefined;
+        const exe = if (std.process.executablePath(runtime.io, &exe_buf)) |n| exe_buf[0..n] else |_| return false;
+        return win_login.set(label, exe, true);
+    }
     var path_buf: [1024]u8 = undefined;
     const path = entryPath(&path_buf, label) orelse return false;
     if (!enable) {
@@ -96,4 +153,21 @@ pub fn setLoginItem(app_name: []const u8, enable: bool) bool {
     fw.interface.writeAll(content) catch return false;
     fw.interface.flush() catch return false;
     return true;
+}
+
+// Windows HKCU\…\Run 레지스트리 round-trip 검증(set/enabled/delete) — runtime.io 비의존
+// (win_login 은 순수 advapi32). 고유 테스트 레이블 + defer 정리로 비파괴. macOS/Linux skip
+// (그쪽 경로는 runtime.io 초기화가 필요한 파일 I/O 라 별도 e2e/수동 검증 영역).
+test "login item (Windows): HKCU Run registry set/enabled/delete round-trip" {
+    if (!comptime is_windows) return error.SkipZigTest;
+    const label = "suji-core-logintest-zz9";
+    _ = win_login.set(label, "", false); // 이전 잔존 제거
+    defer _ = win_login.set(label, "", false); // 항상 정리(테스트 후 레지스트리 클린)
+
+    try std.testing.expect(!win_login.enabled(label)); // 초기 미설정
+    try std.testing.expect(win_login.set(label, "C:\\Temp\\suji-logintest.exe", true)); // 설정
+    try std.testing.expect(win_login.enabled(label)); // 설정 확인
+    try std.testing.expect(win_login.set(label, "", false)); // 해제
+    try std.testing.expect(!win_login.enabled(label)); // 해제 확인
+    try std.testing.expect(win_login.set(label, "", false)); // 멱등(부재 delete 성공)
 }


### PR DESCRIPTION
Windows 백로그 — `cef_login_item.zig` 의 Windows honest-false 해소(setLoginItemSettings).

## 구현
macOS plist / Linux .desktop 만이던 것에 Windows 추가 — `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` (cef_native_theme.zig 와 동일 advapi32 패턴):
- enable → `RegSetValueExW(name=label, REG_SZ, data=exe 경로)`
- disable → `RegDeleteValueW(name=label)` (멱등: ERROR_FILE_NOT_FOUND = 성공)
- enabled → `RegGetValueW(name=label)` 존재 검사

`loginItemEnabled`/`setLoginItem` 에 `comptime is_windows` 분기 추가, `supported` 에 Windows 포함. main.zig 의 `app_get/set_login_item_settings` 디스패치는 이미 호출 중(Windows 만 false 였음).

## 검증 (Windows)
`zig build test` → **81/81 steps, 999/1010 (11 skipped, 0 fail)**. 신규 Windows-gated 테스트가 실제 HKCU\Run round-trip(set → enabled=true → delete → enabled=false → 멱등 delete)을 고유 레이블 + defer 정리로 검증(영구 레지스트리 변경 없음). macOS/Linux skip(그쪽 파일 경로는 runtime.io 초기화 필요 — 별도 영역). `zig build test` 에 배선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)