### PR TITLE
fix(auth): IO-스레드 emit UAF + 구독 게이트 (PR #168 인증 콜백 hotfix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,9 @@ fn onAllClosed(_: suji.Event) void {
 //   app.selectClientCertificateRespond(id, index) 로 선택(index 0-based, -1=기본 select null).
 //   ⚠️ 셋 다 CEF request_handler deferred 콜백(pending pool + UI-thread RespondTask) — 실 TLS/auth/
 //   client-cert 검증은 헤드리스 불가(빌드+wire 검증, 정직 경계). 전 5 SDK.
+//   app.setAuthHandlerEnabled(true) 로 게이트 활성(이벤트 구독 후 호출) — 미활성(기본)=CEF 기본
+//   (cert 차단/auth 취소/client-cert 기본)으로 fallback(미구독 시 콜백 영구 hold/DoS 방지).
+//   getAuthCredentials(IO 스레드) emit 은 UI 로 marshal(execute_java_script cross-thread UB 방지).
 // suji.exit()                  — 앱 강제 종료 (Electron app.exit(), code 무시)
 // suji.relaunch()              — quit 후 현재 앱 재시작 등록 (Electron app.relaunch).
 //   이후 quit/exit 시 cef 메시지 루프 종료 후 현재 argv 로 새 인스턴스 spawn(detached).

--- a/crates/suji-rs/src/lib.rs
+++ b/crates/suji-rs/src/lib.rs
@@ -3713,6 +3713,11 @@ pub fn select_client_certificate_respond(id: u64, index: i64) -> Option<String> 
     invoke("__core__", &serde_json::json!({ "cmd": "select_client_certificate_respond", "id": id, "index": index }).to_string())
 }
 
+/// auth 이벤트 핸들러 활성 (이벤트 구독 후) — 미활성 시 CEF 기본 fallback. 응답 `{"success":bool}`.
+pub fn set_auth_handler_enabled(enabled: bool) -> Option<String> {
+    invoke("__core__", &serde_json::json!({ "cmd": "auth_set_handler_enabled", "enabled": enabled }).to_string())
+}
+
 pub(crate) fn scoped_bookmark_create_json(path: &str) -> String {
     serde_json::json!({ "cmd": "security_scoped_bookmark_create", "path": path }).to_string()
 }

--- a/packages/suji-js/src/index.ts
+++ b/packages/suji-js/src/index.ts
@@ -3346,6 +3346,12 @@ export const app = {
     return r.success === true;
   },
 
+  /** auth 이벤트(certificate-error/login/select-client-certificate) 핸들러 활성. 이벤트 구독 후 호출
+   *  — 미활성(기본) 시 CEF 기본(cert 차단/auth 취소/client-cert 기본 선택)으로 fallback. */
+  async setAuthHandlerEnabled(enabled: boolean): Promise<void> {
+    await coreCall({ cmd: "auth_set_handler_enabled", enabled });
+  },
+
   /**
    * Security-scoped bookmark 생성 (App Sandbox 영속 파일 접근). 실패 시 null.
    * 비-sandbox 빌드에선 일반 bookmark 로 동작 (sandbox escapement no-op).

--- a/packages/suji-node/src/index.ts
+++ b/packages/suji-node/src/index.ts
@@ -3179,6 +3179,12 @@ export const app = {
     return r.success === true;
   },
 
+  /** auth 이벤트(certificate-error/login/select-client-certificate) 핸들러 활성. 이벤트 구독 후 호출
+   *  — 미활성(기본) 시 CEF 기본(cert 차단/auth 취소/client-cert 기본 선택)으로 fallback. */
+  async setAuthHandlerEnabled(enabled: boolean): Promise<void> {
+    await invoke('__core__', { cmd: 'auth_set_handler_enabled', enabled });
+  },
+
   /**
    * Security-scoped bookmark 생성 (App Sandbox 영속 파일 접근). 실패 시 null.
    * 비-sandbox 빌드에선 일반 bookmark 로 동작 (sandbox escapement no-op).

--- a/sdks/suji-go/app/app.go
+++ b/sdks/suji-go/app/app.go
@@ -252,6 +252,12 @@ func SelectClientCertificateRespond(id uint64, index int64) string {
 	return suji.Invoke("__core__", fmt.Sprintf(`{"cmd":"select_client_certificate_respond","id":%d,"index":%d}`, id, index))
 }
 
+// SetAuthHandlerEnabled — auth 이벤트 핸들러 활성(이벤트 구독 후). 미활성 시 CEF 기본 fallback.
+// raw JSON: `{"success":bool}`.
+func SetAuthHandlerEnabled(enabled bool) string {
+	return suji.Invoke("__core__", fmt.Sprintf(`{"cmd":"auth_set_handler_enabled","enabled":%t}`, enabled))
+}
+
 // CreateSecurityScopedBookmark creates a security-scoped bookmark for App
 // Sandbox persistent file access. Response:
 // `{"success":bool,"bookmark":"<base64>"}` (비-sandbox 빌드에선 일반 bookmark).

--- a/src/core/app.zig
+++ b/src/core/app.zig
@@ -2286,6 +2286,13 @@ pub fn selectClientCertificateRespond(id: u64, index: i64) ?[]const u8 {
     return coreCmd("select_client_certificate_respond", fields);
 }
 
+/// auth 이벤트 핸들러 활성 (이벤트 구독 후) — 미활성 시 CEF 기본 fallback. 응답 `{"success":bool}`.
+pub fn setAuthHandlerEnabled(enabled: bool) ?[]const u8 {
+    var fb: [32]u8 = undefined;
+    const fields = std.fmt.bufPrint(&fb, "\"enabled\":{}", .{enabled}) catch return null;
+    return coreCmd("auth_set_handler_enabled", fields);
+}
+
 /// Security-scoped bookmark 생성 (App Sandbox 영속 파일 접근). 응답:
 /// `{"success":bool,"bookmark":"<base64>"}`. 비-sandbox 빌드에선 일반 bookmark.
 pub fn createSecurityScopedBookmark(path: []const u8) ?[]const u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2861,6 +2861,13 @@ fn cefHandleCore(registry: *suji.BackendRegistry, data: []const u8, response_buf
         // base64 알파벳은 JSON-safe — icon 추가 escape 불필요.
         return std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"app_get_application_info_for_protocol\",\"name\":\"{s}\",\"path\":\"{s}\",\"icon\":\"{s}\"}}", .{ name_esc[0..ne], path_esc[0..pe], icon_b64 }) catch null;
     }
+    // app 이 auth 이벤트 구독 토글 (deferred hold 게이트) — 미등록 시 cert/auth/client-cert 콜백이
+    // CEF 기본(차단/취소/기본선택)으로 fallback. Electron app.on 등록을 명시 enable 로 대체(정직 경계).
+    if (std.mem.eql(u8, cmd, "auth_set_handler_enabled")) {
+        const enabled = util.extractJsonBool(req_clean, "enabled") orelse false;
+        cef.setAuthHandlerEnabled(enabled);
+        return std.fmt.bufPrint(response_buf, "{{\"from\":\"zig-core\",\"cmd\":\"auth_set_handler_enabled\",\"success\":true}}", .{}) catch null;
+    }
     // app:certificate-error 응답 — Electron event 의 callback(allow/deny) deferred 적용.
     if (std.mem.eql(u8, cmd, "certificate_error_respond")) {
         const id_n = util.extractJsonInt(req_clean, "id") orelse 0;

--- a/src/platform/cef.zig
+++ b/src/platform/cef.zig
@@ -65,6 +65,7 @@ pub const OpenURLFn = cef_public_api.OpenURLFn;
 pub const installOpenURLHandler = cef_public_api.installOpenURLHandler;
 pub const AuthEmitFn = cef_public_api.AuthEmitFn;
 pub const setAuthEmitHandler = cef_public_api.setAuthEmitHandler;
+pub const setAuthHandlerEnabled = cef_public_api.setAuthHandlerEnabled;
 pub const certificateErrorRespond = cef_public_api.certificateErrorRespond;
 pub const loginRespond = cef_public_api.loginRespond;
 pub const selectClientCertificateRespond = cef_public_api.selectClientCertificateRespond;

--- a/src/platform/cef_auth_handler.zig
+++ b/src/platform/cef_auth_handler.zig
@@ -17,6 +17,14 @@ pub fn setAuthEmitHandler(fn_ptr: AuthEmitFn) void {
     g_emit_fn = fn_ptr;
 }
 
+/// app 이 auth 이벤트를 구독했는지 게이트 (cef_session_permission g_have_handler 동형).
+/// 미등록(false) 시 3 핸들러가 return 0 = CEF 기본(cert 차단 / auth 취소 / client-cert 기본 선택)
+/// 으로 fallback — 미구독 앱에서 콜백 영구 hold(무한 대기 + pending leak/DoS) 방지.
+var g_auth_handler_enabled: std.atomic.Value(bool) = .init(false);
+pub fn setAuthHandlerEnabled(enabled: bool) void {
+    g_auth_handler_enabled.store(enabled, .release);
+}
+
 const MAX_PENDING: usize = 32;
 var g_next_id: std.atomic.Value(u64) = .init(1);
 fn nextId() u64 {
@@ -30,6 +38,73 @@ fn lock() void {
 }
 fn unlock() void {
     g_lock.store(false, .release);
+}
+
+// emit 을 UI 스레드로 마샬 — get_auth_credentials 는 IO 스레드 콜백이라(cert/client-cert 는 UI),
+// emit→EventBus→execute_java_script(UI-전용)를 IO 에서 호출하면 cross-thread UB. UI 면 inline, 아니면 post.
+const EmitTask = struct {
+    task: c.cef_task_t = undefined,
+    allocator: std.mem.Allocator,
+    ref_count: std.atomic.Value(u32) = .init(1),
+    channel: [64]u8 = undefined,
+    channel_len: usize = 0,
+    info: [3072]u8 = undefined,
+    info_len: usize = 0,
+};
+fn emitTaskFromBase(base: ?*c.cef_base_ref_counted_t) ?*EmitTask {
+    return @ptrCast(@alignCast(base orelse return null));
+}
+fn emitTaskFromSelf(self: ?*c._cef_task_t) ?*EmitTask {
+    return @ptrCast(@alignCast(self orelse return null));
+}
+fn emitTaskAddRef(base: ?*c.cef_base_ref_counted_t) callconv(.c) void {
+    const t = emitTaskFromBase(base) orelse return;
+    _ = t.ref_count.fetchAdd(1, .acq_rel);
+}
+fn emitTaskRelease(base: ?*c.cef_base_ref_counted_t) callconv(.c) i32 {
+    const t = emitTaskFromBase(base) orelse return 0;
+    if (t.ref_count.fetchSub(1, .acq_rel) != 1) return 0;
+    t.allocator.destroy(t);
+    return 1;
+}
+fn emitTaskHasOneRef(base: ?*c.cef_base_ref_counted_t) callconv(.c) i32 {
+    const t = emitTaskFromBase(base) orelse return 0;
+    return if (t.ref_count.load(.acquire) == 1) 1 else 0;
+}
+fn emitTaskHasAtLeastOneRef(base: ?*c.cef_base_ref_counted_t) callconv(.c) i32 {
+    const t = emitTaskFromBase(base) orelse return 0;
+    return if (t.ref_count.load(.acquire) >= 1) 1 else 0;
+}
+fn emitTaskExecute(self: ?*c._cef_task_t) callconv(.c) void {
+    const t = emitTaskFromSelf(self) orelse return;
+    if (g_emit_fn) |emit| emit(@ptrCast(&t.channel), &t.info, t.info_len);
+}
+
+/// channel(cstr) + info 를 UI 스레드에서 emit. UI 면 inline, 아니면 EmitTask post(채널/info 복사).
+fn emitOnUi(channel: [*:0]const u8, info: []const u8) void {
+    const emit = g_emit_fn orelse return;
+    if (c.cef_currently_on(c.TID_UI) == 1) {
+        emit(channel, info.ptr, info.len);
+        return;
+    }
+    const t = c_allocator.create(EmitTask) catch return;
+    const ch = std.mem.span(channel);
+    t.* = .{ .allocator = c_allocator };
+    t.channel_len = @min(ch.len, t.channel.len - 1);
+    @memcpy(t.channel[0..t.channel_len], ch[0..t.channel_len]);
+    t.channel[t.channel_len] = 0; // null-term
+    t.info_len = @min(info.len, t.info.len);
+    @memcpy(t.info[0..t.info_len], info[0..t.info_len]);
+    @memset(std.mem.asBytes(&t.task), 0);
+    t.task.base.size = @sizeOf(c.cef_task_t);
+    t.task.base.add_ref = &emitTaskAddRef;
+    t.task.base.release = &emitTaskRelease;
+    t.task.base.has_one_ref = &emitTaskHasOneRef;
+    t.task.base.has_at_least_one_ref = &emitTaskHasAtLeastOneRef;
+    t.task.execute = &emitTaskExecute;
+    if (c.cef_post_task(c.TID_UI, &t.task) != 1) {
+        _ = emitTaskRelease(&t.task.base);
+    }
 }
 
 /// CEF 콜백 ref 해제 + return 0 — hold(add_ref) 후 early-return(push/emit/json 실패) 공용.
@@ -150,7 +225,7 @@ pub fn onCertificateError(
     _: ?*c._cef_sslinfo_t,
     callback: ?*c._cef_callback_t,
 ) callconv(.c) c_int {
-    const emit = g_emit_fn orelse return 0;
+    if (g_emit_fn == null or !g_auth_handler_enabled.load(.acquire)) return 0; // 미구독/미주입 시 CEF 기본
     const cb = callback orelse return 0;
     // hold past 동기 핸들러 반환 — add_ref(respond 의 release 와 짝). 모든 early-return-0 에서 release.
     if (cb.base.add_ref) |ar| ar(&cb.base);
@@ -168,7 +243,7 @@ pub fn onCertificateError(
         _ = certTake(id);
         return releaseCb(&cb.base);
     };
-    emit("app:certificate-error", json.ptr, json.len);
+    emitOnUi("app:certificate-error", json);
     return 1; // hold — certificateErrorRespond 가 cont/cancel
 }
 
@@ -224,7 +299,7 @@ const AuthTask = struct {
     allocator: std.mem.Allocator,
     ref_count: std.atomic.Value(u32) = .init(1),
     callback: *c.cef_auth_callback_t,
-    user: [256]u8 = undefined,
+    user: [256]u8 = undefined, // ⚠️ off-UI 워커 경로만 256 절단(UI 직접 경로 무제한) — 비대칭, 정직 경계
     user_len: usize = 0,
     pass: [256]u8 = undefined,
     pass_len: usize = 0,
@@ -302,7 +377,7 @@ pub fn getAuthCredentials(
     scheme: [*c]const c.cef_string_t,
     callback: ?*c._cef_auth_callback_t,
 ) callconv(.c) c_int {
-    const emit = g_emit_fn orelse return 0;
+    if (g_emit_fn == null or !g_auth_handler_enabled.load(.acquire)) return 0; // 미구독/미주입 시 CEF 기본
     const cb = callback orelse return 0;
     if (cb.base.add_ref) |ar| ar(&cb.base);
     const id = nextId();
@@ -325,7 +400,7 @@ pub fn getAuthCredentials(
     const sn = util.escapeJsonStrFull(scheme_s, &se) orelse return failAuth(id);
     var info: [3000]u8 = undefined;
     const json = std.fmt.bufPrint(&info, "{{\"id\":{d},\"url\":\"{s}\",\"isProxy\":{},\"host\":\"{s}\",\"port\":{d},\"realm\":\"{s}\",\"scheme\":\"{s}\"}}", .{ id, ue[0..un], is_proxy != 0, he[0..hn], port, ree[0..rn], se[0..sn] }) catch return failAuth(id);
-    emit("app:login", json.ptr, json.len);
+    emitOnUi("app:login", json);
     return 1;
 }
 fn failAuth(id: u64) c_int {
@@ -472,7 +547,7 @@ pub fn onSelectClientCertificate(
     certificates: [*c]const ?*c.cef_x509_certificate_t,
     callback: ?*c._cef_select_client_certificate_callback_t,
 ) callconv(.c) c_int {
-    const emit = g_emit_fn orelse return 0;
+    if (g_emit_fn == null or !g_auth_handler_enabled.load(.acquire)) return 0; // 미구독/미주입 시 CEF 기본
     const cb = callback orelse return 0;
     if (certificates_count == 0) return 0; // cert 없음 → CEF 기본
     // callback + 각 cert hold(add_ref) — clientReleaseOnly/clientSelectAndRelease 가 짝 release.
@@ -505,6 +580,6 @@ pub fn onSelectClientCertificate(
         clientReleaseOnly(p);
         return 0;
     };
-    emit("app:select-client-certificate", json.ptr, json.len);
+    emitOnUi("app:select-client-certificate", json);
     return 1;
 }

--- a/src/platform/cef_public_api.zig
+++ b/src/platform/cef_public_api.zig
@@ -251,6 +251,7 @@ pub const OpenURLFn = cef_open_url.OpenURLFn;
 pub const installOpenURLHandler = cef_open_url.installOpenURLHandler;
 pub const AuthEmitFn = cef_auth_handler.AuthEmitFn;
 pub const setAuthEmitHandler = cef_auth_handler.setAuthEmitHandler;
+pub const setAuthHandlerEnabled = cef_auth_handler.setAuthHandlerEnabled;
 pub const certificateErrorRespond = cef_auth_handler.certificateErrorRespond;
 pub const loginRespond = cef_auth_handler.loginRespond;
 pub const selectClientCertificateRespond = cef_auth_handler.selectClientCertificateRespond;


### PR DESCRIPTION
## 요약

`/code-review max` 2차가 PR #168(인증 deferred 콜백)에서 **1차가 놓친 HIGH 2건**을 잡아 hotfix.

- **#1 [HIGH 크래시]** `getAuthCredentials`는 CEF **IO 스레드** 콜백인데(cert/client-cert는 UI 스레드), `emit→EventBus→execute_java_script`(UI-전용)를 IO에서 호출 → cross-thread UB/크래시. `emitOnUi`(UI면 inline, 아니면 `EmitTask` cef_post_task)로 marshal.
- **#2 [HIGH 회귀]** **subscription 게이트 부재** — `g_emit_fn`은 부팅 시 무조건 주입이라 '구독 여부' 프록시가 아님. app 미구독 시 콜백 영구 hold(무한 대기 + pending leak/DoS). `cef_session_permission`의 `g_have_handler` 동형 게이트 추가 — 미활성(기본) 시 `return 0`(CEF 기본 fallback). `app.setAuthHandlerEnabled(true)` 노출(전 5 SDK). **#3(MAX_PENDING 고갈 DoS)도 완화.**
- **#4 [low]** username/password 256 절단(off-UI 워커 경로) 정직 경계 주석.

## 검증
- zig build / cargo / go / JS·Node tsc 통과
- self-review: `EmitTask`=RespondTask 동형(ref_count 짝), 게이트=g_have_handler 동형, post-fail release 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)