### PR TITLE
fix(cli): 네이티브 suji init 도움말/에러에 python backend 누락 보완

### DIFF
--- a/src/cli/init.zig
+++ b/src/cli/init.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const init_mod = @import("../core/init.zig");
 
-const INIT_USAGE = "Usage: suji init <project-name> [--backend=none|zig|rust|go|node|lua|multi] [--frontend=react|vue|svelte|solid|preact|vanilla|next] [--toolchain=vite|rsbuild|next] [--pm=npm|pnpm|bun|vp] [--install]\n";
+const INIT_USAGE = "Usage: suji init <project-name> [--backend=none|zig|rust|go|node|lua|python|multi] [--frontend=react|vue|svelte|solid|preact|vanilla|next] [--toolchain=vite|rsbuild|next] [--pm=npm|pnpm|bun|vp] [--install]\n";
 
 pub fn run(allocator: std.mem.Allocator, init_args: []const [:0]const u8) !void {
     var name: []const u8 = "";
@@ -20,7 +20,7 @@ pub fn run(allocator: std.mem.Allocator, init_args: []const [:0]const u8) !void 
         if (std.mem.startsWith(u8, arg, backend_prefix)) {
             const lang_str = arg[backend_prefix.len..];
             backend = init_mod.BackendLang.fromString(lang_str) orelse {
-                std.debug.print("Unknown backend: {s}. Use: none, zig, rust, go, node, lua, multi\n", .{lang_str});
+                std.debug.print("Unknown backend: {s}. Use: none, zig, rust, go, node, lua, python, multi\n", .{lang_str});
                 return;
             };
         } else if (std.mem.startsWith(u8, arg, frontend_prefix)) {

--- a/src/cli/usage.zig
+++ b/src/cli/usage.zig
@@ -5,7 +5,7 @@ pub fn printUsage() void {
         \\Suji - Zig core multi-backend desktop framework
         \\
         \\Usage:
-        \\  suji init <name> [--backend=none|zig|rust|go|node|lua|multi]
+        \\  suji init <name> [--backend=none|zig|rust|go|node|lua|python|multi]
         \\         [--frontend=react|vue|svelte|solid|preact|vanilla|next]
         \\         [--toolchain=vite|rsbuild|next]
         \\         [--pm=npm|pnpm|bun|vp] [--install]


### PR DESCRIPTION
기능은 정상(fromString=stringToEnum 이라 --backend=python 작동, 템플릿/suji.json 존재)이나 도움말/에러 텍스트 3곳이 python 을 빠뜨림. @suji/cli(JS)는 이미 포함 — 네이티브 CLI 텍스트만 drift 보완.

🤖 Generated with [Claude Code](https://claude.com/claude-code)