### PR TITLE
feat(init): multi 스캐폴딩에 node 백엔드 추가 — 6 backend(examples 동등)

### DIFF
--- a/packages/suji-cli/lib/init.js
+++ b/packages/suji-cli/lib/init.js
@@ -248,7 +248,7 @@ export function backendLabel(backend) {
       node: "Node.js",
       lua: "Lua",
       python: "Python",
-      multi: "Zig · Rust · Go (multi)",
+      multi: "Zig · Rust · Go · Node · Lua · Python (multi)",
     }[backend] ?? backend
   );
 }
@@ -306,6 +306,7 @@ export function sujiJson(name, backend, template, pm) {
         { name: "zig", lang: "zig", entry: "backends/zig" },
         { name: "rust", lang: "rust", entry: "backends/rust" },
         { name: "go", lang: "go", entry: "backends/go" },
+        { name: "node", lang: "node", entry: "backends/node" },
         { name: "lua", lang: "lua", entry: "backends/lua" },
         { name: "python", lang: "python", entry: "backends/python" },
       ],
@@ -356,8 +357,10 @@ export function scaffoldBackend(projectName, backend, name) {
   scaffoldZig("backends/zig");
   scaffoldRust("backends/rust");
   scaffoldGo("backends/go");
-  // lua/python 임베드 런타임은 채널을 router 에 자동 등록하므로(rust/go raw dylib 과
+  // node/lua/python 임베드 런타임은 채널을 router 에 자동 등록하므로(rust/go raw dylib 과
   // 달리) zig 의 ping/greet 와 충돌하지 않게 네임스페이스 채널 템플릿을 쓴다.
+  W(join("backends/node", "package.json"), tpl("node_package.json"));
+  W(join("backends/node", "main.js"), tpl("multi_node_main.js"));
   W(join("backends/lua", "main.lua"), tpl("multi_lua_main.lua"));
   W(join("backends/python", "main.py"), tpl("multi_python_main.py"));
 }

--- a/packages/suji-cli/templates/multi_node_main.js
+++ b/packages/suji-cli/templates/multi_node_main.js
@@ -1,0 +1,7 @@
+// multi-backend: 채널을 백엔드별 네임스페이스로 충돌 회피 (zig 가 ping/greet 소유).
+// target 없이 suji.invoke("node-ping") 으로 자동 라우팅된다.
+const { handle } = require("@suji/node");
+
+handle("node-ping", () => ({ from: "node", msg: "pong" }));
+
+handle("node-greet", () => ({ from: "node", greeting: "Hello from Node.js!" }));

--- a/src/core/init.zig
+++ b/src/core/init.zig
@@ -252,9 +252,15 @@ pub fn run(allocator: std.mem.Allocator, opts: InitOptions) !void {
             defer go_dir.close(io);
             try scaffoldGo(allocator, go_dir, name);
 
-            // lua/python 임베드 런타임은 채널을 router 에 자동 등록하므로(rust/go raw
+            // node/lua/python 임베드 런타임은 채널을 router 에 자동 등록하므로(rust/go raw
             // dylib 과 달리) zig 의 ping/greet 와 충돌하지 않도록 네임스페이스 채널
-            // 템플릿(lua-ping/python-ping)을 쓴다.
+            // 템플릿(node-ping/lua-ping/python-ping)을 쓴다.
+            try backends_dir.createDir(io, "node", .default_dir);
+            var multi_node_dir = try backends_dir.openDir(io, "node", .{});
+            defer multi_node_dir.close(io);
+            try writeFileContent(multi_node_dir, "package.json", @embedFile("../templates/node_package.json"));
+            try writeFileContent(multi_node_dir, "main.js", @embedFile("../templates/multi_node_main.js"));
+
             try backends_dir.createDir(io, "lua", .default_dir);
             var multi_lua_dir = try backends_dir.openDir(io, "lua", .{});
             defer multi_lua_dir.close(io);
@@ -334,6 +340,7 @@ fn writeConfig(allocator: std.mem.Allocator, dir: Dir, name: []const u8, backend
             \\    {{ "name": "zig", "lang": "zig", "entry": "backends/zig" }},
             \\    {{ "name": "rust", "lang": "rust", "entry": "backends/rust" }},
             \\    {{ "name": "go", "lang": "go", "entry": "backends/go" }},
+            \\    {{ "name": "node", "lang": "node", "entry": "backends/node" }},
             \\    {{ "name": "lua", "lang": "lua", "entry": "backends/lua" }},
             \\    {{ "name": "python", "lang": "python", "entry": "backends/python" }}
             \\  ],
@@ -371,7 +378,7 @@ fn backendLabel(backend: BackendLang) []const u8 {
         .node => "Node.js",
         .lua => "Lua",
         .python => "Python",
-        .multi => "Zig · Rust · Go (multi)",
+        .multi => "Zig · Rust · Go · Node · Lua · Python (multi)",
     };
 }
 

--- a/src/templates/multi_node_main.js
+++ b/src/templates/multi_node_main.js
@@ -1,0 +1,7 @@
+// multi-backend: 채널을 백엔드별 네임스페이스로 충돌 회피 (zig 가 ping/greet 소유).
+// target 없이 suji.invoke("node-ping") 으로 자동 라우팅된다.
+const { handle } = require("@suji/node");
+
+handle("node-ping", () => ({ from: "node", msg: "pong" }));
+
+handle("node-greet", () => ({ from: "node", greeting: "Hello from Node.js!" }));

--- a/tests/e2e/init-cli.test.ts
+++ b/tests/e2e/init-cli.test.ts
@@ -138,9 +138,13 @@ test("@suji/cli scaffolds multi backend rsbuild project", async () => {
   expect(suji.frontend.dev_command).toBe("pnpm run dev");
   expect(suji.frontend.build_command).toBe("pnpm run build");
   expect(suji.frontend.dist_dir).toBe("frontend/dist");
-  expect(suji.backends.map((b: any) => b.lang)).toEqual(["zig", "rust", "go", "lua", "python"]);
-  // lua/python 임베드 런타임은 router 자동 등록이라 zig 의 ping/greet 와 충돌하지
+  expect(suji.backends.map((b: any) => b.lang)).toEqual(["zig", "rust", "go", "node", "lua", "python"]);
+  // node/lua/python 임베드 런타임은 router 자동 등록이라 zig 의 ping/greet 와 충돌하지
   // 않도록 네임스페이스 채널 템플릿이 스캐폴드돼야 한다(중복 등록 → auto-routing 차단 방지).
+  const nodeMain = await readFile(path.join(projectDir, "backends", "node", "main.js"), "utf8");
+  expect(nodeMain).toContain('handle("node-ping"');
+  const nodePkg = await readJson<any>(path.join(projectDir, "backends", "node", "package.json"));
+  expect(nodePkg.dependencies?.["@suji/node"]).toBeDefined();
   const luaMain = await readFile(path.join(projectDir, "backends", "lua", "main.lua"), "utf8");
   expect(luaMain).toContain('suji.handle("lua-ping"');
   const pyMain = await readFile(path.join(projectDir, "backends", "python", "main.py"), "utf8");

--- a/tests/init_test.zig
+++ b/tests/init_test.zig
@@ -99,7 +99,7 @@ test "번들 프론트엔드 템플릿: 계약 + suji-cli 미러 drift 가드" {
     }
 
     // 루트 백엔드 템플릿 미러도 동일 가드 (init.zig @embedFile 무가드였음).
-    inline for (.{ "gitignore", "zig_app.zig", "rust_cargo.toml", "rust_lib.rs", "go_main.go", "node_package.json", "node_main.js", "lua_main.lua", "python_main.py", "multi_lua_main.lua", "multi_python_main.py", ".github/workflows/suji.yml" }) |rf| {
+    inline for (.{ "gitignore", "zig_app.zig", "rust_cargo.toml", "rust_lib.rs", "go_main.go", "node_package.json", "node_main.js", "lua_main.lua", "python_main.py", "multi_lua_main.lua", "multi_python_main.py", "multi_node_main.js", ".github/workflows/suji.yml" }) |rf| {
         const s = try slurp(a, "src/templates/" ++ rf);
         defer a.free(s);
         const m = try slurp(a, "packages/suji-cli/templates/" ++ rf);


### PR DESCRIPTION
suji init --backend=multi 가 node 만 빠진 5개였는데(examples/multi-backend 는 이미 6개로 동작 — 불일치) add0c87 패턴대로 node 배선. 신규 multi_node_main.js(node-ping 네임스페이스) + init.zig/JS 양 경로 동형 + backendLabel native↔JS drift 보정 + 테스트(node package.json 검증 포함).

정직 경계: node libnode 미staging 시 multi 에서 node 만 graceful skip(나머지 5개 정상, fatal 아님 — code-review max 확인).

검증: zig build, init_test 미러 byte-동형, run-init-cli.sh 15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)